### PR TITLE
Add the ability to use a subquery as value for the field update

### DIFF
--- a/src/main/java/org/mybatis/dynamic/sql/update/UpdateDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/update/UpdateDSL.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2016-2017 the original author or authors.
+ *    Copyright 2016-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -26,7 +26,10 @@ import org.mybatis.dynamic.sql.SqlColumn;
 import org.mybatis.dynamic.sql.SqlCriterion;
 import org.mybatis.dynamic.sql.SqlTable;
 import org.mybatis.dynamic.sql.VisitableCondition;
+import org.mybatis.dynamic.sql.select.SelectModel;
 import org.mybatis.dynamic.sql.update.render.UpdateStatementProvider;
+import org.mybatis.dynamic.sql.util.Buildable;
+import org.mybatis.dynamic.sql.util.BuildableMapping;
 import org.mybatis.dynamic.sql.util.ConstantMapping;
 import org.mybatis.dynamic.sql.util.NullMapping;
 import org.mybatis.dynamic.sql.util.StringConstantMapping;
@@ -113,6 +116,11 @@ public class UpdateDSL<R> {
 
         public UpdateDSL<R> equalTo(Supplier<T> valueSupplier) {
             columnsAndValues.add(ValueMapping.of(column, valueSupplier));
+            return UpdateDSL.this;
+        }
+        
+        public UpdateDSL<R> equalTo(Buildable<SelectModel> buildable) {
+            columnsAndValues.add(BuildableMapping.of(column, buildable));
             return UpdateDSL.this;
         }
 

--- a/src/main/java/org/mybatis/dynamic/sql/util/BuildableMapping.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/BuildableMapping.java
@@ -1,0 +1,47 @@
+/**
+ *    Copyright 2016-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.dynamic.sql.util;
+
+import org.mybatis.dynamic.sql.SqlColumn;
+import org.mybatis.dynamic.sql.select.SelectModel;
+
+public class BuildableMapping extends AbstractColumnMapping implements UpdateMapping, InsertMapping {
+    private Buildable<SelectModel> selectModelBuilder;
+    
+    private BuildableMapping(SqlColumn<?> column, Buildable<SelectModel> selectModelBuilder) {
+        super(column);
+        this.selectModelBuilder = selectModelBuilder;
+    }
+
+    public Buildable<SelectModel> selectModelBuilder() {
+        return selectModelBuilder;
+    }
+
+    public static BuildableMapping of(SqlColumn<?> column, Buildable<SelectModel> selectModelBuilder) {
+        BuildableMapping mapping = new BuildableMapping(column, selectModelBuilder);
+        return mapping;
+    }
+
+    @Override
+    public <R> R accept(UpdateMappingVisitor<R> visitor) {
+        return visitor.visit(this);
+    }
+
+    @Override
+    public <R> R accept(InsertMappingVisitor<R> visitor) {
+        return visitor.visit(this);
+    }
+}

--- a/src/main/java/org/mybatis/dynamic/sql/util/InsertMappingVisitor.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/InsertMappingVisitor.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2016-2017 the original author or authors.
+ *    Copyright 2016-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -23,4 +23,6 @@ public interface InsertMappingVisitor<T> {
     T visit(StringConstantMapping mapping);
 
     T visit(PropertyMapping mapping);
+    
+    T visit(BuildableMapping mapping);
 }

--- a/src/main/java/org/mybatis/dynamic/sql/util/UpdateMappingVisitor.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/UpdateMappingVisitor.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2016-2017 the original author or authors.
+ *    Copyright 2016-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -23,4 +23,6 @@ public interface UpdateMappingVisitor<T> {
     T visit(StringConstantMapping mapping);
 
     <S> T visit(ValueMapping<S> mapping);
+    
+    T visit(BuildableMapping mapping);
 }


### PR DESCRIPTION
Hello,

I implemented an early solution for my issue #12 :
It work well, but i have a bug and i don't see how to resolve it : the sequence isn't right for the second where clause for the query :
UPDATE table SET field = (SELECT field2 FROM table2 where id = #{id1}) where id = #{id2}

The query is well formed, but the index for "id2" is #{parameters.p1,jdbcType=INTEGER} rather than : #{parameters.p2,jdbcType=INTEGER}

I need your help to solve this bug please.

Thank you