### PR TITLE
remove the local variable and return the result directly

### DIFF
--- a/src/test/java/examples/springbatch/cursor/SpringBatchCursorTest.java
+++ b/src/test/java/examples/springbatch/cursor/SpringBatchCursorTest.java
@@ -80,8 +80,7 @@ public class SpringBatchCursorTest {
                     .build()
                     .render(RenderingStrategy.MYBATIS3);
 
-            long count = personMapper.count(selectStatement);
-            return count;
+            return personMapper.count(selectStatement);
         }
     }
 }


### PR DESCRIPTION
I found a code smell that  Local Variables should not be declared and then immediately returned or thrown.
Some developers argue that the practice improves code readability, because it enables them to explicitly name what is being returned. However, this variable is an internal implementation detail that is not exposed to the callers of the method. The method name should be sufficient for callers to know exactly what will be returned.

So I remove the local variable and return the `personMapper.count(selectStatement);` directly to fix the Code Quality Issue detected by SonarQube.
[https://rules.sonarsource.com/java/RSPEC-1488](url)