### PR TITLE
Add Ability to Modify SQL After Generation

### DIFF
--- a/src/main/java/org/mybatis/dynamic/sql/delete/render/DefaultDeleteStatementProvider.java
+++ b/src/main/java/org/mybatis/dynamic/sql/delete/render/DefaultDeleteStatementProvider.java
@@ -1,0 +1,76 @@
+/**
+ *    Copyright 2016-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.dynamic.sql.delete.render;
+
+import static org.mybatis.dynamic.sql.util.StringUtilities.spaceBefore;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.mybatis.dynamic.sql.where.render.WhereClauseProvider;
+
+public class DefaultDeleteStatementProvider implements DeleteStatementProvider {
+    private String tableName;
+    private Optional<String> whereClause;
+    private Map<String, Object> parameters;
+    
+    private DefaultDeleteStatementProvider(Builder builder) {
+        tableName = Objects.requireNonNull(builder.tableName);
+        whereClause = Optional.ofNullable(builder.whereClause);
+        parameters = Objects.requireNonNull(builder.parameters);
+    }
+    
+    @Override
+    public Map<String, Object> getParameters() {
+        return parameters;
+    }
+    
+    @Override
+    public String getDeleteStatement() {
+        return "delete from" //$NON-NLS-1$
+                + spaceBefore(tableName)
+                + spaceBefore(whereClause);
+    }
+
+    public static Builder withTableName(String tableName) {
+        return new Builder().withTableName(tableName);
+    }
+    
+    public static class Builder {
+        private String tableName;
+        private String whereClause;
+        private Map<String, Object> parameters = new HashMap<>();
+        
+        public Builder withTableName(String tableName) {
+            this.tableName = tableName;
+            return this;
+        }
+        
+        public Builder withWhereClause(Optional<WhereClauseProvider> whereClauseProvider) {
+            whereClauseProvider.ifPresent(wcp -> {
+                whereClause = wcp.getWhereClause();
+                parameters.putAll(wcp.getParameters());
+            });
+            return this;
+        }
+        
+        public DefaultDeleteStatementProvider build() {
+            return new DefaultDeleteStatementProvider(this);
+        }
+    }
+}

--- a/src/main/java/org/mybatis/dynamic/sql/delete/render/DeleteRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/delete/render/DeleteRenderer.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2016-2017 the original author or authors.
+ *    Copyright 2016-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ public class DeleteRenderer {
     }
     
     public DeleteStatementProvider render() {
-        return DeleteStatementProvider.withTableName(deleteModel.table().name())
+        return DefaultDeleteStatementProvider.withTableName(deleteModel.table().name())
                 .withWhereClause(deleteModel.whereModel().map(this::renderWhereClause))
                 .build();
     }

--- a/src/main/java/org/mybatis/dynamic/sql/delete/render/DeleteStatementProvider.java
+++ b/src/main/java/org/mybatis/dynamic/sql/delete/render/DeleteStatementProvider.java
@@ -15,60 +15,10 @@
  */
 package org.mybatis.dynamic.sql.delete.render;
 
-import static org.mybatis.dynamic.sql.util.StringUtilities.spaceBefore;
-
-import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
 
