### PR TITLE
UpdateByExample Support Improvement

### DIFF
--- a/src/main/java/org/mybatis/dynamic/sql/util/mybatis3/MyBatis3CountByExampleHelper.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/mybatis3/MyBatis3CountByExampleHelper.java
@@ -47,10 +47,16 @@ import org.mybatis.dynamic.sql.util.Buildable;
  *         q.where(occupation, isNull()));
  * </pre>
  * 
- * <p>You can also do a "count all" with the following code:
+ * <p>You can implement a "count all" with the following code:
  * 
  * <pre>
  * long rows = mapper.countByExample(q -&gt; q);
+ * </pre>
+ * 
+ * <p>Or
+ * 
+ * <pre>
+ * long rows = mapper.countByExample(MyBatis3CountByExampleHelper.all());
  * </pre>
  *  
  * @author Jeff Butler
@@ -58,4 +64,13 @@ import org.mybatis.dynamic.sql.util.Buildable;
 @FunctionalInterface
 public interface MyBatis3CountByExampleHelper extends
         Function<QueryExpressionDSL<MyBatis3SelectModelAdapter<Long>>, Buildable<MyBatis3SelectModelAdapter<Long>>> {
+    
+    /**
+     * Returns a helper that can be used to count every row in a table.
+     * 
+     * @return the helper that will count every row in a table
+     */
+    static MyBatis3CountByExampleHelper all() {
+        return h -> h;
+    }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/util/mybatis3/MyBatis3CountByExampleHelper.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/mybatis3/MyBatis3CountByExampleHelper.java
@@ -56,7 +56,7 @@ import org.mybatis.dynamic.sql.util.Buildable;
  * <p>Or
  * 
  * <pre>
- * long rows = mapper.countByExample(MyBatis3CountByExampleHelper.all());
+ * long rows = mapper.countByExample(MyBatis3CountByExampleHelper.allRows());
  * </pre>
  *  
  * @author Jeff Butler
@@ -70,7 +70,7 @@ public interface MyBatis3CountByExampleHelper extends
      * 
      * @return the helper that will count every row in a table
      */
-    static MyBatis3CountByExampleHelper all() {
+    static MyBatis3CountByExampleHelper allRows() {
         return h -> h;
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/util/mybatis3/MyBatis3DeleteByExampleHelper.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/mybatis3/MyBatis3DeleteByExampleHelper.java
@@ -46,15 +46,30 @@ import org.mybatis.dynamic.sql.util.Buildable;
  *           q.where(occupation, isNull()));
  * </pre>
  *  
- * <p>You can also do a "delete all" with the following code:
+ * <p>You can implement a "delete all" with the following code:
  * 
  * <pre>
  * int rows = mapper.deleteByExample(q -&gt; q);
  * </pre>
  * 
+ * <p>Or
+ * 
+ * <pre>
+ * long rows = mapper.deleteByExample(MyBatis3DeleteByExampleHelper.all());
+ * </pre>
+
  * @author Jeff Butler
  */
 @FunctionalInterface
 public interface MyBatis3DeleteByExampleHelper extends
         Function<DeleteDSL<MyBatis3DeleteModelAdapter<Integer>>, Buildable<MyBatis3DeleteModelAdapter<Integer>>> {
+
+    /**
+     * Returns a helper that can be used to delete every row in a table.
+     * 
+     * @return the helper that will delete every row in a table
+     */
+    static MyBatis3DeleteByExampleHelper all() {
+        return h -> h;
+    }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/util/mybatis3/MyBatis3DeleteByExampleHelper.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/mybatis3/MyBatis3DeleteByExampleHelper.java
@@ -55,7 +55,7 @@ import org.mybatis.dynamic.sql.util.Buildable;
  * <p>Or
  * 
  * <pre>
- * long rows = mapper.deleteByExample(MyBatis3DeleteByExampleHelper.all());
+ * long rows = mapper.deleteByExample(MyBatis3DeleteByExampleHelper.allRows());
  * </pre>
 
  * @author Jeff Butler
@@ -69,7 +69,7 @@ public interface MyBatis3DeleteByExampleHelper extends
      * 
      * @return the helper that will delete every row in a table
      */
-    static MyBatis3DeleteByExampleHelper all() {
+    static MyBatis3DeleteByExampleHelper allRows() {
         return h -> h;
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/util/mybatis3/MyBatis3SelectByExampleHelper.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/mybatis3/MyBatis3SelectByExampleHelper.java
@@ -66,7 +66,7 @@ import org.mybatis.dynamic.sql.util.Buildable;
  * <p>Or
  * 
  * <pre>
- * List&lt;SimpleRecord&gt; rows = mapper.selectByExample(MyBatis3SelectByExampleHelper.all());
+ * List&lt;SimpleRecord&gt; rows = mapper.selectByExample(MyBatis3SelectByExampleHelper.allRows());
  * </pre>
  * 
  * @author Jeff Butler
@@ -79,9 +79,11 @@ public interface MyBatis3SelectByExampleHelper<T> extends
     /**
      * Returns a helper that can be used to select every row in a table.
      * 
+     * @param <T> the type of row returned
+     * 
      * @return the helper that will select every row in a table
      */
-    static <T> MyBatis3SelectByExampleHelper<T> all() {
+    static <T> MyBatis3SelectByExampleHelper<T> allRows() {
         return h -> h;
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/util/mybatis3/MyBatis3SelectByExampleHelper.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/mybatis3/MyBatis3SelectByExampleHelper.java
@@ -57,10 +57,16 @@ import org.mybatis.dynamic.sql.util.Buildable;
  *     .or(occupation, isNull()));
  * </pre>
  *  
- * <p>You can also do a "select all" with the following code:
+ * <p>You can implement a "select all" with the following code:
  * 
  * <pre>
  * List&lt;SimpleRecord&gt; rows = mapper.selectByExample(q -&gt; q);
+ * </pre>
+ * 
+ * <p>Or
+ * 
+ * <pre>
+ * List&lt;SimpleRecord&gt; rows = mapper.selectByExample(MyBatis3SelectByExampleHelper.all());
  * </pre>
  * 
  * @author Jeff Butler
@@ -69,4 +75,13 @@ import org.mybatis.dynamic.sql.util.Buildable;
 public interface MyBatis3SelectByExampleHelper<T> extends
         Function<QueryExpressionDSL<MyBatis3SelectModelAdapter<List<T>>>,
         Buildable<MyBatis3SelectModelAdapter<List<T>>>> {
+
+    /**
+     * Returns a helper that can be used to select every row in a table.
+     * 
+     * @return the helper that will select every row in a table
+     */
+    static <T> MyBatis3SelectByExampleHelper<T> all() {
+        return h -> h;
+    }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/util/mybatis3/MyBatis3UpdateByExampleCompleter.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/mybatis3/MyBatis3UpdateByExampleCompleter.java
@@ -22,13 +22,22 @@ import org.mybatis.dynamic.sql.SqlTable;
 import org.mybatis.dynamic.sql.update.UpdateDSL;
 import org.mybatis.dynamic.sql.update.render.UpdateStatementProvider;
 
-public class MyBatis3UpdateByExampleRecordGatherer<T> {
+/**
+ * This class is used to complete an update by example method in the style of MyBatis generator.
+ * 
+ * @author Jeff Butler
+ *
+ * @see MyBatis3UpdateByExampleHelper
+ * 
+ * @param <T> the type of record that will be updated
+ */
+public class MyBatis3UpdateByExampleCompleter<T> {
     private SqlTable table;
     private MyBatis3UpdateByExampleHelper helper;
     private ToIntFunction<UpdateStatementProvider> mapper;
     private MyBatis3UpdateByExampleValueSetter<T> valueSetter;
     
-    private MyBatis3UpdateByExampleRecordGatherer(MyBatis3UpdateByExampleRecordGatherer.Builder<T> builder) {
+    private MyBatis3UpdateByExampleCompleter(MyBatis3UpdateByExampleCompleter.Builder<T> builder) {
         helper = Objects.requireNonNull(builder.helper);
         mapper = Objects.requireNonNull(builder.mapper);
         valueSetter = Objects.requireNonNull(builder.valueSetter);
@@ -48,30 +57,30 @@ public class MyBatis3UpdateByExampleRecordGatherer<T> {
         private ToIntFunction<UpdateStatementProvider> mapper;
         private MyBatis3UpdateByExampleValueSetter<T> valueSetter;
         
-        public MyBatis3UpdateByExampleRecordGatherer.Builder<T> withTable(SqlTable table) {
+        public MyBatis3UpdateByExampleCompleter.Builder<T> withTable(SqlTable table) {
             this.table = table;
             return this;
         }
         
-        public MyBatis3UpdateByExampleRecordGatherer.Builder<T> withHelper(MyBatis3UpdateByExampleHelper helper) {
+        public MyBatis3UpdateByExampleCompleter.Builder<T> withHelper(MyBatis3UpdateByExampleHelper helper) {
             this.helper = helper;
             return this;
         }
 
-        public MyBatis3UpdateByExampleRecordGatherer.Builder<T> withMapper(
+        public MyBatis3UpdateByExampleCompleter.Builder<T> withMapper(
                 ToIntFunction<UpdateStatementProvider> mapper) {
             this.mapper = mapper;
             return this;
         }
         
-        public MyBatis3UpdateByExampleRecordGatherer.Builder<T> withValueSetter(
+        public MyBatis3UpdateByExampleCompleter.Builder<T> withValueSetter(
                 MyBatis3UpdateByExampleValueSetter<T> valueSetter) {
             this.valueSetter = valueSetter;
             return this;
         }
         
-        public MyBatis3UpdateByExampleRecordGatherer<T> build() {
-            return new MyBatis3UpdateByExampleRecordGatherer<>(this);
+        public MyBatis3UpdateByExampleCompleter<T> build() {
+            return new MyBatis3UpdateByExampleCompleter<>(this);
         }
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/util/mybatis3/MyBatis3UpdateByExampleHelper.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/mybatis3/MyBatis3UpdateByExampleHelper.java
@@ -53,10 +53,16 @@ import org.mybatis.dynamic.sql.util.Buildable;
  *                .and(firstName, isEqualTo("Joe")));
  * </pre>
  *  
- * <p>You can also do an "update all" with the following code:
+ * <p>You can implement an "update all" with the following code:
  * 
  * <pre>
  * int rows = mapper.updateByExampleSelective(record, q -&gt; q);
+ * </pre>
+ * 
+ * <p>Or
+ * 
+ * <pre>
+ * int rows = mapper.updateByExampleSelective(record, MyBatis3UpdateByExampleHelper.all());
  * </pre>
  * 
  * @author Jeff Butler
@@ -64,4 +70,13 @@ import org.mybatis.dynamic.sql.util.Buildable;
 @FunctionalInterface
 public interface MyBatis3UpdateByExampleHelper extends
         Function<UpdateDSL<MyBatis3UpdateModelAdapter<Integer>>, Buildable<MyBatis3UpdateModelAdapter<Integer>>> {
+
+    /**
+     * Returns a helper that can be used to update every row in a table.
+     * 
+     * @return the helper that will update every row in a table
+     */
+    static MyBatis3UpdateByExampleHelper all() {
+        return h -> h;
+    }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/util/mybatis3/MyBatis3UpdateByExampleHelper.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/mybatis3/MyBatis3UpdateByExampleHelper.java
@@ -32,38 +32,47 @@ import org.mybatis.dynamic.sql.util.Buildable;
  * &#64;UpdateProvider(type=SqlProviderAdapter.class, method="update")
  * int update(UpdateStatementProvider updateStatement);
  *   
- * default int updateByExampleSelective(SimpleTableRecord record, MyBatis3UpdateByExampleHelper helper) {
- *     return helper.apply(UpdateDSL.updateWithMapper(this::update, simpleTable)
- *             .set(id).equalToWhenPresent(record.getId())
- *             .set(firstName).equalToWhenPresent(record::getFirstName)
- *             .set(lastName).equalToWhenPresent(record::getLastName)
- *             .set(birthDate).equalToWhenPresent(record::getBirthDate)
- *             .set(employed).equalToWhenPresent(record::getEmployed)
- *             .set(occupation).equalToWhenPresent(record::getOccupation))
- *             .build()
- *             .execute();
+ * default MyBatis3UpdateByExampleCompleter updateByExampleSelective(MyBatis3UpdateByExampleHelper helper) {
+ *     return new MyBatis3UpdateByExampleCompleter.Builder&lt;SimpleTableRecord&gt;()
+ *             .withHelper(helper)
+ *             .withMapper(this::update)
+ *             .withTable(simpleTable)
+ *             .withValueSetter((record, dsl) -&gt;
+ *                 dsl.set(id).equalToWhenPresent(record::getId)
+ *                 .set(firstName).equalToWhenPresent(record::getFirstName)
+ *                 .set(lastName).equalToWhenPresent(record::getLastName)
+ *                 .set(birthDate).equalToWhenPresent(record::getBirthDate)
+ *                 .set(employed).equalToWhenPresent(record::getEmployed)
+ *                 .set(occupation).equalToWhenPresent(record::getOccupation))
+ *             .build();
  * }
  * </pre>
  * 
  * <p>And then call the simplified default method like this:
  * 
  * <pre>
- * int rows = mapper.updateByExampleSelective(record, q -&gt;
+ * int rows = mapper.updateByExampleSelective(q -&gt;
  *                q.where(id, isEqualTo(100))
- *                .and(firstName, isEqualTo("Joe")));
+ *                .and(firstName, isEqualTo("Joe")))
+ *                .usingRecord(record);
  * </pre>
  *  
  * <p>You can implement an "update all" with the following code:
  * 
  * <pre>
- * int rows = mapper.updateByExampleSelective(record, q -&gt; q);
+ * int rows = mapper.updateByExampleSelective(q -&gt; q)
+ *                .usingRecord(record);
  * </pre>
  * 
  * <p>Or
  * 
  * <pre>
- * int rows = mapper.updateByExampleSelective(record, MyBatis3UpdateByExampleHelper.all());
+ * int rows = mapper.updateByExampleSelective(MyBatis3UpdateByExampleHelper.allRows())
+ *                .usingRecord(record);
  * </pre>
+ * 
+ * @see MyBatis3UpdateByExampleCompleter
+ * @see MyBatis3UpdateByExampleValueSetter
  * 
  * @author Jeff Butler
  */
@@ -76,7 +85,7 @@ public interface MyBatis3UpdateByExampleHelper extends
      * 
      * @return the helper that will update every row in a table
      */
-    static MyBatis3UpdateByExampleHelper all() {
+    static MyBatis3UpdateByExampleHelper allRows() {
         return h -> h;
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/util/mybatis3/MyBatis3UpdateByExampleRecordGatherer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/mybatis3/MyBatis3UpdateByExampleRecordGatherer.java
@@ -1,0 +1,77 @@
+/**
+ *    Copyright 2016-2019 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.dynamic.sql.util.mybatis3;
+
+import java.util.Objects;
+import java.util.function.ToIntFunction;
+
+import org.mybatis.dynamic.sql.SqlTable;
+import org.mybatis.dynamic.sql.update.UpdateDSL;
+import org.mybatis.dynamic.sql.update.render.UpdateStatementProvider;
+
+public class MyBatis3UpdateByExampleRecordGatherer<T> {
+    private SqlTable table;
+    private MyBatis3UpdateByExampleHelper helper;
+    private ToIntFunction<UpdateStatementProvider> mapper;
+    private MyBatis3UpdateByExampleValueSetter<T> valueSetter;
+    
+    private MyBatis3UpdateByExampleRecordGatherer(MyBatis3UpdateByExampleRecordGatherer.Builder<T> builder) {
+        helper = Objects.requireNonNull(builder.helper);
+        mapper = Objects.requireNonNull(builder.mapper);
+        valueSetter = Objects.requireNonNull(builder.valueSetter);
+        table = Objects.requireNonNull(builder.table);
+    }
+    
+    public int usingRecord(T record) {
+        return valueSetter.andThen(helper)
+                .apply(record, UpdateDSL.updateWithMapper(p -> mapper.applyAsInt(p), table))
+                .build()
+                .execute();
+    }
+    
+    public static class Builder<T> {
+        private SqlTable table;
+        private MyBatis3UpdateByExampleHelper helper;
+        private ToIntFunction<UpdateStatementProvider> mapper;
+        private MyBatis3UpdateByExampleValueSetter<T> valueSetter;
+        
+        public MyBatis3UpdateByExampleRecordGatherer.Builder<T> withTable(SqlTable table) {
+            this.table = table;
+            return this;
+        }
+        
+        public MyBatis3UpdateByExampleRecordGatherer.Builder<T> withHelper(MyBatis3UpdateByExampleHelper helper) {
+            this.helper = helper;
+            return this;
+        }
+
+        public MyBatis3UpdateByExampleRecordGatherer.Builder<T> withMapper(
+                ToIntFunction<UpdateStatementProvider> mapper) {
+            this.mapper = mapper;
+            return this;
+        }
+        
+        public MyBatis3UpdateByExampleRecordGatherer.Builder<T> withValueSetter(
+                MyBatis3UpdateByExampleValueSetter<T> valueSetter) {
+            this.valueSetter = valueSetter;
+            return this;
+        }
+        
+        public MyBatis3UpdateByExampleRecordGatherer<T> build() {
+            return new MyBatis3UpdateByExampleRecordGatherer<>(this);
+        }
+    }
+}

--- a/src/main/java/org/mybatis/dynamic/sql/util/mybatis3/MyBatis3UpdateByExampleValueSetter.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/mybatis3/MyBatis3UpdateByExampleValueSetter.java
@@ -21,12 +21,17 @@ import org.mybatis.dynamic.sql.update.MyBatis3UpdateModelAdapter;
 import org.mybatis.dynamic.sql.update.UpdateDSL;
 
 /**
+ * Represents a function that can be used to create an "UpdateByExample" method in the style
+ * of MyBatis Generator. When using this function, you can create a method that will map record fields to
+ * tables columns to be updated in a common mapper, and then allow a user to set a where clause as needed.
  * 
  * @author Jeff Butler
  *
- * @param <R> the type of record that will be updated
+ * @see MyBatis3UpdateByExampleHelper
+ * 
+ * @param <T> the type of record that will be updated
  */
 @FunctionalInterface
-public interface MyBatis3UpdateByExampleValueSetter<R> extends
-        BiFunction<R, UpdateDSL<MyBatis3UpdateModelAdapter<Integer>>, UpdateDSL<MyBatis3UpdateModelAdapter<Integer>>> {
+public interface MyBatis3UpdateByExampleValueSetter<T> extends
+        BiFunction<T, UpdateDSL<MyBatis3UpdateModelAdapter<Integer>>, UpdateDSL<MyBatis3UpdateModelAdapter<Integer>>> {
 }

--- a/src/main/java/org/mybatis/dynamic/sql/util/mybatis3/MyBatis3UpdateByExampleValueSetter.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/mybatis3/MyBatis3UpdateByExampleValueSetter.java
@@ -1,0 +1,32 @@
+/**
+ *    Copyright 2016-2019 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.dynamic.sql.util.mybatis3;
+
+import java.util.function.BiFunction;
+
+import org.mybatis.dynamic.sql.update.MyBatis3UpdateModelAdapter;
+import org.mybatis.dynamic.sql.update.UpdateDSL;
+
+/**
+ * 
+ * @author Jeff Butler
+ *
+ * @param <R> the type of record that will be updated
+ */
+@FunctionalInterface
+public interface MyBatis3UpdateByExampleValueSetter<R> extends
+        BiFunction<R, UpdateDSL<MyBatis3UpdateModelAdapter<Integer>>, UpdateDSL<MyBatis3UpdateModelAdapter<Integer>>> {
+}

--- a/src/test/java/examples/simple/SimpleTableAnnotatedMapperNewStyle.java
+++ b/src/test/java/examples/simple/SimpleTableAnnotatedMapperNewStyle.java
@@ -45,6 +45,7 @@ import org.mybatis.dynamic.sql.util.mybatis3.MyBatis3CountByExampleHelper;
 import org.mybatis.dynamic.sql.util.mybatis3.MyBatis3DeleteByExampleHelper;
 import org.mybatis.dynamic.sql.util.mybatis3.MyBatis3SelectByExampleHelper;
 import org.mybatis.dynamic.sql.util.mybatis3.MyBatis3UpdateByExampleHelper;
+import org.mybatis.dynamic.sql.util.mybatis3.MyBatis3UpdateByExampleRecordGatherer;
 
 /**
  * 
@@ -170,30 +171,36 @@ public interface SimpleTableAnnotatedMapperNewStyle {
             .execute();
     }
 
-    default int updateByExample(SimpleTableRecord record, MyBatis3UpdateByExampleHelper helper) {
-        return helper.apply(UpdateDSL.updateWithMapper(this::update, simpleTable)
-                .set(id).equalTo(record.getId())
-                .set(firstName).equalTo(record::getFirstName)
-                .set(lastName).equalTo(record::getLastName)
-                .set(birthDate).equalTo(record::getBirthDate)
-                .set(employed).equalTo(record::getEmployed)
-                .set(occupation).equalTo(record::getOccupation))
-                .build()
-                .execute();
+    default MyBatis3UpdateByExampleRecordGatherer<SimpleTableRecord> updateByExample(MyBatis3UpdateByExampleHelper helper) {
+        return new MyBatis3UpdateByExampleRecordGatherer.Builder<SimpleTableRecord>()
+                .withHelper(helper)
+                .withMapper(this::update)
+                .withTable(simpleTable)
+                .withValueSetter((record, dsl) ->
+                    dsl.set(id).equalTo(record::getId)
+                    .set(firstName).equalTo(record::getFirstName)
+                    .set(lastName).equalTo(record::getLastName)
+                    .set(birthDate).equalTo(record::getBirthDate)
+                    .set(employed).equalTo(record::getEmployed)
+                    .set(occupation).equalTo(record::getOccupation))
+                .build();
     }
-
-    default int updateByExampleSelective(SimpleTableRecord record, MyBatis3UpdateByExampleHelper helper) {
-        return helper.apply(UpdateDSL.updateWithMapper(this::update, simpleTable)
-                .set(id).equalToWhenPresent(record.getId())
-                .set(firstName).equalToWhenPresent(record::getFirstName)
-                .set(lastName).equalToWhenPresent(record::getLastName)
-                .set(birthDate).equalToWhenPresent(record::getBirthDate)
-                .set(employed).equalToWhenPresent(record::getEmployed)
-                .set(occupation).equalToWhenPresent(record::getOccupation))
-                .build()
-                .execute();
+    
+    default MyBatis3UpdateByExampleRecordGatherer<SimpleTableRecord> updateByExampleSelective(MyBatis3UpdateByExampleHelper helper) {
+        return new MyBatis3UpdateByExampleRecordGatherer.Builder<SimpleTableRecord>()
+                .withHelper(helper)
+                .withMapper(this::update)
+                .withTable(simpleTable)
+                .withValueSetter((record, dsl) ->
+                    dsl.set(id).equalToWhenPresent(record::getId)
+                    .set(firstName).equalToWhenPresent(record::getFirstName)
+                    .set(lastName).equalToWhenPresent(record::getLastName)
+                    .set(birthDate).equalToWhenPresent(record::getBirthDate)
+                    .set(employed).equalToWhenPresent(record::getEmployed)
+                    .set(occupation).equalToWhenPresent(record::getOccupation))
+                .build();
     }
-
+    
     default int updateByPrimaryKey(SimpleTableRecord record) {
         return UpdateDSL.updateWithMapper(this::update, simpleTable)
                 .set(firstName).equalTo(record::getFirstName)

--- a/src/test/java/examples/simple/SimpleTableAnnotatedMapperNewStyle.java
+++ b/src/test/java/examples/simple/SimpleTableAnnotatedMapperNewStyle.java
@@ -44,8 +44,8 @@ import org.mybatis.dynamic.sql.util.SqlProviderAdapter;
 import org.mybatis.dynamic.sql.util.mybatis3.MyBatis3CountByExampleHelper;
 import org.mybatis.dynamic.sql.util.mybatis3.MyBatis3DeleteByExampleHelper;
 import org.mybatis.dynamic.sql.util.mybatis3.MyBatis3SelectByExampleHelper;
+import org.mybatis.dynamic.sql.util.mybatis3.MyBatis3UpdateByExampleCompleter;
 import org.mybatis.dynamic.sql.util.mybatis3.MyBatis3UpdateByExampleHelper;
-import org.mybatis.dynamic.sql.util.mybatis3.MyBatis3UpdateByExampleRecordGatherer;
 
 /**
  * 
@@ -171,8 +171,8 @@ public interface SimpleTableAnnotatedMapperNewStyle {
             .execute();
     }
 
-    default MyBatis3UpdateByExampleRecordGatherer<SimpleTableRecord> updateByExample(MyBatis3UpdateByExampleHelper helper) {
-        return new MyBatis3UpdateByExampleRecordGatherer.Builder<SimpleTableRecord>()
+    default MyBatis3UpdateByExampleCompleter<SimpleTableRecord> updateByExample(MyBatis3UpdateByExampleHelper helper) {
+        return new MyBatis3UpdateByExampleCompleter.Builder<SimpleTableRecord>()
                 .withHelper(helper)
                 .withMapper(this::update)
                 .withTable(simpleTable)
@@ -186,8 +186,8 @@ public interface SimpleTableAnnotatedMapperNewStyle {
                 .build();
     }
     
-    default MyBatis3UpdateByExampleRecordGatherer<SimpleTableRecord> updateByExampleSelective(MyBatis3UpdateByExampleHelper helper) {
-        return new MyBatis3UpdateByExampleRecordGatherer.Builder<SimpleTableRecord>()
+    default MyBatis3UpdateByExampleCompleter<SimpleTableRecord> updateByExampleSelective(MyBatis3UpdateByExampleHelper helper) {
+        return new MyBatis3UpdateByExampleCompleter.Builder<SimpleTableRecord>()
                 .withHelper(helper)
                 .withMapper(this::update)
                 .withTable(simpleTable)

--- a/src/test/java/examples/simple/SimpleTableAnnotatedNewStyleMapperTest.java
+++ b/src/test/java/examples/simple/SimpleTableAnnotatedNewStyleMapperTest.java
@@ -38,6 +38,10 @@ import org.apache.ibatis.session.SqlSessionFactoryBuilder;
 import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mybatis.dynamic.sql.util.mybatis3.MyBatis3CountByExampleHelper;
+import org.mybatis.dynamic.sql.util.mybatis3.MyBatis3DeleteByExampleHelper;
+import org.mybatis.dynamic.sql.util.mybatis3.MyBatis3SelectByExampleHelper;
+import org.mybatis.dynamic.sql.util.mybatis3.MyBatis3UpdateByExampleHelper;
 
 public class SimpleTableAnnotatedNewStyleMapperTest {
 
@@ -81,7 +85,7 @@ public class SimpleTableAnnotatedNewStyleMapperTest {
         try (SqlSession session = sqlSessionFactory.openSession()) {
             SimpleTableAnnotatedMapperNewStyle mapper = session.getMapper(SimpleTableAnnotatedMapperNewStyle.class);
             
-            List<SimpleTableRecord> rows = mapper.selectByExample(q -> q);
+            List<SimpleTableRecord> rows = mapper.selectByExample(MyBatis3SelectByExampleHelper.all());
             
             assertThat(rows.size()).isEqualTo(6);
         }
@@ -147,7 +151,7 @@ public class SimpleTableAnnotatedNewStyleMapperTest {
     public void testDeleteAll() {
         try (SqlSession session = sqlSessionFactory.openSession()) {
             SimpleTableAnnotatedMapperNewStyle mapper = session.getMapper(SimpleTableAnnotatedMapperNewStyle.class);
-            int rows = mapper.deleteByExample(d -> d);
+            int rows = mapper.deleteByExample(MyBatis3DeleteByExampleHelper.all());
                     
             assertThat(rows).isEqualTo(6);
         }
@@ -323,7 +327,7 @@ public class SimpleTableAnnotatedNewStyleMapperTest {
             
             record = new SimpleTableRecord();
             record.setOccupation("Programmer");
-            rows = mapper.updateByExampleSelective(q -> q).usingRecord(record);
+            rows = mapper.updateByExampleSelective(MyBatis3UpdateByExampleHelper.all()).usingRecord(record);
 
             assertThat(rows).isEqualTo(7);
 
@@ -347,7 +351,7 @@ public class SimpleTableAnnotatedNewStyleMapperTest {
     public void testCountAll() {
         try (SqlSession session = sqlSessionFactory.openSession()) {
             SimpleTableAnnotatedMapperNewStyle mapper = session.getMapper(SimpleTableAnnotatedMapperNewStyle.class);
-            long rows = mapper.countByExample(q -> q);
+            long rows = mapper.countByExample(MyBatis3CountByExampleHelper.all());
             
             assertThat(rows).isEqualTo(6L);
         }

--- a/src/test/java/examples/simple/SimpleTableAnnotatedNewStyleMapperTest.java
+++ b/src/test/java/examples/simple/SimpleTableAnnotatedNewStyleMapperTest.java
@@ -85,7 +85,7 @@ public class SimpleTableAnnotatedNewStyleMapperTest {
         try (SqlSession session = sqlSessionFactory.openSession()) {
             SimpleTableAnnotatedMapperNewStyle mapper = session.getMapper(SimpleTableAnnotatedMapperNewStyle.class);
             
-            List<SimpleTableRecord> rows = mapper.selectByExample(MyBatis3SelectByExampleHelper.all());
+            List<SimpleTableRecord> rows = mapper.selectByExample(MyBatis3SelectByExampleHelper.allRows());
             
             assertThat(rows.size()).isEqualTo(6);
         }
@@ -151,7 +151,7 @@ public class SimpleTableAnnotatedNewStyleMapperTest {
     public void testDeleteAll() {
         try (SqlSession session = sqlSessionFactory.openSession()) {
             SimpleTableAnnotatedMapperNewStyle mapper = session.getMapper(SimpleTableAnnotatedMapperNewStyle.class);
-            int rows = mapper.deleteByExample(MyBatis3DeleteByExampleHelper.all());
+            int rows = mapper.deleteByExample(MyBatis3DeleteByExampleHelper.allRows());
                     
             assertThat(rows).isEqualTo(6);
         }
@@ -327,7 +327,7 @@ public class SimpleTableAnnotatedNewStyleMapperTest {
             
             record = new SimpleTableRecord();
             record.setOccupation("Programmer");
-            rows = mapper.updateByExampleSelective(MyBatis3UpdateByExampleHelper.all()).usingRecord(record);
+            rows = mapper.updateByExampleSelective(MyBatis3UpdateByExampleHelper.allRows()).usingRecord(record);
 
             assertThat(rows).isEqualTo(7);
 
@@ -351,7 +351,7 @@ public class SimpleTableAnnotatedNewStyleMapperTest {
     public void testCountAll() {
         try (SqlSession session = sqlSessionFactory.openSession()) {
             SimpleTableAnnotatedMapperNewStyle mapper = session.getMapper(SimpleTableAnnotatedMapperNewStyle.class);
-            long rows = mapper.countByExample(MyBatis3CountByExampleHelper.all());
+            long rows = mapper.countByExample(MyBatis3CountByExampleHelper.allRows());
             
             assertThat(rows).isEqualTo(6L);
         }

--- a/src/test/java/examples/simple/SimpleTableAnnotatedNewStyleMapperTest.java
+++ b/src/test/java/examples/simple/SimpleTableAnnotatedNewStyleMapperTest.java
@@ -39,7 +39,7 @@ import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class SimpleTableAnnotatedMapperTestNewStyle {
+public class SimpleTableAnnotatedNewStyleMapperTest {
 
     private static final String JDBC_URL = "jdbc:hsqldb:mem:aname";
     private static final String JDBC_DRIVER = "org.hsqldb.jdbcDriver"; 
@@ -293,9 +293,11 @@ public class SimpleTableAnnotatedMapperTestNewStyle {
             assertThat(rows).isEqualTo(1);
 
             record.setOccupation("Programmer");
-            rows = mapper.updateByExample(record, q ->
+            
+            rows = mapper.updateByExample(q ->
                     q.where(id, isEqualTo(100))
-                    .and(firstName, isEqualTo("Joe")));
+                    .and(firstName, isEqualTo("Joe")))
+                    .usingRecord(record);
 
             assertThat(rows).isEqualTo(1);
 
@@ -321,7 +323,7 @@ public class SimpleTableAnnotatedMapperTestNewStyle {
             
             record = new SimpleTableRecord();
             record.setOccupation("Programmer");
-            rows = mapper.updateByExampleSelective(record, q -> q);
+            rows = mapper.updateByExampleSelective(q -> q).usingRecord(record);
 
             assertThat(rows).isEqualTo(7);
 


### PR DESCRIPTION
This PR adds support for an improved syntax of UpdateByExample as created by MyBatis Generator. With this change, it is more clear where to code the "where clause" and where to specify the record to be used as a supplier of values.

This PR also adds static "allRows()" methods to the MyBatis3 helper interfaces to enable more expressive coding for "countAllRows", "selectAllRows", etc.
