### PR TITLE
remove the local variable and return the result directly

### DIFF
--- a/src/test/java/examples/springbatch/paging/SpringBatchPagingTest.java
+++ b/src/test/java/examples/springbatch/paging/SpringBatchPagingTest.java
@@ -92,7 +92,7 @@ public class SpringBatchPagingTest {
                     .build()
                     .render(RenderingStrategy.MYBATIS3);
 
-            return personMapper.count(selectStatement);;
+            return personMapper.count(selectStatement);
         }
     }
 }

--- a/src/test/java/examples/springbatch/paging/SpringBatchPagingTest.java
+++ b/src/test/java/examples/springbatch/paging/SpringBatchPagingTest.java
@@ -92,8 +92,7 @@ public class SpringBatchPagingTest {
                     .build()
                     .render(RenderingStrategy.MYBATIS3);
 
-            long count = personMapper.count(selectStatement);
-            return count;
+            return personMapper.count(selectStatement);;
         }
     }
 }


### PR DESCRIPTION
@jeffgbutler ,hello, i found the Code Smell just the same as #86 . 
Return the `personMapper.count(selectStatement);` directly to improve the Code Quality.
See details in #86 