-import org.mybatis.dynamic.sql.where.render.WhereClauseProvider;
-
-public class DeleteStatementProvider {
-    private String tableName;
-    private Optional<String> whereClause;
-    private Map<String, Object> parameters;
+public interface DeleteStatementProvider {
+    Map<String, Object> getParameters();
     
-    private DeleteStatementProvider(Builder builder) {
-        tableName = Objects.requireNonNull(builder.tableName);
-        whereClause = Optional.ofNullable(builder.whereClause);
-        parameters = Objects.requireNonNull(builder.parameters);
-    }
-    
-    public Map<String, Object> getParameters() {
-        return parameters;
-    }
-    
-    public String getDeleteStatement() {
-        return "delete from" //$NON-NLS-1$
-                + spaceBefore(tableName)
-                + spaceBefore(whereClause);
-    }
-
-    public static Builder withTableName(String tableName) {
-        return new Builder().withTableName(tableName);
-    }
-    
-    public static class Builder {
-        private String tableName;
-        private String whereClause;
-        private Map<String, Object> parameters = new HashMap<>();
-        
-        public Builder withTableName(String tableName) {
-            this.tableName = tableName;
-            return this;
-        }
-        
-        public Builder withWhereClause(Optional<WhereClauseProvider> whereClauseProvider) {
-            whereClauseProvider.ifPresent(wcp -> {
-                whereClause = wcp.getWhereClause();
-                parameters.putAll(wcp.getParameters());
-            });
-            return this;
-        }
-        
-        public DeleteStatementProvider build() {
-            return new DeleteStatementProvider(this);
-        }
-    }
+    String getDeleteStatement();
 }

--- a/src/main/java/org/mybatis/dynamic/sql/insert/render/DefaultInsertSelectStatementProvider.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/render/DefaultInsertSelectStatementProvider.java
@@ -1,0 +1,85 @@
+/**
+ *    Copyright 2016-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.dynamic.sql.insert.render;
+
+import static org.mybatis.dynamic.sql.util.StringUtilities.spaceBefore;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+public class DefaultInsertSelectStatementProvider implements InsertSelectStatementProvider {
+    private String tableName;
+    private Optional<String> columnsPhrase;
+    private String selectStatement;
+    private Map<String, Object> parameters;
+    
+    private DefaultInsertSelectStatementProvider(Builder builder) {
+        tableName = Objects.requireNonNull(builder.tableName);
+        columnsPhrase = Objects.requireNonNull(builder.columnsPhrase);
+        selectStatement = Objects.requireNonNull(builder.selectStatement);
+        parameters = Objects.requireNonNull(builder.parameters);
+    }
+    
+    @Override
+    public String getInsertStatement() {
+        return "insert into" //$NON-NLS-1$
+                + spaceBefore(tableName)
+                + spaceBefore(columnsPhrase)
+                + spaceBefore(selectStatement);
+    }
+    
+    @Override
+    public Map<String, Object> getParameters() {
+        return parameters;
+    }
+
+    public static Builder withTableName(String tableName) {
+        return new Builder().withTableName(tableName);
+    }
+    
+    public static class Builder {
+        private String tableName;
+        private Optional<String> columnsPhrase;
+        private String selectStatement;
+        private Map<String, Object> parameters = new HashMap<>();
+        
+        public Builder withTableName(String tableName) {
+            this.tableName = tableName;
+            return this;
+        }
+
+        public Builder withColumnsPhrase(Optional<String> columnsPhrase) {
+            this.columnsPhrase = columnsPhrase;
+            return this;
+        }
+        
+        public Builder withSelectStatement(String selectStatement) {
+            this.selectStatement = selectStatement;
+            return this;
+        }
+        
+        public Builder withParameters(Map<String, Object> parameters) {
+            this.parameters.putAll(parameters);
+            return this;
+        }
+        
+        public DefaultInsertSelectStatementProvider build() {
+            return new DefaultInsertSelectStatementProvider(this);
+        }
+    }
+}

--- a/src/main/java/org/mybatis/dynamic/sql/insert/render/DefaultInsertStatementProvider.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/render/DefaultInsertStatementProvider.java
@@ -17,65 +17,43 @@ package org.mybatis.dynamic.sql.insert.render;
 
 import static org.mybatis.dynamic.sql.util.StringUtilities.spaceBefore;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
-public class BatchInsert<T> {
+public class DefaultInsertStatementProvider<T> implements InsertStatementProvider<T> {
     private String tableName;
     private String columnsPhrase;
     private String valuesPhrase;
-    private List<T> records;
+    private T record;
     
-    private BatchInsert(Builder<T> builder) {
+    private DefaultInsertStatementProvider(Builder<T> builder) {
         tableName = Objects.requireNonNull(builder.tableName);
         columnsPhrase = Objects.requireNonNull(builder.columnsPhrase);
         valuesPhrase = Objects.requireNonNull(builder.valuesPhrase);
-        records = Collections.unmodifiableList(Objects.requireNonNull(builder.records));
+        record = Objects.requireNonNull(builder.record);
     }
     
-    /**
-     * Returns a list of InsertStatement objects.  This is useful for MyBatis batch support.
-     * 
-     * @return a List of InsertStatements
-     */
-    public List<InsertStatementProvider<T>> insertStatements() {
-        return records.stream()
-                .map(this::toInsertStatement)
-                .collect(Collectors.toList());
+    @Override
+    public T getRecord() {
+        return record;
     }
     
-    private InsertStatementProvider<T> toInsertStatement(T record) {
-        return DefaultInsertStatementProvider.withRecord(record)
-                .withTableName(tableName)
-                .withColumnsPhrase(columnsPhrase)
-                .withValuesPhrase(valuesPhrase)
-                .build();
-    }
-
-    /**
-     * Returns the generated SQL for this batch.  This is useful for Spring JDBC batch support.
-     * 
-     * @return the generated INSERT statement
-     */
-    public String getInsertStatementSQL() {
+    @Override
+    public String getInsertStatement() {
         return "insert into" //$NON-NLS-1$
                 + spaceBefore(tableName)
                 + spaceBefore(columnsPhrase)
                 + spaceBefore(valuesPhrase);
     }
-    
-    public static <T> Builder<T> withRecords(List<T> records) {
-        return new Builder<T>().withRecords(records);
+
+    public static <T> Builder<T> withRecord(T record) {
+        return new Builder<T>().withRecord(record);
     }
     
     public static class Builder<T> {
         private String tableName;
         private String columnsPhrase;
         private String valuesPhrase;
-        private List<T> records = new ArrayList<>();
+        private T record;
         
         public Builder<T> withTableName(String tableName) {
             this.tableName = tableName;
@@ -92,13 +70,13 @@ public class BatchInsert<T> {
             return this;
         }
         
-        public Builder<T> withRecords(List<T> records) {
-            this.records.addAll(records);
+        public Builder<T> withRecord(T record) {
+            this.record = record;
             return this;
         }
         
-        public BatchInsert<T> build() {
-            return new BatchInsert<>(this);
+        public DefaultInsertStatementProvider<T> build() {
+            return new DefaultInsertStatementProvider<>(this);
         }
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/insert/render/InsertRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/render/InsertRenderer.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2016-2017 the original author or authors.
+ *    Copyright 2016-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ public class InsertRenderer<T> {
         ValuePhraseVisitor visitor = new ValuePhraseVisitor(renderingStrategy);
         FieldAndValueCollector<T> collector = model.mapColumnMappings(toFieldAndValue(visitor))
                 .collect(FieldAndValueCollector.collect());
-        return InsertStatementProvider.withRecord(model.record())
+        return DefaultInsertStatementProvider.withRecord(model.record())
                 .withTableName(model.table().name())
                 .withColumnsPhrase(collector.columnsPhrase())
                 .withValuesPhrase(collector.valuesPhrase())

--- a/src/main/java/org/mybatis/dynamic/sql/insert/render/InsertSelectRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/render/InsertSelectRenderer.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2016-2017 the original author or authors.
+ *    Copyright 2016-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ public class InsertSelectRenderer {
     public InsertSelectStatementProvider render() {
         SelectStatementProvider selectStatement = model.selectModel().render(renderingStrategy);
         
-        return InsertSelectStatementProvider.withTableName(model.table().name())
+        return DefaultInsertSelectStatementProvider.withTableName(model.table().name())
                 .withColumnsPhrase(calculateColumnsPhrase())
                 .withSelectStatement(selectStatement.getSelectStatement())
                 .withParameters(selectStatement.getParameters())

--- a/src/main/java/org/mybatis/dynamic/sql/insert/render/InsertSelectStatementProvider.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/render/InsertSelectStatementProvider.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2016-2017 the original author or authors.
+ *    Copyright 2016-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,69 +15,10 @@
  */
 package org.mybatis.dynamic.sql.insert.render;
 
-import static org.mybatis.dynamic.sql.util.StringUtilities.spaceBefore;
-
-import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
 
-public class InsertSelectStatementProvider {
-    private String tableName;
-    private Optional<String> columnsPhrase;
-    private String selectStatement;
-    private Map<String, Object> parameters;
-    
-    private InsertSelectStatementProvider(Builder builder) {
-        tableName = Objects.requireNonNull(builder.tableName);
-        columnsPhrase = Objects.requireNonNull(builder.columnsPhrase);
-        selectStatement = Objects.requireNonNull(builder.selectStatement);
-        parameters = Objects.requireNonNull(builder.parameters);
-    }
-    
-    public String getInsertStatement() {
-        return "insert into" //$NON-NLS-1$
-                + spaceBefore(tableName)
-                + spaceBefore(columnsPhrase)
-                + spaceBefore(selectStatement);
-    }
-    
-    public Map<String, Object> getParameters() {
-        return parameters;
-    }
+public interface InsertSelectStatementProvider {
+    Map<String, Object> getParameters();
 
-    public static Builder withTableName(String tableName) {
-        return new Builder().withTableName(tableName);
-    }
-    
-    public static class Builder {
-        private String tableName;
-        private Optional<String> columnsPhrase;
-        private String selectStatement;
-        private Map<String, Object> parameters = new HashMap<>();
-        
-        public Builder withTableName(String tableName) {
-            this.tableName = tableName;
-            return this;
-        }
-
-        public Builder withColumnsPhrase(Optional<String> columnsPhrase) {
-            this.columnsPhrase = columnsPhrase;
-            return this;
-        }
-        
-        public Builder withSelectStatement(String selectStatement) {
-            this.selectStatement = selectStatement;
-            return this;
-        }
-        
-        public Builder withParameters(Map<String, Object> parameters) {
-            this.parameters.putAll(parameters);
-            return this;
-        }
-        
-        public InsertSelectStatementProvider build() {
-            return new InsertSelectStatementProvider(this);
-        }
-    }
+    String getInsertStatement();
 }

--- a/src/main/java/org/mybatis/dynamic/sql/insert/render/InsertStatementProvider.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/render/InsertStatementProvider.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2016-2017 the original author or authors.
+ *    Copyright 2016-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,66 +15,8 @@
  */
 package org.mybatis.dynamic.sql.insert.render;
 
-import static org.mybatis.dynamic.sql.util.StringUtilities.spaceBefore;
-
-import java.util.Objects;
-
-public class InsertStatementProvider<T> {
-    private String tableName;
-    private String columnsPhrase;
-    private String valuesPhrase;
-    private T record;
+public interface InsertStatementProvider<T> {
+    T getRecord();
     
-    private InsertStatementProvider(Builder<T> builder) {
-        tableName = Objects.requireNonNull(builder.tableName);
-        columnsPhrase = Objects.requireNonNull(builder.columnsPhrase);
-        valuesPhrase = Objects.requireNonNull(builder.valuesPhrase);
-        record = Objects.requireNonNull(builder.record);
-    }
-    
-    public T getRecord() {
-        return record;
-    }
-    
-    public String getInsertStatement() {
-        return "insert into" //$NON-NLS-1$
-                + spaceBefore(tableName)
-                + spaceBefore(columnsPhrase)
-                + spaceBefore(valuesPhrase);
-    }
-
-    public static <T> Builder<T> withRecord(T record) {
-        return new Builder<T>().withRecord(record);
-    }
-    
-    public static class Builder<T> {
-        private String tableName;
-        private String columnsPhrase;
-        private String valuesPhrase;
-        private T record;
-        
-        public Builder<T> withTableName(String tableName) {
-            this.tableName = tableName;
-            return this;
-        }
-
-        public Builder<T> withColumnsPhrase(String columnsPhrase) {
-            this.columnsPhrase = columnsPhrase;
-            return this;
-        }
-        
-        public Builder<T> withValuesPhrase(String valuesPhrase) {
-            this.valuesPhrase = valuesPhrase;
-            return this;
-        }
-        
-        public Builder<T> withRecord(T record) {
-            this.record = record;
-            return this;
-        }
-        
-        public InsertStatementProvider<T> build() {
-            return new InsertStatementProvider<>(this);
-        }
-    }
+    String getInsertStatement();
 }

--- a/src/main/java/org/mybatis/dynamic/sql/select/render/DefaultSelectStatementProvider.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/render/DefaultSelectStatementProvider.java
@@ -1,0 +1,75 @@
+/**
+ *    Copyright 2016-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.dynamic.sql.select.render;
+
+import static org.mybatis.dynamic.sql.util.StringUtilities.spaceBefore;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+public class DefaultSelectStatementProvider implements SelectStatementProvider {
+    private String queryExpression;
+    private Map<String, Object> parameters;
+    private Optional<String> orderByClause;
+    
+    private DefaultSelectStatementProvider(Builder builder) {
+        queryExpression = Objects.requireNonNull(builder.queryExpression);
+        orderByClause = Objects.requireNonNull(builder.orderByClause);
+        parameters = Collections.unmodifiableMap(Objects.requireNonNull(builder.parameters));
+    }
+    
+    @Override
+    public Map<String, Object> getParameters() {
+        return parameters;
+    }
+    
+    @Override
+    public String getSelectStatement() {
+        return queryExpression + spaceBefore(orderByClause);
+    }
+    
+    public static Builder withQueryExpression(String queryExpression) {
+        return new Builder().withQueryExpression(queryExpression);
+    }
+    
+    public static class Builder {
+        private String queryExpression;
+        private Optional<String> orderByClause = Optional.empty();
+        private Map<String, Object> parameters = new HashMap<>();
+        
+        public Builder withQueryExpression(String queryExpression) {
+            this.queryExpression = queryExpression;
+            return this;
+        }
+        
+        public Builder withOrderByClause(Optional<String> orderByClause) {
+            this.orderByClause = orderByClause;
+            return this;
+        }
+        
+        public Builder withParameters(Map<String, Object> parameters) {
+            this.parameters.putAll(parameters);
+            return this;
+        }
+        
+        public DefaultSelectStatementProvider build() {
+            return new DefaultSelectStatementProvider(this);
+        }
+    }
+}

--- a/src/main/java/org/mybatis/dynamic/sql/select/render/SelectRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/render/SelectRenderer.java
@@ -42,7 +42,7 @@ public class SelectRenderer {
                 .mapQueryExpressions(this::renderQueryExpression)
                 .collect(QueryExpressionCollector.collect());
         
-        return SelectStatementProvider.withQueryExpression(collector.queryExpression())
+        return DefaultSelectStatementProvider.withQueryExpression(collector.queryExpression())
                 .withParameters(collector.parameters())
                 .withOrderByClause(selectModel.orderByModel().map(this::renderOrderBy))
                 .build();

--- a/src/main/java/org/mybatis/dynamic/sql/select/render/SelectStatementProvider.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/render/SelectStatementProvider.java
@@ -15,60 +15,10 @@
  */
 package org.mybatis.dynamic.sql.select.render;
 
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
 
-import org.mybatis.dynamic.sql.util.StringUtilities;
+public interface SelectStatementProvider {
+    Map<String, Object> getParameters();
 
-public class SelectStatementProvider {
-    
-    private String queryExpression;
-    private Map<String, Object> parameters;
-    private Optional<String> orderByClause;
-    
-    private SelectStatementProvider(Builder builder) {
-        queryExpression = Objects.requireNonNull(builder.queryExpression);
-        orderByClause = Objects.requireNonNull(builder.orderByClause);
-        parameters = Collections.unmodifiableMap(Objects.requireNonNull(builder.parameters));
-    }
-    
-    public Map<String, Object> getParameters() {
-        return parameters;
-    }
-    
-    public String getSelectStatement() {
-        return queryExpression + StringUtilities.spaceBefore(orderByClause);
-    }
-    
-    public static Builder withQueryExpression(String queryExpression) {
-        return new Builder().withQueryExpression(queryExpression);
-    }
-    
-    public static class Builder {
-        private String queryExpression;
-        private Optional<String> orderByClause = Optional.empty();
-        private Map<String, Object> parameters = new HashMap<>();
-        
-        public Builder withQueryExpression(String queryExpression) {
-            this.queryExpression = queryExpression;
-            return this;
-        }
-        
-        public Builder withOrderByClause(Optional<String> orderByClause) {
-            this.orderByClause = orderByClause;
-            return this;
-        }
-        
-        public Builder withParameters(Map<String, Object> parameters) {
-            this.parameters.putAll(parameters);
-            return this;
-        }
-        
-        public SelectStatementProvider build() {
-            return new SelectStatementProvider(this);
-        }
-    }
+    String getSelectStatement();
 }

--- a/src/main/java/org/mybatis/dynamic/sql/update/render/DefaultUpdateStatementProvider.java
+++ b/src/main/java/org/mybatis/dynamic/sql/update/render/DefaultUpdateStatementProvider.java
@@ -1,0 +1,97 @@
+/**
+ *    Copyright 2016-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.dynamic.sql.update.render;
+
+import static org.mybatis.dynamic.sql.util.StringUtilities.spaceBefore;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.mybatis.dynamic.sql.where.render.WhereClauseProvider;
+
+/**
+ * This class combines a "set" clause and a "where" clause into one parameter object
+ * that can be sent to a MyBatis3 mapper method.
+ * 
+ * @author Jeff Butler
+ *
+ */
+public class DefaultUpdateStatementProvider implements UpdateStatementProvider {
+    private String tableName;
+    private String setClause;
+    private Optional<String> whereClause;
+    private Map<String, Object> parameters = new HashMap<>();
+
+    private DefaultUpdateStatementProvider(Builder builder) {
+        tableName = Objects.requireNonNull(builder.tableName);
+        setClause = Objects.requireNonNull(builder.setClause);
+        whereClause = Optional.ofNullable(builder.whereClause);
+        parameters.putAll(builder.parameters);
+    }
+
+    @Override
+    public Map<String, Object> getParameters() {
+        return parameters;
+    }
+
+    @Override
+    public String getUpdateStatement() {
+        return "update" //$NON-NLS-1$
+                + spaceBefore(tableName)
+                + spaceBefore(setClause)
+                + spaceBefore(whereClause);
+    }
+    
+    public static Builder withTableName(String tableName) {
+        return new Builder().withTableName(tableName);
+    }
+    
+    public static class Builder {
+        private String tableName;
+        private String setClause;
+        private String whereClause;
+        private Map<String, Object> parameters = new HashMap<>();
+        
+        public Builder withTableName(String tableName) {
+            this.tableName = tableName;
+            return this;
+        }
+        
+        public Builder withSetClause(String setClause) {
+            this.setClause = setClause;
+            return this;
+        }
+        
+        public Builder withWhereClause(Optional<WhereClauseProvider> whereClauseProvider) {
+            whereClauseProvider.ifPresent(wcp -> {
+                whereClause = wcp.getWhereClause();
+                parameters.putAll(wcp.getParameters());
+            });
+            return this;
+        }
+        
+        public Builder withParameters(Map<String, Object> parameters) {
+            this.parameters.putAll(parameters);
+            return this;
+        }
+        
+        public DefaultUpdateStatementProvider build() {
+            return new DefaultUpdateStatementProvider(this);
+        }
+    }
+}

--- a/src/main/java/org/mybatis/dynamic/sql/update/render/UpdateRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/update/render/UpdateRenderer.java
@@ -46,7 +46,7 @@ public class UpdateRenderer {
         FragmentCollector fc = updateModel.mapColumnMappings(toFragmentAndParameters(visitor))
                 .collect(FragmentCollector.collect());
         
-        return UpdateStatementProvider.withTableName(updateModel.table().name())
+        return DefaultUpdateStatementProvider.withTableName(updateModel.table().name())
                 .withSetClause(calculateSetPhrase(fc))
                 .withParameters(fc.parameters())
                 .withWhereClause(updateModel.whereModel().map(this::renderWhereClause))

--- a/src/main/java/org/mybatis/dynamic/sql/update/render/UpdateStatementProvider.java
+++ b/src/main/java/org/mybatis/dynamic/sql/update/render/UpdateStatementProvider.java
@@ -15,81 +15,10 @@
  */
 package org.mybatis.dynamic.sql.update.render;
 
-import static org.mybatis.dynamic.sql.util.StringUtilities.spaceBefore;
-
-import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
 
-import org.mybatis.dynamic.sql.where.render.WhereClauseProvider;
+public interface UpdateStatementProvider {
+    Map<String, Object> getParameters();
 
-/**
- * This class combines a "set" clause and a "where" clause into one parameter object
- * that can be sent to a MyBatis3 mapper method.
- * 
- * @author Jeff Butler
- *
- */
-public class UpdateStatementProvider {
-    private String tableName;
-    private String setClause;
-    private Optional<String> whereClause;
-    private Map<String, Object> parameters = new HashMap<>();
-
-    private UpdateStatementProvider(Builder builder) {
-        tableName = Objects.requireNonNull(builder.tableName);
-        setClause = Objects.requireNonNull(builder.setClause);
-        whereClause = Optional.ofNullable(builder.whereClause);
-        parameters.putAll(builder.parameters);
-    }
-
-    public Map<String, Object> getParameters() {
-        return parameters;
-    }
-
-    public String getUpdateStatement() {
-        return "update" //$NON-NLS-1$
-                + spaceBefore(tableName)
-                + spaceBefore(setClause)
-                + spaceBefore(whereClause);
-    }
-    
-    public static Builder withTableName(String tableName) {
-        return new Builder().withTableName(tableName);
-    }
-    
-    public static class Builder {
-        private String tableName;
-        private String setClause;
-        private String whereClause;
-        private Map<String, Object> parameters = new HashMap<>();
-        
-        public Builder withTableName(String tableName) {
-            this.tableName = tableName;
-            return this;
-        }
-        
-        public Builder withSetClause(String setClause) {
-            this.setClause = setClause;
-            return this;
-        }
-        
-        public Builder withWhereClause(Optional<WhereClauseProvider> whereClauseProvider) {
-            whereClauseProvider.ifPresent(wcp -> {
-                whereClause = wcp.getWhereClause();
-                parameters.putAll(wcp.getParameters());
-            });
-            return this;
-        }
-        
-        public Builder withParameters(Map<String, Object> parameters) {
-            this.parameters.putAll(parameters);
-            return this;
-        }
-        
-        public UpdateStatementProvider build() {
-            return new UpdateStatementProvider(this);
-        }
-    }
+    String getUpdateStatement();
 }

--- a/src/test/java/examples/paging/LimitAndOffsetAdapter.java
+++ b/src/test/java/examples/paging/LimitAndOffsetAdapter.java
@@ -1,0 +1,90 @@
+/**
+ *    Copyright 2016-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package examples.paging;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+
+import org.mybatis.dynamic.sql.render.RenderingStrategy;
+import org.mybatis.dynamic.sql.select.SelectModel;
+import org.mybatis.dynamic.sql.select.render.SelectStatementProvider;
+
+/**
+ * This adapter modifies the generated SQL by adding a LIMIT and OFFSET clause at the end
+ * of the generated SQL.  This can be used to create a paginated query.
+ * 
+ * LIMIT and OFFSET has limited support in relational databases, so this cannot be considered
+ * a general solution for all paginated queries (and that is why this adapter lives only in the
+ * test source tree and is not packaged with the core library code).
+ * 
+ * I believe it works in MySQL, HSQLDB, and Postgres.
+ * 
+ * @author Jeff Butler
+ */
+public class LimitAndOffsetAdapter<R> {
+    private SelectModel selectModel;
+    private Function<SelectStatementProvider, R> mapperMethod;
+    private int limit;
+    private int offset;
+    
+    private LimitAndOffsetAdapter(SelectModel selectModel, Function<SelectStatementProvider, R> mapperMethod,
+            int limit, int offset) {
+        this.selectModel = Objects.requireNonNull(selectModel);
+        this.mapperMethod = Objects.requireNonNull(mapperMethod);
+        this.limit = limit;
+        this.offset = offset;
+    }
+    
+    public R execute() {
+        return mapperMethod.apply(selectStatement());
+    }
+    
+    private SelectStatementProvider selectStatement() {
+        return new LimitAndOffsetDecorator(
+                selectModel.render(RenderingStrategy.MYBATIS3));
+    }
+    
+    public static <R> LimitAndOffsetAdapter<R> of(SelectModel selectModel,
+            Function<SelectStatementProvider, R> mapperMethod, int limit, int offset) {
+        return new LimitAndOffsetAdapter<>(selectModel, mapperMethod, limit, offset);
+    }
+    
+    public class LimitAndOffsetDecorator implements SelectStatementProvider {
+        private Map<String, Object> parameters = new HashMap<>();
+        private String selectStatement;
+        
+        public LimitAndOffsetDecorator(SelectStatementProvider delegate) {
+            parameters.putAll(delegate.getParameters());
+            parameters.put("limit", limit);
+            parameters.put("offset", offset);
+            
+            selectStatement = delegate.getSelectStatement() +
+                    " LIMIT #{parameters.limit} OFFSET #{parameters.offset}";
+        }
+
+        @Override
+        public Map<String, Object> getParameters() {
+            return parameters;
+        }
+
+        @Override
+        public String getSelectStatement() {
+            return selectStatement;
+        }
+    }
+}

--- a/src/test/java/examples/paging/LimitAndOffsetMapper.java
+++ b/src/test/java/examples/paging/LimitAndOffsetMapper.java
@@ -1,0 +1,48 @@
+/**
+ *    Copyright 2016-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package examples.paging;
+
+import static examples.animal.data.AnimalDataDynamicSqlSupport.*;
+
+import java.util.List;
+
+import org.apache.ibatis.annotations.Result;
+import org.apache.ibatis.annotations.Results;
+import org.apache.ibatis.annotations.SelectProvider;
+import org.mybatis.dynamic.sql.select.QueryExpressionDSL;
+import org.mybatis.dynamic.sql.select.SelectDSL;
+import org.mybatis.dynamic.sql.select.render.SelectStatementProvider;
+import org.mybatis.dynamic.sql.util.SqlProviderAdapter;
+
+import examples.animal.data.AnimalData;
+
+public interface LimitAndOffsetMapper {
+
+    @SelectProvider(type=SqlProviderAdapter.class, method="select")
+    @Results(id="AnimalDataResult", value={
+        @Result(column="id", property="id", id=true),
+        @Result(column="animal_name", property="animalName"),
+        @Result(column="brain_weight", property="brainWeight"),
+        @Result(column="body_weight", property="bodyWeight")
+    })
+    List<AnimalData> selectMany(SelectStatementProvider selectStatement);
+
+    default QueryExpressionDSL<LimitAndOffsetAdapter<List<AnimalData>>> selectByExampleWithLimitAndOffset(int limit, int offset) {
+        return SelectDSL.select(selectModel -> LimitAndOffsetAdapter.of(selectModel, this::selectMany, limit, offset),
+                id, animalName, brainWeight, bodyWeight)
+                .from(animalData);
+    }
+}

--- a/src/test/java/examples/paging/LimitAndOffsetTest.java
+++ b/src/test/java/examples/paging/LimitAndOffsetTest.java
@@ -1,0 +1,81 @@
+/**
+ *    Copyright 2016-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package examples.paging;
+
+import static examples.animal.data.AnimalDataDynamicSqlSupport.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.util.List;
+
+import org.apache.ibatis.datasource.unpooled.UnpooledDataSource;
+import org.apache.ibatis.jdbc.ScriptRunner;
+import org.apache.ibatis.mapping.Environment;
+import org.apache.ibatis.session.Configuration;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+import examples.animal.data.AnimalData;
+
+@RunWith(JUnitPlatform.class)
+public class LimitAndOffsetTest {
+    
+    private static final String JDBC_URL = "jdbc:hsqldb:mem:aname";
+    private static final String JDBC_DRIVER = "org.hsqldb.jdbcDriver"; 
+    
+    private SqlSessionFactory sqlSessionFactory;
+    
+    @BeforeEach
+    public void setup() throws Exception {
+        Class.forName(JDBC_DRIVER);
+        InputStream is = getClass().getResourceAsStream("/examples/animal/data/CreateAnimalData.sql");
+        try (Connection connection = DriverManager.getConnection(JDBC_URL, "sa", "")) {
+            ScriptRunner sr = new ScriptRunner(connection);
+            sr.setLogWriter(null);
+            sr.runScript(new InputStreamReader(is));
+        }
+        
+        UnpooledDataSource ds = new UnpooledDataSource(JDBC_DRIVER, JDBC_URL, "sa", "");
+        Environment environment = new Environment("test", new JdbcTransactionFactory(), ds);
+        Configuration config = new Configuration(environment);
+        config.addMapper(LimitAndOffsetMapper.class);
+        sqlSessionFactory = new SqlSessionFactoryBuilder().build(config);
+    }
+    
+    @Test
+    public void testLimitandOffset() {
+        try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+            LimitAndOffsetMapper mapper = sqlSession.getMapper(LimitAndOffsetMapper.class);
+            
+            List<AnimalData> rows = mapper.selectByExampleWithLimitAndOffset(5, 3)
+                    .orderBy(id)
+                    .build()
+                    .execute();
+            
+            assertThat(rows.size()).isEqualTo(5);
+            assertThat(rows.get(0).getId()).isEqualTo(4);
+        }
+    }
+}


### PR DESCRIPTION
This PR changes all the provider classes into interfaces to that another class could act as a decorator and make changes before the SQL is executed.

The test shows how to create a paging query using a decorator.