### PR TITLE
Deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ One capability is that very expressive dynamic queries can be generated.  Here's
                     .and(bodyWeight, isBetween(1.0).and(3.0))
                     .orderBy(id.descending(), bodyWeight)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
 
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertThat(animals.size()).isEqualTo(4);
@@ -192,7 +192,7 @@ For example, a very simple select statement can be defined like this:
                 .from(simpleTable)
                 .where(id, isEqualTo(3))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 ```
 
 Or this (also note that you can give a table an alias):
@@ -202,7 +202,7 @@ Or this (also note that you can give a table an alias):
                 .from(simpleTable, "a")
                 .where(id, isNull())
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 ```
 A delete statement looks like this:
 
@@ -210,7 +210,7 @@ A delete statement looks like this:
         DeleteStatementProvider deleteStatement = deleteFrom(simpleTable)
                 .where(occupation, isNull())
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 ```
 
 The "between" condition is also expressive:
@@ -220,7 +220,7 @@ The "between" condition is also expressive:
                 .from(simpleTable)
                 .where(id, isBetween(1).and(4))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 ```
 
 More complex expressions can be built using the "and" and "or" conditions as follows:
@@ -231,7 +231,7 @@ More complex expressions can be built using the "and" and "or" conditions as fol
                 .where(id, isGreaterThan(2))
                 .or(occupation, isNull(), and(id, isLessThan(6)))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 ```
 
 All of these statements rely on a set of expressive static methods.  It is typical to import the following:
@@ -259,7 +259,7 @@ an example from `examples.simple.SimpleTableAnnotatedMapperTest`:
                     .where(id, isEqualTo(1))
                     .or(occupation, isNull())
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             List<SimpleTableRecord> rows = mapper.selectMany(selectStatement);
             

--- a/src/main/java/org/mybatis/dynamic/sql/delete/DeleteDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/delete/DeleteDSL.java
@@ -17,6 +17,7 @@ package org.mybatis.dynamic.sql.delete;
 
 import java.util.Objects;
 import java.util.function.Function;
+import java.util.function.ToIntFunction;
 
 import org.mybatis.dynamic.sql.BindableColumn;
 import org.mybatis.dynamic.sql.SqlCriterion;
@@ -24,6 +25,8 @@ import org.mybatis.dynamic.sql.SqlTable;
 import org.mybatis.dynamic.sql.VisitableCondition;
 import org.mybatis.dynamic.sql.delete.render.DeleteStatementProvider;
 import org.mybatis.dynamic.sql.util.Buildable;
+import org.mybatis.dynamic.sql.util.mybatis3.MyBatis3DeleteCompleter;
+import org.mybatis.dynamic.sql.util.mybatis3.MyBatis3Utils;
 import org.mybatis.dynamic.sql.where.AbstractWhereDSL;
 
 public class DeleteDSL<R> implements Buildable<R> {
@@ -75,6 +78,17 @@ public class DeleteDSL<R> implements Buildable<R> {
         return deleteFrom(Function.identity(), table);
     }
     
+    /**
+     * Delete record(s) by executing a MyBatis3 mapper method.
+     * 
+     * @deprecated in favor of {@link MyBatis3Utils#deleteFrom(ToIntFunction, SqlTable, MyBatis3DeleteCompleter)}.
+     *     This method will be removed without direct replacement in a future version
+     * @param <T> return value from a delete method - typically Integer
+     * @param mapperMethod MyBatis3 mapper method that performs the delete
+     * @param table table to delete from
+     * @return number of records deleted - typically as Integer
+     */
+    @Deprecated
     public static <T> DeleteDSL<MyBatis3DeleteModelAdapter<T>> deleteFromWithMapper(
             Function<DeleteStatementProvider, T> mapperMethod, SqlTable table) {
         return deleteFrom(deleteModel -> MyBatis3DeleteModelAdapter.of(deleteModel, mapperMethod), table);

--- a/src/main/java/org/mybatis/dynamic/sql/delete/MyBatis3DeleteModelAdapter.java
+++ b/src/main/java/org/mybatis/dynamic/sql/delete/MyBatis3DeleteModelAdapter.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2016-2017 the original author or authors.
+ *    Copyright 2016-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,13 +20,18 @@ import java.util.function.Function;
 
 import org.mybatis.dynamic.sql.delete.render.DeleteStatementProvider;
 import org.mybatis.dynamic.sql.render.RenderingStrategy;
+import org.mybatis.dynamic.sql.util.mybatis3.MyBatis3DeleteCompleter;
 
 /**
  * This adapter will render the underlying delete model for MyBatis3, and then call a MyBatis mapper method.
+ *
+ * @deprecated in favor of {@link MyBatis3DeleteCompleter}. This class will be removed without replacement in a
+ *     future version
  * 
  * @author Jeff Butler
  *
  */
+@Deprecated
 public class MyBatis3DeleteModelAdapter<R> {
 
     private DeleteModel deleteModel;

--- a/src/main/java/org/mybatis/dynamic/sql/render/RenderingStrategies.java
+++ b/src/main/java/org/mybatis/dynamic/sql/render/RenderingStrategies.java
@@ -1,0 +1,24 @@
+/**
+ *    Copyright 2016-2019 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.dynamic.sql.render;
+
+public class RenderingStrategies {
+    private RenderingStrategies() {}
+    
+    public static final RenderingStrategy MYBATIS3 = new MyBatis3RenderingStrategy();
+    
+    public static final RenderingStrategy SPRING_NAMED_PARAMETER = new SpringNamedParameterRenderingStrategy();
+}

--- a/src/main/java/org/mybatis/dynamic/sql/render/RenderingStrategy.java
+++ b/src/main/java/org/mybatis/dynamic/sql/render/RenderingStrategy.java
@@ -18,10 +18,24 @@ package org.mybatis.dynamic.sql.render;
 import org.mybatis.dynamic.sql.BindableColumn;
 
 public abstract class RenderingStrategy {
+    /**
+     * Rendering strategy for MyBatis3.
+     * 
+     * @deprecated use {@link RenderingStrategies#MYBATIS3} instead
+     */
+    @Deprecated
     @SuppressWarnings("squid:S2390")
     public static final RenderingStrategy MYBATIS3 = new MyBatis3RenderingStrategy();
+
+    /**
+     * Rendering strategy for Spring JDBC Template Named Parameters.
+     * 
+     * @deprecated use {@link RenderingStrategies#SPRING_NAMED_PARAMETER} instead
+     */
+    @Deprecated
     @SuppressWarnings("squid:S2390")
     public static final RenderingStrategy SPRING_NAMED_PARAMETER = new SpringNamedParameterRenderingStrategy();
+
     public static final String DEFAULT_PARAMETER_PREFIX = "parameters"; //$NON-NLS-1$
     
     public abstract String getFormattedJdbcPlaceholder(BindableColumn<?> column, String prefix, String parameterName);

--- a/src/main/java/org/mybatis/dynamic/sql/select/MyBatis3SelectModelAdapter.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/MyBatis3SelectModelAdapter.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2016-2017 the original author or authors.
+ *    Copyright 2016-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,13 +20,18 @@ import java.util.function.Function;
 
 import org.mybatis.dynamic.sql.render.RenderingStrategy;
 import org.mybatis.dynamic.sql.select.render.SelectStatementProvider;
+import org.mybatis.dynamic.sql.util.mybatis3.MyBatis3SelectCompleter;
 
 /**
  * This adapter will render the underlying select model for MyBatis3, and then call a MyBatis mapper method.
- * 
+ *
+ * @deprecated in favor is {@link MyBatis3SelectCompleter}. This class will be removed without direct replacement
+ *     in a future version
+ *     
  * @author Jeff Butler
  *
  */
+@Deprecated
 public class MyBatis3SelectModelAdapter<R> {
 
     private SelectModel selectModel;

--- a/src/main/java/org/mybatis/dynamic/sql/select/SelectDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/SelectDSL.java
@@ -26,6 +26,7 @@ import org.mybatis.dynamic.sql.SortSpecification;
 import org.mybatis.dynamic.sql.select.QueryExpressionDSL.FromGatherer;
 import org.mybatis.dynamic.sql.select.render.SelectStatementProvider;
 import org.mybatis.dynamic.sql.util.Buildable;
+import org.mybatis.dynamic.sql.util.mybatis3.MyBatis3Utils;
 
 /**
  * Implements a standard SQL dialect for building model classes.
@@ -72,11 +73,33 @@ public class SelectDSL<R> implements Buildable<R> {
                 .build();
     }
     
+    /**
+     * Select records by executing a MyBatis3 Mapper.
+     * 
+     * @deprecated in favor of various select methods in {@link MyBatis3Utils}.
+     *     This method will be removed without direct replacement in a future version
+     * @param <T> the return type from a MyBatis mapper - typically a List or a single record
+     * @param mapperMethod MyBatis3 Mapper Method to perfomr the select
+     * @param selectList the column list to select
+     * @return the partially created query
+     */
+    @Deprecated
     public static <T> QueryExpressionDSL.FromGatherer<MyBatis3SelectModelAdapter<T>> selectWithMapper(
             Function<SelectStatementProvider, T> mapperMethod, BasicColumn...selectList) {
         return select(selectModel -> MyBatis3SelectModelAdapter.of(selectModel, mapperMethod), selectList);
     }
     
+    /**
+     * Select records by executing a MyBatis3 Mapper.
+     * 
+     * @deprecated in favor of various select methods in {@link MyBatis3Utils}.
+     *     This method will be removed without direct replacement in a future version
+     * @param <T> the return type from a MyBatis mapper - typically a List or a single record
+     * @param mapperMethod MyBatis3 Mapper Method to perfomr the select
+     * @param selectList the column list to select
+     * @return the partially created query
+     */
+    @Deprecated
     public static <T> QueryExpressionDSL.FromGatherer<MyBatis3SelectModelAdapter<T>> selectDistinctWithMapper(
             Function<SelectStatementProvider, T> mapperMethod, BasicColumn...selectList) {
         return selectDistinct(selectModel -> MyBatis3SelectModelAdapter.of(selectModel, mapperMethod),

--- a/src/main/java/org/mybatis/dynamic/sql/update/MyBatis3UpdateModelAdapter.java
+++ b/src/main/java/org/mybatis/dynamic/sql/update/MyBatis3UpdateModelAdapter.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2016-2017 the original author or authors.
+ *    Copyright 2016-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,13 +20,17 @@ import java.util.function.Function;
 
 import org.mybatis.dynamic.sql.render.RenderingStrategy;
 import org.mybatis.dynamic.sql.update.render.UpdateStatementProvider;
+import org.mybatis.dynamic.sql.util.mybatis3.MyBatis3UpdateCompleter;
 
 /**
  * This adapter will render the underlying update model for MyBatis3, and then call a MyBatis mapper method.
  * 
+ * @deprecated in favor of {@link MyBatis3UpdateCompleter}. This class will be removed without direct
+ *     replacement in a future version.
  * @author Jeff Butler
  *
  */
+@Deprecated
 public class MyBatis3UpdateModelAdapter<R> {
 
     private UpdateModel updateModel;

--- a/src/main/java/org/mybatis/dynamic/sql/update/UpdateDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/update/UpdateDSL.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.function.ToIntFunction;
 
 import org.mybatis.dynamic.sql.BasicColumn;
 import org.mybatis.dynamic.sql.BindableColumn;
@@ -37,6 +38,8 @@ import org.mybatis.dynamic.sql.util.SelectMapping;
 import org.mybatis.dynamic.sql.util.StringConstantMapping;
 import org.mybatis.dynamic.sql.util.UpdateMapping;
 import org.mybatis.dynamic.sql.util.ValueMapping;
+import org.mybatis.dynamic.sql.util.mybatis3.MyBatis3UpdateCompleter;
+import org.mybatis.dynamic.sql.util.mybatis3.MyBatis3Utils;
 import org.mybatis.dynamic.sql.where.AbstractWhereDSL;
 
 public class UpdateDSL<R> implements Buildable<R> {
@@ -94,6 +97,17 @@ public class UpdateDSL<R> implements Buildable<R> {
         return update(Function.identity(), table);
     }
     
+    /**
+     * Executes an update using a MyBatis3 mapper method.
+     * 
+     * @deprecated in favor of {@link MyBatis3Utils#update(ToIntFunction, SqlTable, MyBatis3UpdateCompleter)}. This
+     *     method will be removed without direct replacement in a future version.
+     * @param <T> return value from an update method - typically Integer
+     * @param mapperMethod MyBatis3 mapper method that performs the update
+     * @param table table to update
+     * @return number of records updated - typically as Integer
+     */
+    @Deprecated
     public static <T> UpdateDSL<MyBatis3UpdateModelAdapter<T>> updateWithMapper(
             Function<UpdateStatementProvider, T> mapperMethod, SqlTable table) {
         return update(updateModel -> MyBatis3UpdateModelAdapter.of(updateModel, mapperMethod), table);

--- a/src/main/java/org/mybatis/dynamic/sql/util/mybatis3/MyBatis3Utils.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/mybatis3/MyBatis3Utils.java
@@ -17,7 +17,6 @@ package org.mybatis.dynamic.sql.util.mybatis3;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.ToIntFunction;
 import java.util.function.ToLongFunction;
@@ -32,7 +31,7 @@ import org.mybatis.dynamic.sql.insert.InsertDSL;
 import org.mybatis.dynamic.sql.insert.MultiRowInsertDSL;
 import org.mybatis.dynamic.sql.insert.render.InsertStatementProvider;
 import org.mybatis.dynamic.sql.insert.render.MultiRowInsertStatementProvider;
-import org.mybatis.dynamic.sql.render.RenderingStrategy;
+import org.mybatis.dynamic.sql.render.RenderingStrategies;
 import org.mybatis.dynamic.sql.select.CompletableQuery;
 import org.mybatis.dynamic.sql.select.QueryExpressionDSL;
 import org.mybatis.dynamic.sql.select.SelectDSL;
@@ -57,7 +56,7 @@ public class MyBatis3Utils {
 
     public static long count(ToLongFunction<SelectStatementProvider> mapper,
             QueryExpressionDSL<SelectModel> start, MyBatis3SelectCompleter completer) {
-        return mapper.applyAsLong(completer.apply(start).build().render(RenderingStrategy.MYBATIS3));
+        return mapper.applyAsLong(completer.apply(start).build().render(RenderingStrategies.MYBATIS3));
     }
 
     public static int deleteFrom(ToIntFunction<DeleteStatementProvider> mapper,
@@ -65,19 +64,19 @@ public class MyBatis3Utils {
         return mapper.applyAsInt(
                 completer.apply(DeleteDSL.deleteFrom(table))
                 .build()
-                .render(RenderingStrategy.MYBATIS3));
+                .render(RenderingStrategies.MYBATIS3));
     }
     
     public static <R> int insert(ToIntFunction<InsertStatementProvider<R>> mapper, R record, 
             SqlTable table, UnaryOperator<InsertDSL<R>> completer) {
         return mapper.applyAsInt(completer.apply(
-                InsertDSL.insert(record).into(table)).build().render(RenderingStrategy.MYBATIS3));
+                InsertDSL.insert(record).into(table)).build().render(RenderingStrategies.MYBATIS3));
     }
     
     public static <R> int insertMultiple(ToIntFunction<MultiRowInsertStatementProvider<R>> mapper,
             Collection<R> records, SqlTable table, UnaryOperator<MultiRowInsertDSL<R>> completer) {
         return mapper.applyAsInt(completer.apply(
-                MultiRowInsertDSL.insert(records).into(table)).build().render(RenderingStrategy.MYBATIS3));
+                MultiRowInsertDSL.insert(records).into(table)).build().render(RenderingStrategies.MYBATIS3));
     }
     
     public static <R> List<R> selectDistinct(Function<SelectStatementProvider, List<R>> mapper,
@@ -87,7 +86,7 @@ public class MyBatis3Utils {
 
     public static <R> List<R> selectDistinct(Function<SelectStatementProvider, List<R>> mapper,
             CompletableQuery<SelectModel> start, MyBatis3SelectCompleter completer) {
-        return mapper.apply(completer.apply(start).build().render(RenderingStrategy.MYBATIS3));
+        return mapper.apply(completer.apply(start).build().render(RenderingStrategies.MYBATIS3));
     }
 
     public static <R> List<R> selectList(Function<SelectStatementProvider, List<R>> mapper,
@@ -97,18 +96,18 @@ public class MyBatis3Utils {
 
     public static <R> List<R> selectList(Function<SelectStatementProvider, List<R>> mapper,
             CompletableQuery<SelectModel> start, MyBatis3SelectCompleter completer) {
-        return mapper.apply(completer.apply(start).build().render(RenderingStrategy.MYBATIS3));
+        return mapper.apply(completer.apply(start).build().render(RenderingStrategies.MYBATIS3));
     }
 
-    public static <R> Optional<R> selectOne(Function<SelectStatementProvider, Optional<R>> mapper,
+    public static <R> R selectOne(Function<SelectStatementProvider, R> mapper,
             BasicColumn[] selectList, SqlTable table, MyBatis3SelectCompleter completer) {
         return selectOne(mapper, SelectDSL.select(selectList).from(table), completer);
     }
 
-    public static <R> Optional<R> selectOne(Function<SelectStatementProvider, Optional<R>> mapper,
+    public static <R> R selectOne(Function<SelectStatementProvider, R> mapper,
             CompletableQuery<SelectModel> start,
             MyBatis3SelectCompleter completer) {
-        return mapper.apply(completer.apply(start).build().render(RenderingStrategy.MYBATIS3));
+        return mapper.apply(completer.apply(start).build().render(RenderingStrategies.MYBATIS3));
     }
 
     public static int update(ToIntFunction<UpdateStatementProvider> mapper,
@@ -116,6 +115,6 @@ public class MyBatis3Utils {
         return mapper.applyAsInt(
                 completer.apply(UpdateDSL.update(table))
                 .build()
-                .render(RenderingStrategy.MYBATIS3));
+                .render(RenderingStrategies.MYBATIS3));
     }
 }

--- a/src/site/markdown/docs/complexQueries.md
+++ b/src/site/markdown/docs/complexQueries.md
@@ -27,7 +27,7 @@ public SelectStatementProvider search(Integer targetId, String fName, String lNa
         .orderBy(lastName, firstName)
         .fetchFirst(50).rowsOnly();    // (6)
         
-    return builder.build().render(RenderingStrategy.MYBATIS3);    // (7)
+    return builder.build().render(RenderingStrategies.MYBATIS3);    // (7)
 }
     
 public String addWildcards(String s) {

--- a/src/site/markdown/docs/conditions.md
+++ b/src/site/markdown/docs/conditions.md
@@ -77,7 +77,7 @@ For example, you could code a search like this:
                 .and(bodyWeight, isEqualToWhen(bodyWeight_).when(Objects::nonNull))
                 .and(brainWeight, isEqualToWhen(brainWeight_).when(Objects::nonNull))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
         ...
     }
 ```
@@ -154,7 +154,7 @@ The extension point for modifying the value list is the method `then(UnaryOperat
                                     .filter(st -> !st.isEmpty())))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
 ```
 
 This code is a bit cumbersome, so if this is a common use case you could write a specialization of the `IsIn` condition as follows:
@@ -181,7 +181,7 @@ Then the condition could be used in a query as follows:
                     .where(animalName, MyInCondition.isIn("  Mouse", "  ", null, "", "Musk shrew  "))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
 ```
 
 You can apply value stream operations to the conditions `IsIn`, `IsInCaseInsensitive`, `IsNotIn`, and `IsNotInCaseInsensitive`. With the case insensitive conditions, the library will automatically convert non-null strings to upper case after any value stream operation you specify.

--- a/src/site/markdown/docs/delete.md
+++ b/src/site/markdown/docs/delete.md
@@ -7,7 +7,7 @@ statement is a DeleteStatementProvider object.  For example
     DeleteStatementProvider deleteStatement = deleteFrom(simpleTable)
             .where(occupation, isNull())
             .build()
-            .render(RenderingStrategy.MYBATIS3);
+            .render(RenderingStrategies.MYBATIS3);
 ```
 You can also build a delete statement without a where clause.  This will delete every row in a table.
 For example:
@@ -15,7 +15,7 @@ For example:
 ```java
     DeleteStatementProvider deleteStatement = deleteFrom(foo)
             .build()
-            .render(RenderingStrategy.MYBATIS3);
+            .render(RenderingStrategies.MYBATIS3);
 ``` 
 
 ## Annotated Mapper for Delete Statements

--- a/src/site/markdown/docs/extending.md
+++ b/src/site/markdown/docs/extending.md
@@ -129,6 +129,11 @@ public class PlainJDBCRenderingStrategy extends RenderingStrategy {
     public String getFormattedJdbcPlaceholder(BindableColumn<?> column, String prefix, String parameterName) {
         return "?";
     }
+
+    @Override
+    public String getFormattedJdbcPlaceholder(String prefix, String parameterName) {
+        return "?";
+    }
 }
 
 ```

--- a/src/site/markdown/docs/insert.md
+++ b/src/site/markdown/docs/insert.md
@@ -28,7 +28,7 @@ A single record insert is a statement that inserts a single record into a table.
             .map(employed).toProperty("employed")
             .map(occupation).toProperty("occupation")
             .build()
-            .render(RenderingStrategy.MYBATIS3);
+            .render(RenderingStrategies.MYBATIS3);
 
     int rows = mapper.insert(insertStatement);
 ...
@@ -115,7 +115,7 @@ A multiple row insert statement looks like this:
                 .map(firstName).toProperty("firstName")
                 .map(lastName).toProperty("lastName")
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
             
         int rows = mapper.insertMultiple(multiRowInsert);
     }
@@ -200,7 +200,7 @@ A batch insert is a collection of statements that can be used to execute a JDBC 
                 .map(employed).toProperty("employed")
                 .map(occupation).toProperty("occupation")
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         batchInsert.insertStatements().stream().forEach(mapper::insert);
 
@@ -224,7 +224,7 @@ An insert select is an SQL insert statement the inserts the results of a select.
                 .from(animalData)
                 .where(id, isLessThan(22)))
             .build()
-            .render(RenderingStrategy.MYBATIS3);
+            .render(RenderingStrategies.MYBATIS3);
 
     int rows = mapper.insertSelect(insertSelectStatement);
 ```

--- a/src/site/markdown/docs/quickStart.md
+++ b/src/site/markdown/docs/quickStart.md
@@ -146,7 +146,7 @@ an example from `examples.simple.SimpleTableAnnotatedMapperTest`:
                     .where(id, isEqualTo(1))
                     .or(occupation, isNull())
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
 
             List<SimpleTableRecord> rows = mapper.selectMany(selectStatement);
 

--- a/src/site/markdown/docs/select.md
+++ b/src/site/markdown/docs/select.md
@@ -29,7 +29,7 @@ The user guide page for WHERE Clauses shows examples of many different types of 
             .and(bodyWeight, isBetween(1.0).and(3.0))
             .orderBy(id.descending(), bodyWeight)
             .build()
-            .render(RenderingStrategy.MYBATIS3);
+            .render(RenderingStrategies.MYBATIS3);
 
     List<AnimalData> animals = mapper.selectMany(selectStatement);
 ```
@@ -44,7 +44,7 @@ The library supports the generation of equijoin statements - joins defined by co
             .from(orderMaster, "om")
             .join(orderDetail, "od").on(orderMaster.orderId, equalTo(orderDetail.orderId))
             .build()
-            .render(RenderingStrategy.MYBATIS3);
+            .render(RenderingStrategies.MYBATIS3);
 ```
 
 Notice that you can give an alias to a table if desired. If you don't specify an alias, the full table name will be used in the generated SQL.
@@ -58,7 +58,7 @@ Multiple tables can be joined in a single statement. For example:
             .join(itemMaster, "im").on(orderLine.itemId, equalTo(itemMaster.itemId))
             .where(orderMaster.orderId, isEqualTo(2))
             .build()
-            .render(RenderingStrategy.MYBATIS3);
+            .render(RenderingStrategies.MYBATIS3);
 ```
 Join queries will likely require you to define a MyBatis result mapping in XML. This is the only instance where XML is required.  This is due to the limitations of the MyBatis annotations when mapping collections.
 
@@ -80,7 +80,7 @@ The library supports the generation of UNION and UNION ALL queries. For example:
             .from(animalData)
             .orderBy(id)
             .build()
-            .render(RenderingStrategy.MYBATIS3);
+            .render(RenderingStrategies.MYBATIS3);
 ```
 
 Any number of SELECT statements can be added to a UNION query. Only one ORDER BY phrase is allowed.
@@ -190,7 +190,7 @@ When using a column function (lower, upper, etc.), then is is customary to give 
             .groupBy(substring(gender, 1, 1))
             .orderBy(sortColumn("ShortGender").descending())
             .build()
-            .render(RenderingStrategy.MYBATIS3);
+            .render(RenderingStrategies.MYBATIS3);
 ```
 
 In this example the `substring` function is used in both the select list and the GROUP BY expression.  In the ORDER BY expression, we use the `sortColumn` function to duplicate the alias given to the column in the select list.
@@ -213,7 +213,7 @@ An example follows:
             .limit(3)
             .offset(22)
             .build()
-            .render(RenderingStrategy.MYBATIS3);
+            .render(RenderingStrategies.MYBATIS3);
 ```
 
 ## Fetch First Support
@@ -234,5 +234,5 @@ An example follows:
             .offset(22)
             .fetchFirst(3).rowsOnly()
             .build()
-            .render(RenderingStrategy.MYBATIS3);
+            .render(RenderingStrategies.MYBATIS3);
 ```

--- a/src/site/markdown/docs/spring.md
+++ b/src/site/markdown/docs/spring.md
@@ -9,7 +9,7 @@ The SQL statement objects are created in exactly the same way as for MyBatis - o
             .where(id, isGreaterThan(3))
             .orderBy(id.descending())
             .build()
-            .render(RenderingStrategy.SPRING_NAMED_PARAMETER);
+            .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
 ```
 
 ## Executing Select Statements
@@ -23,7 +23,7 @@ The Spring Named Parameter JDBC template expects an SQL statement with parameter
             .where(id, isGreaterThan(3))
             .orderBy(id.descending())
             .build()
-            .render(RenderingStrategy.SPRING_NAMED_PARAMETER);
+            .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
         
     SqlParameterSource namedParameters = new MapSqlParameterSource(selectStatement.getParameters());
     List<GeneratedAlwaysRecord> records = template.query(selectStatement.getSelectStatement(), namedParameters,
@@ -57,7 +57,7 @@ Insert statements are a bit different - MyBatis Dynamic SQL generates a properly
             .map(firstName).toProperty("firstName")
             .map(lastName).toProperty("lastName")
             .build()
-            .render(RenderingStrategy.SPRING_NAMED_PARAMETER);
+            .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
         
     SqlParameterSource parameterSource = new BeanPropertySqlParameterSource(insertStatement.getRecord());
     KeyHolder keyHolder = new GeneratedKeyHolder();
@@ -93,7 +93,7 @@ Batch insert support in Spring is a bit different than batch support in MyBatis3
             .map(firstName).toProperty("firstName")
             .map(lastName).toProperty("lastName")
             .build()
-            .render(RenderingStrategy.SPRING_NAMED_PARAMETER);
+            .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
         
     int[] updateCounts = template.batchUpdate(batchInsert.getInsertStatementSQL(), batch);
 ```
@@ -108,7 +108,7 @@ Updates and deletes use the `MapSqlParameterSource` as with select statements, b
             .set(firstName).equalToStringConstant("Rob")
             .where(id,  isIn(1, 5, 22))
             .build()
-            .render(RenderingStrategy.SPRING_NAMED_PARAMETER);
+            .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
         
     SqlParameterSource parameterSource = new MapSqlParameterSource(updateStatement.getParameters());
         

--- a/src/site/markdown/docs/update.md
+++ b/src/site/markdown/docs/update.md
@@ -10,7 +10,7 @@ Update statements are composed by specifying the table and columns to update, an
             .or(id, isGreaterThan(60))
             .and(bodyWeight, isBetween(1.0).and(3.0))
             .build()
-            .render(RenderingStrategy.MYBATIS3);
+            .render(RenderingStrategies.MYBATIS3);
 
     int rows = mapper.update(updateStatement);
 ```
@@ -35,7 +35,7 @@ For example:
             .set(bodyWeight).equalTo(record.getBodyWeight())
             .set(animalName).equalToNull()
             .build()
-            .render(RenderingStrategy.MYBATIS3);
+            .render(RenderingStrategies.MYBATIS3);
 ```
 
 ## Annotated Mapper for Update Statements

--- a/src/site/markdown/docs/whereClauses.md
+++ b/src/site/markdown/docs/whereClauses.md
@@ -12,7 +12,7 @@ The simplest WHERE clause is of this form:
                 .from(simpleTable)
                 .where(id, isEqualTo(3))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 ```
 
 The library ships with a wide variety of conditions that can be used in WHERE clauses including
@@ -23,7 +23,7 @@ The library ships with a wide variety of conditions that can be used in WHERE cl
                 .from(simpleTable)
                 .where(id, isBetween(3).and(6))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 ```
 
 ```java
@@ -31,7 +31,7 @@ The library ships with a wide variety of conditions that can be used in WHERE cl
                 .from(simpleTable)
                 .where(id, isIn(3,4,5))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 ```
 
 ```java
@@ -39,7 +39,7 @@ The library ships with a wide variety of conditions that can be used in WHERE cl
                 .from(simpleTable)
                 .where(id, isNotNull())
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 ```
 
 ## Complex WHERE Clauses
@@ -52,7 +52,7 @@ Conditions can be "anded" and "ored" in virtually any combination. For example:
                 .where(id, isGreaterThan(2))
                 .or(occupation, isNull(), and(id, isLessThan(6)))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 ```
 
 ## Subqueries
@@ -65,7 +65,7 @@ Most of the conditions also support a subquery.  For example:
                 .where(column2, isIn(select(column2).from(table).where(column2, isEqualTo(3))))
                 .or(column1, isLessThan(d))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 ```
 
 ## Stand Alone Where Clauses
@@ -86,7 +86,7 @@ You can build a stand alone where clause and call your mapper like this:
 ```java
     WhereClauseProvider whereClause = where(id, isNotBetween(10).and(60))
             .build()
-            .render(RenderingStrategy.MYBATIS3);
+            .render(RenderingStrategies.MYBATIS3);
 
     List<AnimalData> animals = mapper.selectByExample(whereClause);
 ```
@@ -109,7 +109,7 @@ Then you can specify the alias for the generated WHERE clause on the render meth
 ```java
     WhereClauseProvider whereClause = where(id, isEqualTo(1), or(bodyWeight, isGreaterThan(1.0)))
             .build()
-            .render(RenderingStrategy.MYBATIS3, TableAliasCalculator.of(animalData, "a"));
+            .render(RenderingStrategies.MYBATIS3, TableAliasCalculator.of(animalData, "a"));
 
     List<AnimalData> animals = mapper.selectByExampleWithAlias(whereClause);
 ```
@@ -136,7 +136,7 @@ In this mapper method there are three parameters.  So in this case it will be ne
 ```java
     WhereClauseProvider whereClause = where(id, isLessThan(60))
             .build()
-            .render(RenderingStrategy.MYBATIS3, "whereClauseProvider");
+            .render(RenderingStrategies.MYBATIS3, "whereClauseProvider");
             
     List<AnimalData> animals = mapper.selectByExampleWithLimitAndOffset(whereClause, 5, 15);
 ```

--- a/src/test/java/examples/animal/data/FetchFirstTest.java
+++ b/src/test/java/examples/animal/data/FetchFirstTest.java
@@ -36,7 +36,7 @@ import org.apache.ibatis.session.SqlSessionFactoryBuilder;
 import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mybatis.dynamic.sql.render.RenderingStrategy;
+import org.mybatis.dynamic.sql.render.RenderingStrategies;
 import org.mybatis.dynamic.sql.select.render.SelectStatementProvider;
 
 public class FetchFirstTest {
@@ -71,7 +71,7 @@ public class FetchFirstTest {
                     .offset(22)
                     .fetchFirst(3).rowsOnly()
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             List<AnimalData> records = mapper.selectMany(selectStatement);
@@ -93,7 +93,7 @@ public class FetchFirstTest {
                     .from(animalData)
                     .fetchFirst(3).rowsOnly()
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             List<AnimalData> records = mapper.selectMany(selectStatement);
@@ -117,7 +117,7 @@ public class FetchFirstTest {
                     .offset(22)
                     .fetchFirst(3).rowsOnly()
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             List<AnimalData> records = mapper.selectMany(selectStatement);
@@ -140,7 +140,7 @@ public class FetchFirstTest {
                     .where(id, isLessThan(50))
                     .fetchFirst(3).rowsOnly()
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             List<AnimalData> records = mapper.selectMany(selectStatement);
@@ -163,7 +163,7 @@ public class FetchFirstTest {
                     .offset(22)
                     .fetchFirst(3).rowsOnly()
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             List<AnimalData> records = mapper.selectMany(selectStatement);
@@ -186,7 +186,7 @@ public class FetchFirstTest {
                     .orderBy(id)
                     .fetchFirst(3).rowsOnly()
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
         
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             List<AnimalData> records = mapper.selectMany(selectStatement);

--- a/src/test/java/examples/animal/data/LimitAndOffsetTest.java
+++ b/src/test/java/examples/animal/data/LimitAndOffsetTest.java
@@ -36,7 +36,7 @@ import org.apache.ibatis.session.SqlSessionFactoryBuilder;
 import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mybatis.dynamic.sql.render.RenderingStrategy;
+import org.mybatis.dynamic.sql.render.RenderingStrategies;
 import org.mybatis.dynamic.sql.select.render.SelectStatementProvider;
 
 public class LimitAndOffsetTest {
@@ -71,7 +71,7 @@ public class LimitAndOffsetTest {
                     .limit(3)
                     .offset(22)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             List<AnimalData> records = mapper.selectMany(selectStatement);
@@ -93,7 +93,7 @@ public class LimitAndOffsetTest {
                     .from(animalData)
                     .limit(3)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             List<AnimalData> records = mapper.selectMany(selectStatement);
@@ -114,7 +114,7 @@ public class LimitAndOffsetTest {
                     .from(animalData)
                     .offset(22)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             List<AnimalData> records = mapper.selectMany(selectStatement);
@@ -138,7 +138,7 @@ public class LimitAndOffsetTest {
                     .limit(3)
                     .offset(22)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             List<AnimalData> records = mapper.selectMany(selectStatement);
@@ -161,7 +161,7 @@ public class LimitAndOffsetTest {
                     .where(id, isLessThan(50))
                     .limit(3)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             List<AnimalData> records = mapper.selectMany(selectStatement);
@@ -183,7 +183,7 @@ public class LimitAndOffsetTest {
                     .where(id, isLessThan(50))
                     .offset(22)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             List<AnimalData> records = mapper.selectMany(selectStatement);
@@ -206,7 +206,7 @@ public class LimitAndOffsetTest {
                     .limit(3)
                     .offset(22)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             List<AnimalData> records = mapper.selectMany(selectStatement);
@@ -229,7 +229,7 @@ public class LimitAndOffsetTest {
                     .orderBy(id)
                     .limit(3)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
         
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             List<AnimalData> records = mapper.selectMany(selectStatement);
@@ -251,7 +251,7 @@ public class LimitAndOffsetTest {
                     .orderBy(id)
                     .offset(22)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
         
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             List<AnimalData> records = mapper.selectMany(selectStatement);

--- a/src/test/java/examples/animal/data/OptionalConditionsAnimalDataTest.java
+++ b/src/test/java/examples/animal/data/OptionalConditionsAnimalDataTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2016-2018 the original author or authors.
+ *    Copyright 2016-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ import org.apache.ibatis.session.SqlSessionFactoryBuilder;
 import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mybatis.dynamic.sql.render.RenderingStrategy;
+import org.mybatis.dynamic.sql.render.RenderingStrategies;
 import org.mybatis.dynamic.sql.select.render.SelectStatementProvider;
 
 public class OptionalConditionsAnimalDataTest {
@@ -73,7 +73,7 @@ public class OptionalConditionsAnimalDataTest {
                     .where(id, isGreaterThanWhenPresent(NULL_INTEGER))  // the where clause should not render
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData order by id"),
@@ -95,7 +95,7 @@ public class OptionalConditionsAnimalDataTest {
                     .or(id, isEqualToWhenPresent(4))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id = #{parameters.p1,jdbcType=INTEGER} or id = #{parameters.p2,jdbcType=INTEGER} order by id"),
@@ -117,7 +117,7 @@ public class OptionalConditionsAnimalDataTest {
                     .or(id, isEqualToWhenPresent(4))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id = #{parameters.p1,jdbcType=INTEGER} or id = #{parameters.p2,jdbcType=INTEGER} order by id"),
@@ -140,7 +140,7 @@ public class OptionalConditionsAnimalDataTest {
                     .and(id, isNotEqualToWhenPresent(NULL_INTEGER))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id = #{parameters.p1,jdbcType=INTEGER} or id = #{parameters.p2,jdbcType=INTEGER} order by id"),
@@ -161,7 +161,7 @@ public class OptionalConditionsAnimalDataTest {
                     .or(id, isEqualToWhenPresent(4))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id = #{parameters.p1,jdbcType=INTEGER} or id = #{parameters.p2,jdbcType=INTEGER} order by id"),
@@ -181,7 +181,7 @@ public class OptionalConditionsAnimalDataTest {
                     .where(id, isEqualToWhenPresent(4))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id = #{parameters.p1,jdbcType=INTEGER} order by id"),
@@ -201,7 +201,7 @@ public class OptionalConditionsAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id <= #{parameters.p1,jdbcType=INTEGER} order by id"),
@@ -221,7 +221,7 @@ public class OptionalConditionsAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id <> #{parameters.p1,jdbcType=INTEGER} and id <= #{parameters.p2,jdbcType=INTEGER} order by id"),
@@ -241,7 +241,7 @@ public class OptionalConditionsAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id <= #{parameters.p1,jdbcType=INTEGER} order by id"),
@@ -261,7 +261,7 @@ public class OptionalConditionsAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id > #{parameters.p1,jdbcType=INTEGER} and id <= #{parameters.p2,jdbcType=INTEGER} order by id"),
@@ -281,7 +281,7 @@ public class OptionalConditionsAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id <= #{parameters.p1,jdbcType=INTEGER} order by id"),
@@ -301,7 +301,7 @@ public class OptionalConditionsAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id >= #{parameters.p1,jdbcType=INTEGER} and id <= #{parameters.p2,jdbcType=INTEGER} order by id"),
@@ -321,7 +321,7 @@ public class OptionalConditionsAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id <= #{parameters.p1,jdbcType=INTEGER} order by id"),
@@ -340,7 +340,7 @@ public class OptionalConditionsAnimalDataTest {
                     .where(id, isLessThanWhenPresent(4))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id < #{parameters.p1,jdbcType=INTEGER} order by id"),
@@ -360,7 +360,7 @@ public class OptionalConditionsAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id <= #{parameters.p1,jdbcType=INTEGER} order by id"),
@@ -379,7 +379,7 @@ public class OptionalConditionsAnimalDataTest {
                     .where(id, isLessThanOrEqualToWhenPresent(4))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id <= #{parameters.p1,jdbcType=INTEGER} order by id"),
@@ -399,7 +399,7 @@ public class OptionalConditionsAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id <= #{parameters.p1,jdbcType=INTEGER} order by id"),
@@ -418,7 +418,7 @@ public class OptionalConditionsAnimalDataTest {
                     .where(id, isInWhenPresent(4, 5, 6))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id in (#{parameters.p1,jdbcType=INTEGER},#{parameters.p2,jdbcType=INTEGER},#{parameters.p3,jdbcType=INTEGER}) order by id"),
@@ -437,7 +437,7 @@ public class OptionalConditionsAnimalDataTest {
                     .where(id, isInWhenPresent(3, NULL_INTEGER, 5))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id in (#{parameters.p1,jdbcType=INTEGER},#{parameters.p2,jdbcType=INTEGER}) order by id"),
@@ -457,7 +457,7 @@ public class OptionalConditionsAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id <= #{parameters.p1,jdbcType=INTEGER} order by id"),
@@ -476,7 +476,7 @@ public class OptionalConditionsAnimalDataTest {
                     .where(animalName, isInCaseInsensitiveWhenPresent("mouse", "musk shrew"))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where upper(animal_name) in (#{parameters.p1,jdbcType=VARCHAR},#{parameters.p2,jdbcType=VARCHAR}) order by id"),
@@ -495,7 +495,7 @@ public class OptionalConditionsAnimalDataTest {
                     .where(animalName, isInCaseInsensitiveWhenPresent("mouse", null, "musk shrew"))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where upper(animal_name) in (#{parameters.p1,jdbcType=VARCHAR},#{parameters.p2,jdbcType=VARCHAR}) order by id"),
@@ -515,7 +515,7 @@ public class OptionalConditionsAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id <= #{parameters.p1,jdbcType=INTEGER} order by id"),
@@ -535,7 +535,7 @@ public class OptionalConditionsAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id not in (#{parameters.p1,jdbcType=INTEGER},#{parameters.p2,jdbcType=INTEGER},#{parameters.p3,jdbcType=INTEGER}) and id <= #{parameters.p4,jdbcType=INTEGER} order by id"),
@@ -555,7 +555,7 @@ public class OptionalConditionsAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id not in (#{parameters.p1,jdbcType=INTEGER},#{parameters.p2,jdbcType=INTEGER}) and id <= #{parameters.p3,jdbcType=INTEGER} order by id"),
@@ -575,7 +575,7 @@ public class OptionalConditionsAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id <= #{parameters.p1,jdbcType=INTEGER} order by id"),
@@ -595,7 +595,7 @@ public class OptionalConditionsAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where upper(animal_name) not in (#{parameters.p1,jdbcType=VARCHAR},#{parameters.p2,jdbcType=VARCHAR}) and id <= #{parameters.p3,jdbcType=INTEGER} order by id"),
@@ -615,7 +615,7 @@ public class OptionalConditionsAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where upper(animal_name) not in (#{parameters.p1,jdbcType=VARCHAR},#{parameters.p2,jdbcType=VARCHAR}) and id <= #{parameters.p3,jdbcType=INTEGER} order by id"),
@@ -635,7 +635,7 @@ public class OptionalConditionsAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id <= #{parameters.p1,jdbcType=INTEGER} order by id"),
@@ -654,7 +654,7 @@ public class OptionalConditionsAnimalDataTest {
                     .where(id, isBetweenWhenPresent(3).and(6))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id between #{parameters.p1,jdbcType=INTEGER} and #{parameters.p2,jdbcType=INTEGER} order by id"),
@@ -674,7 +674,7 @@ public class OptionalConditionsAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id <= #{parameters.p1,jdbcType=INTEGER} order by id"),
@@ -694,7 +694,7 @@ public class OptionalConditionsAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id <= #{parameters.p1,jdbcType=INTEGER} order by id"),
@@ -714,7 +714,7 @@ public class OptionalConditionsAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id <= #{parameters.p1,jdbcType=INTEGER} order by id"),
@@ -734,7 +734,7 @@ public class OptionalConditionsAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id not between #{parameters.p1,jdbcType=INTEGER} and #{parameters.p2,jdbcType=INTEGER} and id <= #{parameters.p3,jdbcType=INTEGER} order by id"),
@@ -754,7 +754,7 @@ public class OptionalConditionsAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id <= #{parameters.p1,jdbcType=INTEGER} order by id"),
@@ -774,7 +774,7 @@ public class OptionalConditionsAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id <= #{parameters.p1,jdbcType=INTEGER} order by id"),
@@ -794,7 +794,7 @@ public class OptionalConditionsAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id <= #{parameters.p1,jdbcType=INTEGER} order by id"),
@@ -814,7 +814,7 @@ public class OptionalConditionsAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where animal_name like #{parameters.p1,jdbcType=VARCHAR} and id <= #{parameters.p2,jdbcType=INTEGER} order by id"),
@@ -834,7 +834,7 @@ public class OptionalConditionsAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id <= #{parameters.p1,jdbcType=INTEGER} order by id"),
@@ -854,7 +854,7 @@ public class OptionalConditionsAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where upper(animal_name) like #{parameters.p1,jdbcType=VARCHAR} and id <= #{parameters.p2,jdbcType=INTEGER} order by id"),
@@ -874,7 +874,7 @@ public class OptionalConditionsAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id <= #{parameters.p1,jdbcType=INTEGER} order by id"),
@@ -894,7 +894,7 @@ public class OptionalConditionsAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where animal_name not like #{parameters.p1,jdbcType=VARCHAR} and id <= #{parameters.p2,jdbcType=INTEGER} order by id"),
@@ -914,7 +914,7 @@ public class OptionalConditionsAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id <= #{parameters.p1,jdbcType=INTEGER} order by id"),
@@ -934,7 +934,7 @@ public class OptionalConditionsAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where upper(animal_name) not like #{parameters.p1,jdbcType=VARCHAR} and id <= #{parameters.p2,jdbcType=INTEGER} order by id"),
@@ -954,7 +954,7 @@ public class OptionalConditionsAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id <= #{parameters.p1,jdbcType=INTEGER} order by id"),

--- a/src/test/java/examples/animal/data/OptionalConditionsWithPredicatesAnimalDataTest.java
+++ b/src/test/java/examples/animal/data/OptionalConditionsWithPredicatesAnimalDataTest.java
@@ -41,7 +41,7 @@ import org.apache.ibatis.session.SqlSessionFactoryBuilder;
 import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mybatis.dynamic.sql.render.RenderingStrategy;
+import org.mybatis.dynamic.sql.render.RenderingStrategies;
 import org.mybatis.dynamic.sql.select.render.SelectStatementProvider;
 import org.mybatis.dynamic.sql.util.Predicates;
 
@@ -79,7 +79,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .where(id, isGreaterThan(NULL_INTEGER).when(Objects::nonNull))  // the where clause should not render
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData order by id"),
@@ -101,7 +101,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .or(id, isEqualTo(4).when(Objects::nonNull))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id = #{parameters.p1,jdbcType=INTEGER} or id = #{parameters.p2,jdbcType=INTEGER} order by id"),
@@ -123,7 +123,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .or(id, isEqualTo(4).when(Objects::nonNull))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id = #{parameters.p1,jdbcType=INTEGER} or id = #{parameters.p2,jdbcType=INTEGER} order by id"),
@@ -146,7 +146,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .and(id, isNotEqualTo(NULL_INTEGER).when(Objects::nonNull))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id = #{parameters.p1,jdbcType=INTEGER} or id = #{parameters.p2,jdbcType=INTEGER} order by id"),
@@ -167,7 +167,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .or(id, isEqualTo(4).when(Objects::nonNull))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id = #{parameters.p1,jdbcType=INTEGER} or id = #{parameters.p2,jdbcType=INTEGER} order by id"),
@@ -187,7 +187,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .where(id, isEqualTo(4).when(Objects::nonNull))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id = #{parameters.p1,jdbcType=INTEGER} order by id"),
@@ -207,7 +207,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id <= #{parameters.p1,jdbcType=INTEGER} order by id"),
@@ -227,7 +227,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id <> #{parameters.p1,jdbcType=INTEGER} and id <= #{parameters.p2,jdbcType=INTEGER} order by id"),
@@ -247,7 +247,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id <= #{parameters.p1,jdbcType=INTEGER} order by id"),
@@ -267,7 +267,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id > #{parameters.p1,jdbcType=INTEGER} and id <= #{parameters.p2,jdbcType=INTEGER} order by id"),
@@ -287,7 +287,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id <= #{parameters.p1,jdbcType=INTEGER} order by id"),
@@ -307,7 +307,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id >= #{parameters.p1,jdbcType=INTEGER} and id <= #{parameters.p2,jdbcType=INTEGER} order by id"),
@@ -327,7 +327,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id <= #{parameters.p1,jdbcType=INTEGER} order by id"),
@@ -346,7 +346,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .where(id, isLessThan(4).when(Objects::nonNull))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id < #{parameters.p1,jdbcType=INTEGER} order by id"),
@@ -366,7 +366,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id <= #{parameters.p1,jdbcType=INTEGER} order by id"),
@@ -385,7 +385,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .where(id, isLessThanOrEqualTo(4).when(Objects::nonNull))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id <= #{parameters.p1,jdbcType=INTEGER} order by id"),
@@ -405,7 +405,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id <= #{parameters.p1,jdbcType=INTEGER} order by id"),
@@ -424,7 +424,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .where(id, isIn(4, 5, 6))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id in (#{parameters.p1,jdbcType=INTEGER},#{parameters.p2,jdbcType=INTEGER},#{parameters.p3,jdbcType=INTEGER}) order by id"),
@@ -443,7 +443,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .where(id, isIn(3, NULL_INTEGER, 5).then(s -> s.filter(Objects::nonNull).map(i -> i + 3)))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id in (#{parameters.p1,jdbcType=INTEGER},#{parameters.p2,jdbcType=INTEGER}) order by id"),
@@ -463,7 +463,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .where(animalName, isInCaseInsensitive("mouse", "musk shrew"))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where upper(animal_name) in (#{parameters.p1,jdbcType=VARCHAR},#{parameters.p2,jdbcType=VARCHAR}) order by id"),
@@ -485,7 +485,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                                     .filter(st -> !st.isEmpty())))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where animal_name in (#{parameters.p1,jdbcType=VARCHAR},#{parameters.p2,jdbcType=VARCHAR}) order by id"),
@@ -504,7 +504,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .where(animalName, MyInCondition.isIn("  Mouse", "  ", null, "", "Musk shrew  "))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where animal_name in (#{parameters.p1,jdbcType=VARCHAR},#{parameters.p2,jdbcType=VARCHAR}) order by id"),
@@ -523,7 +523,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .where(animalName, isInCaseInsensitive("mouse", null, "musk shrew").then(s -> s.filter(Objects::nonNull)))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where upper(animal_name) in (#{parameters.p1,jdbcType=VARCHAR},#{parameters.p2,jdbcType=VARCHAR}) order by id"),
@@ -543,7 +543,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id <= #{parameters.p1,jdbcType=INTEGER} order by id"),
@@ -563,7 +563,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id not in (#{parameters.p1,jdbcType=INTEGER},#{parameters.p2,jdbcType=INTEGER},#{parameters.p3,jdbcType=INTEGER}) and id <= #{parameters.p4,jdbcType=INTEGER} order by id"),
@@ -583,7 +583,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id not in (#{parameters.p1,jdbcType=INTEGER},#{parameters.p2,jdbcType=INTEGER}) and id <= #{parameters.p3,jdbcType=INTEGER} order by id"),
@@ -603,7 +603,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where upper(animal_name) not in (#{parameters.p1,jdbcType=VARCHAR},#{parameters.p2,jdbcType=VARCHAR}) and id <= #{parameters.p3,jdbcType=INTEGER} order by id"),
@@ -623,7 +623,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where upper(animal_name) not in (#{parameters.p1,jdbcType=VARCHAR},#{parameters.p2,jdbcType=VARCHAR}) and id <= #{parameters.p3,jdbcType=INTEGER} order by id"),
@@ -643,7 +643,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id <= #{parameters.p1,jdbcType=INTEGER} order by id"),
@@ -662,7 +662,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .where(id, isBetween(3).and(6).when(Predicates.bothPresent()))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id between #{parameters.p1,jdbcType=INTEGER} and #{parameters.p2,jdbcType=INTEGER} order by id"),
@@ -682,7 +682,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id <= #{parameters.p1,jdbcType=INTEGER} order by id"),
@@ -702,7 +702,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id <= #{parameters.p1,jdbcType=INTEGER} order by id"),
@@ -722,7 +722,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id <= #{parameters.p1,jdbcType=INTEGER} order by id"),
@@ -742,7 +742,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id not between #{parameters.p1,jdbcType=INTEGER} and #{parameters.p2,jdbcType=INTEGER} and id <= #{parameters.p3,jdbcType=INTEGER} order by id"),
@@ -762,7 +762,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id <= #{parameters.p1,jdbcType=INTEGER} order by id"),
@@ -782,7 +782,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id <= #{parameters.p1,jdbcType=INTEGER} order by id"),
@@ -802,7 +802,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id <= #{parameters.p1,jdbcType=INTEGER} order by id"),
@@ -822,7 +822,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where animal_name like #{parameters.p1,jdbcType=VARCHAR} and id <= #{parameters.p2,jdbcType=INTEGER} order by id"),
@@ -842,7 +842,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id <= #{parameters.p1,jdbcType=INTEGER} order by id"),
@@ -862,7 +862,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where upper(animal_name) like #{parameters.p1,jdbcType=VARCHAR} and id <= #{parameters.p2,jdbcType=INTEGER} order by id"),
@@ -882,7 +882,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id <= #{parameters.p1,jdbcType=INTEGER} order by id"),
@@ -902,7 +902,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where animal_name not like #{parameters.p1,jdbcType=VARCHAR} and id <= #{parameters.p2,jdbcType=INTEGER} order by id"),
@@ -922,7 +922,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id <= #{parameters.p1,jdbcType=INTEGER} order by id"),
@@ -942,7 +942,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where upper(animal_name) not like #{parameters.p1,jdbcType=VARCHAR} and id <= #{parameters.p2,jdbcType=INTEGER} order by id"),
@@ -962,7 +962,7 @@ public class OptionalConditionsWithPredicatesAnimalDataTest {
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             List<AnimalData> animals = mapper.selectMany(selectStatement);
             assertAll(
                     () -> assertThat(selectStatement.getSelectStatement()).isEqualTo("select id, animal_name, body_weight, brain_weight from AnimalData where id <= #{parameters.p1,jdbcType=INTEGER} order by id"),

--- a/src/test/java/examples/column/comparison/ColumnComparisonTest.java
+++ b/src/test/java/examples/column/comparison/ColumnComparisonTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2016-2018 the original author or authors.
+ *    Copyright 2016-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ import org.apache.ibatis.session.SqlSessionFactoryBuilder;
 import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mybatis.dynamic.sql.render.RenderingStrategy;
+import org.mybatis.dynamic.sql.render.RenderingStrategies;
 import org.mybatis.dynamic.sql.select.render.SelectStatementProvider;
 
 public class ColumnComparisonTest {
@@ -73,7 +73,7 @@ public class ColumnComparisonTest {
                     .where(number1, isLessThan(number2))
                     .orderBy(number1, number2)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String expected = "select number1, number2 "
                     + "from ColumnComparison "
@@ -101,7 +101,7 @@ public class ColumnComparisonTest {
                     .where(number1, isLessThanOrEqualTo(number2))
                     .orderBy(number1, number2)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String expected = "select number1, number2 "
                     + "from ColumnComparison "
@@ -129,7 +129,7 @@ public class ColumnComparisonTest {
                     .where(number1, isGreaterThan(number2))
                     .orderBy(number1, number2)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String expected = "select number1, number2 "
                     + "from ColumnComparison "
@@ -157,7 +157,7 @@ public class ColumnComparisonTest {
                     .where(number1, isGreaterThanOrEqualTo(number2))
                     .orderBy(number1, number2)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String expected = "select number1, number2 "
                     + "from ColumnComparison "
@@ -185,7 +185,7 @@ public class ColumnComparisonTest {
                     .where(number1, isEqualTo(number2))
                     .orderBy(number1, number2)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String expected = "select number1, number2 "
                     + "from ColumnComparison "
@@ -212,7 +212,7 @@ public class ColumnComparisonTest {
                     .where(number1, isNotEqualTo(number2))
                     .orderBy(number1, number2)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String expected = "select number1, number2 "
                     + "from ColumnComparison "

--- a/src/test/java/examples/complexquery/ComplexQueryTest.java
+++ b/src/test/java/examples/complexquery/ComplexQueryTest.java
@@ -25,7 +25,7 @@ import static org.mybatis.dynamic.sql.SqlBuilder.*;
 import java.util.Objects;
 
 import org.junit.jupiter.api.Test;
-import org.mybatis.dynamic.sql.render.RenderingStrategy;
+import org.mybatis.dynamic.sql.render.RenderingStrategies;
 import org.mybatis.dynamic.sql.select.QueryExpressionDSL;
 import org.mybatis.dynamic.sql.select.SelectModel;
 import org.mybatis.dynamic.sql.select.render.SelectStatementProvider;
@@ -125,7 +125,7 @@ public class ComplexQueryTest {
             .orderBy(lastName, firstName)
             .fetchFirst(50).rowsOnly();
         
-        return builder.build().render(RenderingStrategy.MYBATIS3);
+        return builder.build().render(RenderingStrategies.MYBATIS3);
     }
     
     public String addWildcards(String s) {

--- a/src/test/java/examples/emptywhere/EmptyWhereTest.java
+++ b/src/test/java/examples/emptywhere/EmptyWhereTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.mybatis.dynamic.sql.delete.DeleteDSL;
 import org.mybatis.dynamic.sql.delete.DeleteModel;
 import org.mybatis.dynamic.sql.delete.render.DeleteStatementProvider;
-import org.mybatis.dynamic.sql.render.RenderingStrategy;
+import org.mybatis.dynamic.sql.render.RenderingStrategies;
 import org.mybatis.dynamic.sql.select.QueryExpressionDSL;
 import org.mybatis.dynamic.sql.select.SelectModel;
 import org.mybatis.dynamic.sql.select.render.SelectStatementProvider;
@@ -49,7 +49,7 @@ public class EmptyWhereTest {
         builder.and(firstName, isEqualTo(fName).when(Objects::nonNull));
         builder.and(lastName, isEqualTo(lName).when(Objects::nonNull));
         
-        DeleteStatementProvider deleteStatement = builder.build().render(RenderingStrategy.MYBATIS3);
+        DeleteStatementProvider deleteStatement = builder.build().render(RenderingStrategies.MYBATIS3);
         
         String expected = "delete from person"
                 + " where id = #{parameters.p1}"
@@ -70,7 +70,7 @@ public class EmptyWhereTest {
         builder.and(firstName, isEqualTo(fName).when(Objects::nonNull));
         builder.or(lastName, isEqualTo(lName).when(Objects::nonNull));
         
-        DeleteStatementProvider deleteStatement = builder.build().render(RenderingStrategy.MYBATIS3);
+        DeleteStatementProvider deleteStatement = builder.build().render(RenderingStrategies.MYBATIS3);
         
         String expected = "delete from person"
                 + " where first_name = #{parameters.p1}"
@@ -90,7 +90,7 @@ public class EmptyWhereTest {
         builder.and(firstName, isEqualTo(fName).when(Objects::nonNull));
         builder.and(lastName, isEqualTo(lName).when(Objects::nonNull));
         
-        DeleteStatementProvider deleteStatement = builder.build().render(RenderingStrategy.MYBATIS3);
+        DeleteStatementProvider deleteStatement = builder.build().render(RenderingStrategies.MYBATIS3);
         
         String expected = "delete from person"
                 + " where last_name = #{parameters.p1}";
@@ -109,7 +109,7 @@ public class EmptyWhereTest {
         builder.and(firstName, isEqualTo(fName).when(Objects::nonNull));
         builder.and(lastName, isEqualTo(lName).when(Objects::nonNull));
         
-        DeleteStatementProvider deleteStatement = builder.build().render(RenderingStrategy.MYBATIS3);
+        DeleteStatementProvider deleteStatement = builder.build().render(RenderingStrategies.MYBATIS3);
         
         String expected = "delete from person"
                 + " where first_name = #{parameters.p1}";
@@ -128,7 +128,7 @@ public class EmptyWhereTest {
         builder.and(firstName, isEqualTo(fName).when(Objects::nonNull));
         builder.and(lastName, isEqualTo(lName).when(Objects::nonNull));
         
-        DeleteStatementProvider deleteStatement = builder.build().render(RenderingStrategy.MYBATIS3);
+        DeleteStatementProvider deleteStatement = builder.build().render(RenderingStrategies.MYBATIS3);
         
         String expected = "delete from person";
         
@@ -147,7 +147,7 @@ public class EmptyWhereTest {
         builder.and(firstName, isEqualTo(fName).when(Objects::nonNull));
         builder.and(lastName, isEqualTo(lName).when(Objects::nonNull));
         
-        SelectStatementProvider selectStatement = builder.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder.build().render(RenderingStrategies.MYBATIS3);
         
         String expected = "select id, first_name, last_name"
                 + " from person"
@@ -170,7 +170,7 @@ public class EmptyWhereTest {
         builder.and(firstName, isEqualTo(fName).when(Objects::nonNull));
         builder.and(lastName, isEqualTo(lName).when(Objects::nonNull));
         
-        SelectStatementProvider selectStatement = builder.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder.build().render(RenderingStrategies.MYBATIS3);
         
         String expected = "select *"
                 + " from person"
@@ -192,7 +192,7 @@ public class EmptyWhereTest {
         builder.and(firstName, isEqualTo(fName).when(Objects::nonNull));
         builder.and(lastName, isEqualTo(lName).when(Objects::nonNull));
         
-        SelectStatementProvider selectStatement = builder.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder.build().render(RenderingStrategies.MYBATIS3);
         
         String expected = "select id, first_name, last_name"
                 + " from person"
@@ -213,7 +213,7 @@ public class EmptyWhereTest {
         builder.and(firstName, isEqualTo(fName).when(Objects::nonNull));
         builder.and(lastName, isEqualTo(lName).when(Objects::nonNull));
         
-        SelectStatementProvider selectStatement = builder.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder.build().render(RenderingStrategies.MYBATIS3);
         
         String expected = "select id, first_name, last_name"
                 + " from person"
@@ -234,7 +234,7 @@ public class EmptyWhereTest {
         builder.and(firstName, isEqualTo(fName).when(Objects::nonNull));
         builder.and(lastName, isEqualTo(lName).when(Objects::nonNull));
         
-        SelectStatementProvider selectStatement = builder.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder.build().render(RenderingStrategies.MYBATIS3);
         
         String expected = "select id, first_name, last_name"
                 + " from person";
@@ -254,7 +254,7 @@ public class EmptyWhereTest {
         builder.and(firstName, isEqualTo(fName).when(Objects::nonNull));
         builder.and(lastName, isEqualTo(lName).when(Objects::nonNull));
         
-        SelectStatementProvider selectStatement = builder.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder.build().render(RenderingStrategies.MYBATIS3);
         
         String expected = "select person.id, person.first_name, person.last_name, order.order_date"
                 + " from person"
@@ -278,7 +278,7 @@ public class EmptyWhereTest {
         builder.and(firstName, isEqualTo(fName).when(Objects::nonNull));
         builder.and(lastName, isEqualTo(lName).when(Objects::nonNull));
         
-        SelectStatementProvider selectStatement = builder.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder.build().render(RenderingStrategies.MYBATIS3);
         
         String expected = "select person.id, person.first_name, person.last_name, order.order_date"
                 + " from person"
@@ -301,7 +301,7 @@ public class EmptyWhereTest {
         builder.and(firstName, isEqualTo(fName).when(Objects::nonNull));
         builder.and(lastName, isEqualTo(lName).when(Objects::nonNull));
         
-        SelectStatementProvider selectStatement = builder.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder.build().render(RenderingStrategies.MYBATIS3);
         
         String expected = "select person.id, person.first_name, person.last_name, order.order_date"
                 + " from person"
@@ -323,7 +323,7 @@ public class EmptyWhereTest {
         builder.and(firstName, isEqualTo(fName).when(Objects::nonNull));
         builder.and(lastName, isEqualTo(lName).when(Objects::nonNull));
         
-        SelectStatementProvider selectStatement = builder.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder.build().render(RenderingStrategies.MYBATIS3);
         
         String expected = "select person.id, person.first_name, person.last_name, order.order_date"
                 + " from person"
@@ -345,7 +345,7 @@ public class EmptyWhereTest {
         builder.and(firstName, isEqualTo(fName).when(Objects::nonNull));
         builder.and(lastName, isEqualTo(lName).when(Objects::nonNull));
         
-        SelectStatementProvider selectStatement = builder.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder.build().render(RenderingStrategies.MYBATIS3);
         
         String expected = "select person.id, person.first_name, person.last_name, order.order_date"
                 + " from person"
@@ -366,7 +366,7 @@ public class EmptyWhereTest {
         builder.and(firstName, isEqualTo(fName).when(Objects::nonNull));
         builder.and(lastName, isEqualTo(lName).when(Objects::nonNull));
         
-        UpdateStatementProvider updateStatement = builder.build().render(RenderingStrategy.MYBATIS3);
+        UpdateStatementProvider updateStatement = builder.build().render(RenderingStrategies.MYBATIS3);
         
         String expected = "update person"
                 + " set id = #{parameters.p1}"
@@ -389,7 +389,7 @@ public class EmptyWhereTest {
         builder.and(firstName, isEqualTo(fName).when(Objects::nonNull));
         builder.and(lastName, isEqualTo(lName).when(Objects::nonNull));
         
-        UpdateStatementProvider updateStatement = builder.build().render(RenderingStrategy.MYBATIS3);
+        UpdateStatementProvider updateStatement = builder.build().render(RenderingStrategies.MYBATIS3);
         
         String expected = "update person"
                 + " set id = #{parameters.p1}"
@@ -410,7 +410,7 @@ public class EmptyWhereTest {
         builder.and(firstName, isEqualTo(fName).when(Objects::nonNull));
         builder.and(lastName, isEqualTo(lName).when(Objects::nonNull));
         
-        DeleteStatementProvider deleteStatement = builder.build().render(RenderingStrategy.MYBATIS3);
+        DeleteStatementProvider deleteStatement = builder.build().render(RenderingStrategies.MYBATIS3);
         
         String expected = "delete from person"
                 + " where last_name = #{parameters.p1}";
@@ -430,7 +430,7 @@ public class EmptyWhereTest {
         builder.and(firstName, isEqualTo(fName).when(Objects::nonNull));
         builder.and(lastName, isEqualTo(lName).when(Objects::nonNull));
         
-        UpdateStatementProvider updateStatement = builder.build().render(RenderingStrategy.MYBATIS3);
+        UpdateStatementProvider updateStatement = builder.build().render(RenderingStrategies.MYBATIS3);
         
         String expected = "update person"
                 + " set id = #{parameters.p1}"
@@ -451,7 +451,7 @@ public class EmptyWhereTest {
         builder.and(firstName, isEqualTo(fName).when(Objects::nonNull));
         builder.and(lastName, isEqualTo(lName).when(Objects::nonNull));
         
-        UpdateStatementProvider updateStatement = builder.build().render(RenderingStrategy.MYBATIS3);
+        UpdateStatementProvider updateStatement = builder.build().render(RenderingStrategies.MYBATIS3);
         
         String expected = "update person"
                 + " set id = #{parameters.p1}";
@@ -469,7 +469,7 @@ public class EmptyWhereTest {
         builder.and(firstName, isEqualTo(fName).when(Objects::nonNull));
         builder.and(lastName, isEqualTo(lName).when(Objects::nonNull));
         
-        WhereClauseProvider whereClause = builder.build().render(RenderingStrategy.MYBATIS3);
+        WhereClauseProvider whereClause = builder.build().render(RenderingStrategies.MYBATIS3);
         
         String expected = "where id = #{parameters.p1}"
                 + " and first_name = #{parameters.p2}"
@@ -488,7 +488,7 @@ public class EmptyWhereTest {
         builder.and(firstName, isEqualTo(fName).when(Objects::nonNull));
         builder.and(lastName, isEqualTo(lName).when(Objects::nonNull));
         
-        WhereClauseProvider whereClause = builder.build().render(RenderingStrategy.MYBATIS3);
+        WhereClauseProvider whereClause = builder.build().render(RenderingStrategies.MYBATIS3);
         
         String expected = "where first_name = #{parameters.p1}"
                 + " and last_name = #{parameters.p2}";
@@ -506,7 +506,7 @@ public class EmptyWhereTest {
         builder.and(firstName, isEqualTo(fName).when(Objects::nonNull));
         builder.and(lastName, isEqualTo(lName).when(Objects::nonNull));
         
-        WhereClauseProvider whereClause = builder.build().render(RenderingStrategy.MYBATIS3);
+        WhereClauseProvider whereClause = builder.build().render(RenderingStrategies.MYBATIS3);
         
         String expected = "where last_name = #{parameters.p1}";
         
@@ -523,7 +523,7 @@ public class EmptyWhereTest {
         builder.and(firstName, isEqualTo(fName).when(Objects::nonNull));
         builder.and(lastName, isEqualTo(lName).when(Objects::nonNull));
         
-        WhereClauseProvider whereClause = builder.build().render(RenderingStrategy.MYBATIS3);
+        WhereClauseProvider whereClause = builder.build().render(RenderingStrategies.MYBATIS3);
         
         String expected = "where first_name = #{parameters.p1}";
         
@@ -540,7 +540,7 @@ public class EmptyWhereTest {
         builder.and(firstName, isEqualTo(fName).when(Objects::nonNull));
         builder.and(lastName, isEqualTo(lName).when(Objects::nonNull));
         
-        WhereClauseProvider whereClause = builder.build().render(RenderingStrategy.MYBATIS3);
+        WhereClauseProvider whereClause = builder.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(whereClause.getWhereClause()).isEmpty();
     }

--- a/src/test/java/examples/generated/always/mybatis/GeneratedAlwaysAnnotatedMapperTest.java
+++ b/src/test/java/examples/generated/always/mybatis/GeneratedAlwaysAnnotatedMapperTest.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mybatis.dynamic.sql.insert.render.BatchInsert;
 import org.mybatis.dynamic.sql.insert.render.MultiRowInsertStatementProvider;
-import org.mybatis.dynamic.sql.render.RenderingStrategy;
+import org.mybatis.dynamic.sql.render.RenderingStrategies;
 import org.mybatis.dynamic.sql.select.render.SelectStatementProvider;
 import org.mybatis.dynamic.sql.update.render.UpdateStatementProvider;
 
@@ -78,7 +78,7 @@ public class GeneratedAlwaysAnnotatedMapperTest {
             SelectStatementProvider selectStatement = selectByExample()
                     .where(id, isEqualTo(1))
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             List<GeneratedAlwaysRecord> rows = mapper.selectMany(selectStatement);
             
@@ -94,7 +94,7 @@ public class GeneratedAlwaysAnnotatedMapperTest {
             SelectStatementProvider selectStatement = selectByExample()
                     .where(firstName, isIn("Fred", "Barney"))
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             List<GeneratedAlwaysRecord> rows = mapper.selectMany(selectStatement);
             
@@ -132,7 +132,7 @@ public class GeneratedAlwaysAnnotatedMapperTest {
                     .map(firstName).toProperty("firstName")
                     .map(lastName).toProperty("lastName")
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             batchInsert.insertStatements().stream().forEach(mapper::insert);
             
@@ -168,7 +168,7 @@ public class GeneratedAlwaysAnnotatedMapperTest {
                     .map(firstName).toProperty("firstName")
                     .map(lastName).toProperty("lastName")
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             batchInsert.insertStatements().stream().forEach(mapper::insert);
             
@@ -218,7 +218,7 @@ public class GeneratedAlwaysAnnotatedMapperTest {
                     .map(firstName).toProperty("firstName")
                     .map(lastName).toProperty("lastName")
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String statement = "insert into GeneratedAlways (id, first_name, last_name)" +
                     " values" +
@@ -262,7 +262,7 @@ public class GeneratedAlwaysAnnotatedMapperTest {
                     .map(firstName).toProperty("firstName")
                     .map(lastName).toProperty("lastName")
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String statement = "insert into GeneratedAlways (id, first_name, last_name)" +
                     " values" +
@@ -293,7 +293,7 @@ public class GeneratedAlwaysAnnotatedMapperTest {
                     .map(lastName).toProperty("lastName")
                     .map(age).toNull()
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String statement = "insert into GeneratedAlways (id, first_name, last_name, age)" +
                     " values (1000, 'George', #{records[0].lastName,jdbcType=VARCHAR}, null)";
@@ -388,7 +388,7 @@ public class GeneratedAlwaysAnnotatedMapperTest {
             UpdateStatementProvider updateStatement = updateByExampleSelective(record)
                     .where(lastName, isEqualTo("Flintstone"))
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             int rows = mapper.update(updateStatement);
             assertThat(rows).isEqualTo(3);
@@ -397,7 +397,7 @@ public class GeneratedAlwaysAnnotatedMapperTest {
                     .where(lastName, isEqualTo("Jones"))
                     .orderBy(firstName)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             List<GeneratedAlwaysRecord> records = mapper.selectMany(selectStatement);
             assertAll(

--- a/src/test/java/examples/generated/always/mybatis/GeneratedAlwaysDynamicSqlSupport.java
+++ b/src/test/java/examples/generated/always/mybatis/GeneratedAlwaysDynamicSqlSupport.java
@@ -22,7 +22,7 @@ import java.sql.JDBCType;
 import org.mybatis.dynamic.sql.SqlColumn;
 import org.mybatis.dynamic.sql.SqlTable;
 import org.mybatis.dynamic.sql.insert.render.InsertStatementProvider;
-import org.mybatis.dynamic.sql.render.RenderingStrategy;
+import org.mybatis.dynamic.sql.render.RenderingStrategies;
 import org.mybatis.dynamic.sql.select.QueryExpressionDSL;
 import org.mybatis.dynamic.sql.select.SelectModel;
 import org.mybatis.dynamic.sql.select.render.SelectStatementProvider;
@@ -59,7 +59,7 @@ public final class GeneratedAlwaysDynamicSqlSupport {
                 .map(firstName).toProperty("firstName")
                 .map(lastName).toProperty("lastName")
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
     }
 
     public static InsertStatementProvider<GeneratedAlwaysRecord> buildInsertSelectiveStatement(GeneratedAlwaysRecord record) {
@@ -69,7 +69,7 @@ public final class GeneratedAlwaysDynamicSqlSupport {
                 .map(firstName).toPropertyWhenPresent("firstName", record::getFirstName)
                 .map(lastName).toPropertyWhenPresent("lastName", record::getLastName)
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
     }
     
     public static UpdateStatementProvider buildUpdateByPrimaryKeyStatement(GeneratedAlwaysRecord record) {
@@ -78,7 +78,7 @@ public final class GeneratedAlwaysDynamicSqlSupport {
                 .set(lastName).equalTo(record.getLastName())
                 .where(id, isEqualTo(record.getId()))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
     }
 
     public static UpdateStatementProvider buildUpdateByPrimaryKeySelectiveStatement(GeneratedAlwaysRecord record) {
@@ -87,7 +87,7 @@ public final class GeneratedAlwaysDynamicSqlSupport {
                 .set(lastName).equalToWhenPresent(record::getLastName)
                 .where(id, isEqualTo(record::getId))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
     }
 
     public static UpdateDSL<UpdateModel> updateByExample(GeneratedAlwaysRecord record) {
@@ -114,6 +114,6 @@ public final class GeneratedAlwaysDynamicSqlSupport {
                 .from(generatedAlways)
                 .where(id, isEqualTo(id_))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
     }
 }

--- a/src/test/java/examples/generated/always/spring/SpringTest.java
+++ b/src/test/java/examples/generated/always/spring/SpringTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2016-2018 the original author or authors.
+ *    Copyright 2016-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.mybatis.dynamic.sql.delete.render.DeleteStatementProvider;
 import org.mybatis.dynamic.sql.insert.render.BatchInsert;
 import org.mybatis.dynamic.sql.insert.render.InsertStatementProvider;
-import org.mybatis.dynamic.sql.render.RenderingStrategy;
+import org.mybatis.dynamic.sql.render.RenderingStrategies;
 import org.mybatis.dynamic.sql.select.render.SelectStatementProvider;
 import org.mybatis.dynamic.sql.update.render.UpdateStatementProvider;
 import org.springframework.jdbc.core.RowMapper;
@@ -68,7 +68,7 @@ public class SpringTest {
                 .where(id, isGreaterThan(3))
                 .orderBy(id.descending())
                 .build()
-                .render(RenderingStrategy.SPRING_NAMED_PARAMETER);
+                .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
         
         String expected = "select a.id as A_ID, a.first_name, a.last_name, a.full_name "
                 + "from GeneratedAlways a "
@@ -85,7 +85,7 @@ public class SpringTest {
                 .where(id, isGreaterThan(3))
                 .orderBy(id.descending())
                 .build()
-                .render(RenderingStrategy.SPRING_NAMED_PARAMETER);
+                .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
         
         SqlParameterSource namedParameters = new MapSqlParameterSource(selectStatement.getParameters());
         
@@ -118,7 +118,7 @@ public class SpringTest {
         DeleteStatementProvider deleteStatement = deleteFrom(generatedAlways)
                 .where(id,  isLessThan(3))
                 .build()
-                .render(RenderingStrategy.SPRING_NAMED_PARAMETER);
+                .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
         
         SqlParameterSource parameterSource = new MapSqlParameterSource(deleteStatement.getParameters());
         
@@ -140,7 +140,7 @@ public class SpringTest {
                 .map(firstName).toProperty("firstName")
                 .map(lastName).toProperty("lastName")
                 .build()
-                .render(RenderingStrategy.SPRING_NAMED_PARAMETER);
+                .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
         
         SqlParameterSource parameterSource = new BeanPropertySqlParameterSource(insertStatement.getRecord());
         KeyHolder keyHolder = new GeneratedKeyHolder();
@@ -176,7 +176,7 @@ public class SpringTest {
                 .map(firstName).toProperty("firstName")
                 .map(lastName).toProperty("lastName")
                 .build()
-                .render(RenderingStrategy.SPRING_NAMED_PARAMETER);
+                .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
         
         int[] updateCounts = template.batchUpdate(batchInsert.getInsertStatementSQL(), batch);
         
@@ -191,7 +191,7 @@ public class SpringTest {
                 .set(firstName).equalToStringConstant("Rob")
                 .where(id,  isIn(1, 5, 22))
                 .build()
-                .render(RenderingStrategy.SPRING_NAMED_PARAMETER);
+                .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
         
         SqlParameterSource parameterSource = new MapSqlParameterSource(updateStatement.getParameters());
         

--- a/src/test/java/examples/groupby/GroupByTest.java
+++ b/src/test/java/examples/groupby/GroupByTest.java
@@ -38,7 +38,7 @@ import org.apache.ibatis.session.SqlSessionFactoryBuilder;
 import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mybatis.dynamic.sql.render.RenderingStrategy;
+import org.mybatis.dynamic.sql.render.RenderingStrategies;
 import org.mybatis.dynamic.sql.select.render.SelectStatementProvider;
 
 public class GroupByTest {
@@ -74,7 +74,7 @@ public class GroupByTest {
                     .from(person)
                     .groupBy(gender)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String expected = "select gender, count(*) from Person group by gender";
             assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
@@ -100,7 +100,7 @@ public class GroupByTest {
                     .from(person)
                     .groupBy(gender)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String expected = "select gender, count(*) as count from Person group by gender";
             assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
@@ -126,7 +126,7 @@ public class GroupByTest {
                     .from(person, "p").join(address, "a").on(person.addressId, equalTo(address.id))
                     .groupBy(lastName, streetAddress)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String expected = "select p.last_name, a.street_address, count(*) as count" +
                     " from Person p join Address a on p.address_id = a.address_id" +
@@ -159,7 +159,7 @@ public class GroupByTest {
                     .from(person2, "p").join(address, "a").on(person2.addressId, equalTo(address.id))
                     .orderBy(lastName, firstName)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String expected = "select p.last_name, p.first_name, a.street_address" +
                     " from Person p join Address a on p.address_id = a.address_id" +
@@ -195,7 +195,7 @@ public class GroupByTest {
                     .from(person2, "p").join(address, "a").on(person2.addressId, equalTo(address.id))
                     .orderBy(lastName, firstName)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String expected = "select p.last_name, p.first_name, a.street_address" +
                     " from Person p join Address a on p.address_id = a.address_id" +
@@ -232,7 +232,7 @@ public class GroupByTest {
                     .from(person)
                     .groupBy(lastName)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String expected = "select 'Gender', gender as value, count(*) as count from Person group by gender" +
                     " union" +
@@ -276,7 +276,7 @@ public class GroupByTest {
                     .from(person)
                     .groupBy(lastName)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String expected = "select 'Gender', gender as value, count(*) as count from Person group by gender" +
                     " union all" +
@@ -317,7 +317,7 @@ public class GroupByTest {
                     .groupBy(gender)
                     .orderBy(gender)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String expected = "select gender, count(*) as count from Person group by gender order by gender";
             assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
@@ -344,7 +344,7 @@ public class GroupByTest {
                     .groupBy(substring(gender, 1, 1))
                     .orderBy(sortColumn("ShortGender").descending())
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String expected = "select substring(a.gender, 1, 1) as ShortGender, avg(a.age) as AverageAge from Person a group by substring(a.gender, 1, 1) order by ShortGender DESC";
             assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
@@ -371,7 +371,7 @@ public class GroupByTest {
                     .where(gender, isEqualTo("Male"))
                     .groupBy(lastName)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String expected = "select a.last_name, count(*) as count from Person a where a.gender = #{parameters.p1,jdbcType=VARCHAR} group by a.last_name";
             assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
@@ -399,7 +399,7 @@ public class GroupByTest {
                     .limit(1)
                     .offset(1)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String expected = "select last_name, count(*) as count from Person group by last_name limit #{parameters._limit} offset #{parameters._offset}";
             assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
@@ -422,7 +422,7 @@ public class GroupByTest {
                     .groupBy(lastName)
                     .limit(1)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String expected = "select last_name, count(*) as count from Person group by last_name limit #{parameters._limit}";
             assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
@@ -445,7 +445,7 @@ public class GroupByTest {
                     .groupBy(lastName)
                     .offset(1)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String expected = "select last_name, count(*) as count from Person group by last_name offset #{parameters._offset} rows";
             assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
@@ -469,7 +469,7 @@ public class GroupByTest {
                     .offset(1)
                     .fetchFirst(1).rowsOnly()
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String expected = "select last_name, count(*) as count from Person group by last_name offset #{parameters._offset} rows fetch first #{parameters._fetchFirstRows} rows only";
             assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
@@ -492,7 +492,7 @@ public class GroupByTest {
                     .groupBy(lastName)
                     .fetchFirst(1).rowsOnly()
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String expected = "select last_name, count(*) as count from Person group by last_name fetch first #{parameters._fetchFirstRows} rows only";
             assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
@@ -513,7 +513,7 @@ public class GroupByTest {
             SelectStatementProvider selectStatement = select(countDistinct(lastName).as("count"))
                     .from(person)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String expected = "select count(distinct last_name) as count from Person";
             assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);

--- a/src/test/java/examples/joins/JoinMapperTest.java
+++ b/src/test/java/examples/joins/JoinMapperTest.java
@@ -41,7 +41,7 @@ import org.apache.ibatis.session.SqlSessionFactoryBuilder;
 import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mybatis.dynamic.sql.render.RenderingStrategy;
+import org.mybatis.dynamic.sql.render.RenderingStrategies;
 import org.mybatis.dynamic.sql.select.render.SelectStatementProvider;
 
 public class JoinMapperTest {
@@ -77,7 +77,7 @@ public class JoinMapperTest {
                     .from(orderMaster, "om")
                     .join(orderDetail, "od").on(orderMaster.orderId, equalTo(orderDetail.orderId))
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String expectedStatment = "select om.order_id, om.order_date, od.line_number, od.description, od.quantity"
                     + " from OrderMaster om join OrderDetail od on om.order_id = od.order_id";
@@ -109,7 +109,7 @@ public class JoinMapperTest {
                 .from(orderMaster, "om")
                 .join(orderDetail, "od").on(orderMaster.orderId, equalTo(orderDetail.orderId), and(orderMaster.orderId, equalTo(orderDetail.orderId)))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
         
         String expectedStatment = "select om.order_id, om.order_date, od.line_number, od.description, od.quantity"
                 + " from OrderMaster om join OrderDetail od on om.order_id = od.order_id and om.order_id = od.order_id";
@@ -124,7 +124,7 @@ public class JoinMapperTest {
                 .join(orderDetail, "od").on(orderMaster.orderId, equalTo(orderDetail.orderId))
                 .and(orderMaster.orderId, equalTo(orderDetail.orderId))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
         
         String expectedStatment = "select om.order_id, om.order_date, od.line_number, od.description, od.quantity"
                 + " from OrderMaster om join OrderDetail od on om.order_id = od.order_id and om.order_id = od.order_id";
@@ -142,7 +142,7 @@ public class JoinMapperTest {
                     .join(itemMaster, "im").on(orderLine.itemId, equalTo(itemMaster.itemId))
                     .where(orderMaster.orderId, isEqualTo(2))
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String expectedStatment = "select om.order_id, om.order_date, ol.line_number, im.description, ol.quantity"
                     + " from OrderMaster om join OrderLine ol on om.order_id = ol.order_id join ItemMaster im on ol.item_id = im.item_id"
@@ -173,7 +173,7 @@ public class JoinMapperTest {
                     .join(itemMaster, "im").on(orderLine.itemId, equalTo(itemMaster.itemId))
                     .where(orderMaster.orderId, isEqualTo(2), and(orderLine.lineNumber, isEqualTo(2)))
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String expectedStatment = "select om.order_id, om.order_date, ol.line_number, im.description, ol.quantity"
                     + " from OrderMaster om join OrderLine ol on om.order_id = ol.order_id join ItemMaster im on ol.item_id = im.item_id"
@@ -202,7 +202,7 @@ public class JoinMapperTest {
                     .join(itemMaster, "im").on(orderLine.itemId, equalTo(itemMaster.itemId))
                     .orderBy(orderMaster.orderId)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String expectedStatment = "select om.order_id, om.order_date, ol.line_number, im.description, ol.quantity"
                     + " from OrderMaster om join OrderLine ol on om.order_id = ol.order_id join ItemMaster im on ol.item_id = im.item_id"
@@ -240,7 +240,7 @@ public class JoinMapperTest {
                     .where(orderMaster.orderId, isEqualTo(2))
                     .orderBy(orderMaster.orderId)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String expectedStatment = "select OrderMaster.order_id, OrderMaster.order_date, OrderLine.line_number, ItemMaster.description, OrderLine.quantity"
                     + " from OrderMaster join OrderLine on OrderMaster.order_id = OrderLine.order_id join ItemMaster on OrderLine.item_id = ItemMaster.item_id"
@@ -271,7 +271,7 @@ public class JoinMapperTest {
                     .rightJoin(itemMaster, "im").on(orderLine.itemId, equalTo(itemMaster.itemId))
                     .orderBy(itemMaster.itemId)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String expectedStatment = "select ol.order_id, ol.quantity, im.item_id, im.description"
                     + " from OrderLine ol right join ItemMaster im on ol.item_id = im.item_id"
@@ -306,7 +306,7 @@ public class JoinMapperTest {
                     .rightJoin(itemMaster, "im").on(orderLine.itemId, equalTo(itemMaster.itemId))
                     .orderBy(orderLine.orderId, itemMaster.itemId)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String expectedStatment = "select ol.order_id, ol.quantity, im.item_id, im.description"
                     + " from OrderMaster om join OrderLine ol on om.order_id = ol.order_id"
@@ -342,7 +342,7 @@ public class JoinMapperTest {
                     .rightJoin(itemMaster).on(orderLine.itemId, equalTo(itemMaster.itemId))
                     .orderBy(orderLine.orderId, itemMaster.itemId)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String expectedStatment = "select OrderLine.order_id, OrderLine.quantity, ItemMaster.item_id, ItemMaster.description"
                     + " from OrderMaster join OrderLine on OrderMaster.order_id = OrderLine.order_id"
@@ -377,7 +377,7 @@ public class JoinMapperTest {
                     .leftJoin(orderLine, "ol").on(orderLine.itemId, equalTo(itemMaster.itemId))
                     .orderBy(itemMaster.itemId)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String expectedStatment = "select ol.order_id, ol.quantity, im.item_id, im.description"
                     + " from ItemMaster im left join OrderLine ol on ol.item_id = im.item_id"
@@ -412,7 +412,7 @@ public class JoinMapperTest {
                     .leftJoin(itemMaster, "im").on(orderLine.itemId, equalTo(itemMaster.itemId))
                     .orderBy(orderLine.orderId, itemMaster.itemId)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String expectedStatment = "select ol.order_id, ol.quantity, im.item_id, im.description"
                     + " from OrderMaster om join OrderLine ol on om.order_id = ol.order_id"
@@ -448,7 +448,7 @@ public class JoinMapperTest {
                     .leftJoin(itemMaster).on(orderLine.itemId, equalTo(itemMaster.itemId))
                     .orderBy(orderLine.orderId, itemMaster.itemId)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String expectedStatment = "select OrderLine.order_id, OrderLine.quantity, ItemMaster.item_id, ItemMaster.description"
                     + " from OrderMaster join OrderLine on OrderMaster.order_id = OrderLine.order_id"
@@ -483,7 +483,7 @@ public class JoinMapperTest {
                     .fullJoin(orderLine, "ol").on(itemMaster.itemId, equalTo(orderLine.itemId))
                     .orderBy(sortColumn("im_itemid"))
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String expectedStatment = "select ol.order_id, ol.quantity, ol.item_id as ol_itemid, im.item_id as im_itemid, im.description"
                     + " from ItemMaster im full join OrderLine ol on im.item_id = ol.item_id"
@@ -525,7 +525,7 @@ public class JoinMapperTest {
                     .fullJoin(itemMaster, "im").on(orderLine.itemId, equalTo(itemMaster.itemId))
                     .orderBy(orderLine.orderId, itemMaster.itemId)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String expectedStatment = "select ol.order_id, ol.quantity, im.item_id, im.description"
                     + " from OrderMaster om join OrderLine ol on om.order_id = ol.order_id"
@@ -567,7 +567,7 @@ public class JoinMapperTest {
                     .fullJoin(itemMaster).on(orderLine.itemId, equalTo(itemMaster.itemId))
                     .orderBy(orderLine.orderId, itemMaster.itemId)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String expectedStatment = "select OrderLine.order_id, OrderLine.quantity, ItemMaster.item_id, ItemMaster.description"
                     + " from OrderMaster join OrderLine on OrderMaster.order_id = OrderLine.order_id"
@@ -609,7 +609,7 @@ public class JoinMapperTest {
                     .join(user2, "u2").on(user1.userId, equalTo(user2.parentId))
                     .where(user2.userId, isEqualTo(4))
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String expectedStatment = "select u1.user_id, u1.user_name, u1.parent_id"
                     + " from User u1 join User u2 on u1.user_id = u2.parent_id"
@@ -637,7 +637,7 @@ public class JoinMapperTest {
                     .limit(2)
                     .offset(1)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String expectedStatment = "select ol.order_id, ol.quantity, im.item_id, im.description"
                     + " from ItemMaster im left join OrderLine ol on ol.item_id = im.item_id"
@@ -671,7 +671,7 @@ public class JoinMapperTest {
                     .leftJoin(orderLine, "ol").on(orderLine.itemId, equalTo(itemMaster.itemId))
                     .limit(2)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String expectedStatment = "select ol.order_id, ol.quantity, im.item_id, im.description"
                     + " from ItemMaster im left join OrderLine ol on ol.item_id = im.item_id"
@@ -705,7 +705,7 @@ public class JoinMapperTest {
                     .leftJoin(orderLine, "ol").on(orderLine.itemId, equalTo(itemMaster.itemId))
                     .offset(2)
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String expectedStatment = "select ol.order_id, ol.quantity, im.item_id, im.description"
                     + " from ItemMaster im left join OrderLine ol on ol.item_id = im.item_id"
@@ -740,7 +740,7 @@ public class JoinMapperTest {
                     .offset(1)
                     .fetchFirst(2).rowsOnly()
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String expectedStatment = "select ol.order_id, ol.quantity, im.item_id, im.description"
                     + " from ItemMaster im left join OrderLine ol on ol.item_id = im.item_id"
@@ -774,7 +774,7 @@ public class JoinMapperTest {
                     .leftJoin(orderLine, "ol").on(orderLine.itemId, equalTo(itemMaster.itemId))
                     .fetchFirst(2).rowsOnly()
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
             
             String expectedStatment = "select ol.order_id, ol.quantity, im.item_id, im.description"
                     + " from ItemMaster im left join OrderLine ol on ol.item_id = im.item_id"

--- a/src/test/java/examples/paging/LimitAndOffsetAdapter.java
+++ b/src/test/java/examples/paging/LimitAndOffsetAdapter.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2016-2018 the original author or authors.
+ *    Copyright 2016-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 
-import org.mybatis.dynamic.sql.render.RenderingStrategy;
+import org.mybatis.dynamic.sql.render.RenderingStrategies;
 import org.mybatis.dynamic.sql.select.SelectModel;
 import org.mybatis.dynamic.sql.select.render.SelectStatementProvider;
 
@@ -56,7 +56,7 @@ public class LimitAndOffsetAdapter<R> {
     
     private SelectStatementProvider selectStatement() {
         return new LimitAndOffsetDecorator(
-                selectModel.render(RenderingStrategy.MYBATIS3));
+                selectModel.render(RenderingStrategies.MYBATIS3));
     }
     
     public static <R> LimitAndOffsetAdapter<R> of(SelectModel selectModel,

--- a/src/test/java/examples/schema_supplier/SchemaSupplierTest.java
+++ b/src/test/java/examples/schema_supplier/SchemaSupplierTest.java
@@ -35,6 +35,7 @@ import org.apache.ibatis.session.SqlSessionFactoryBuilder;
 import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mybatis.dynamic.sql.util.mybatis3.MyBatis3SelectCompleter;
 
 public class SchemaSupplierTest {
 
@@ -88,9 +89,7 @@ public class SchemaSupplierTest {
 
             insertFlintstones(mapper);
             
-            List<User> records = mapper.selectByExample()
-                    .build()
-                    .execute();
+            List<User> records = mapper.select(MyBatis3SelectCompleter.allRows());
             assertThat(records.size()).isEqualTo(2);
         }
     }
@@ -103,18 +102,14 @@ public class SchemaSupplierTest {
             System.setProperty(SchemaSupplier.schema_property, "schema1");
             insertFlintstones(mapper);
             
-            List<User> records = mapper.selectByExample()
-                    .build()
-                    .execute();
+            List<User> records = mapper.select(MyBatis3SelectCompleter.allRows());
             assertThat(records.size()).isEqualTo(2);
 
             
             System.setProperty(SchemaSupplier.schema_property, "schema2");
             insertRubbles(mapper);
             
-            records = mapper.selectByExample()
-                    .build()
-                    .execute();
+            records = mapper.select(MyBatis3SelectCompleter.allRows());
             assertThat(records.size()).isEqualTo(3);
         }
     }

--- a/src/test/java/examples/schema_supplier/UserMapper.java
+++ b/src/test/java/examples/schema_supplier/UserMapper.java
@@ -24,14 +24,14 @@ import org.apache.ibatis.annotations.Result;
 import org.apache.ibatis.annotations.Results;
 import org.apache.ibatis.annotations.SelectProvider;
 import org.apache.ibatis.type.JdbcType;
+import org.mybatis.dynamic.sql.BasicColumn;
 import org.mybatis.dynamic.sql.SqlBuilder;
 import org.mybatis.dynamic.sql.insert.render.InsertStatementProvider;
-import org.mybatis.dynamic.sql.render.RenderingStrategy;
-import org.mybatis.dynamic.sql.select.MyBatis3SelectModelAdapter;
-import org.mybatis.dynamic.sql.select.QueryExpressionDSL;
-import org.mybatis.dynamic.sql.select.SelectDSL;
+import org.mybatis.dynamic.sql.render.RenderingStrategies;
 import org.mybatis.dynamic.sql.select.render.SelectStatementProvider;
 import org.mybatis.dynamic.sql.util.SqlProviderAdapter;
+import org.mybatis.dynamic.sql.util.mybatis3.MyBatis3SelectCompleter;
+import org.mybatis.dynamic.sql.util.mybatis3.MyBatis3Utils;
 
 public interface UserMapper {
 
@@ -45,17 +45,16 @@ public interface UserMapper {
     })
     List<User> selectMany(SelectStatementProvider selectStatement);
 
-    default QueryExpressionDSL<MyBatis3SelectModelAdapter<List<User>>> selectByExample() {
-        return SelectDSL.selectWithMapper(this::selectMany, id, name)
-            .from(user);
+    default List<User> select(MyBatis3SelectCompleter completer) {
+        return MyBatis3Utils.selectList(this::selectMany, new BasicColumn[] {id, name}, user, completer);
     }
-
+    
     default int insert(User record) {
         return insert(SqlBuilder.insert(record)
                 .into(user)
                 .map(id).toProperty("id")
                 .map(name).toProperty("name")
                 .build()
-                .render(RenderingStrategy.MYBATIS3));
+                .render(RenderingStrategies.MYBATIS3));
     }
 }

--- a/src/test/java/examples/springbatch/common/UpdateStatementConvertor.java
+++ b/src/test/java/examples/springbatch/common/UpdateStatementConvertor.java
@@ -18,7 +18,7 @@ package examples.springbatch.common;
 import static examples.springbatch.mapper.PersonDynamicSqlSupport.*;
 import static org.mybatis.dynamic.sql.SqlBuilder.*;
 
-import org.mybatis.dynamic.sql.render.RenderingStrategy;
+import org.mybatis.dynamic.sql.render.RenderingStrategies;
 import org.mybatis.dynamic.sql.update.UpdateDSL;
 import org.mybatis.dynamic.sql.update.render.UpdateStatementProvider;
 import org.springframework.core.convert.converter.Converter;
@@ -34,6 +34,6 @@ public class UpdateStatementConvertor implements Converter<Person, UpdateStateme
                 .set(lastName).equalTo(source::getLastName)
                 .where(id, isEqualTo(source::getId))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
     }
 }

--- a/src/test/java/examples/springbatch/cursor/SpringBatchCursorTest.java
+++ b/src/test/java/examples/springbatch/cursor/SpringBatchCursorTest.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.junit.jupiter.api.Test;
-import org.mybatis.dynamic.sql.render.RenderingStrategy;
+import org.mybatis.dynamic.sql.render.RenderingStrategies;
 import org.mybatis.dynamic.sql.select.SelectDSL;
 import org.mybatis.dynamic.sql.select.render.SelectStatementProvider;
 import org.springframework.batch.core.ExitStatus;
@@ -78,7 +78,7 @@ public class SpringBatchCursorTest {
                     .from(person)
                     .where(lastName, isEqualTo("FLINTSTONE"))
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
 
             return personMapper.count(selectStatement);
         }

--- a/src/test/java/examples/springbatch/paging/SpringBatchPagingTest.java
+++ b/src/test/java/examples/springbatch/paging/SpringBatchPagingTest.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.junit.jupiter.api.Test;
-import org.mybatis.dynamic.sql.render.RenderingStrategy;
+import org.mybatis.dynamic.sql.render.RenderingStrategies;
 import org.mybatis.dynamic.sql.select.SelectDSL;
 import org.mybatis.dynamic.sql.select.render.SelectStatementProvider;
 import org.springframework.batch.core.ExitStatus;
@@ -90,7 +90,7 @@ public class SpringBatchPagingTest {
                     .from(person)
                     .where(lastName, isEqualTo("SMITH"))
                     .build()
-                    .render(RenderingStrategy.MYBATIS3);
+                    .render(RenderingStrategies.MYBATIS3);
 
             return personMapper.count(selectStatement);
         }

--- a/src/test/java/issues/gh100/FromGroupByTest.java
+++ b/src/test/java/issues/gh100/FromGroupByTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mybatis.dynamic.sql.SqlBuilder.*;
 
 import org.junit.jupiter.api.Test;
-import org.mybatis.dynamic.sql.render.RenderingStrategy;
+import org.mybatis.dynamic.sql.render.RenderingStrategies;
 import org.mybatis.dynamic.sql.select.QueryExpressionDSL;
 import org.mybatis.dynamic.sql.select.SelectDSL;
 import org.mybatis.dynamic.sql.select.SelectModel;
@@ -38,7 +38,7 @@ public class FromGroupByTest {
                 + " from student"
                 + " group by name";
         
-        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategies.MYBATIS3);
 
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -54,7 +54,7 @@ public class FromGroupByTest {
                 + " from student"
                 + " group by name";
         
-        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategies.MYBATIS3);
 
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -73,7 +73,7 @@ public class FromGroupByTest {
                 + " group by name"
                 + " limit #{parameters._limit}";
         
-        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategies.MYBATIS3);
 
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -92,7 +92,7 @@ public class FromGroupByTest {
                 + " group by name"
                 + " limit #{parameters._limit}";
         
-        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategies.MYBATIS3);
 
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -111,7 +111,7 @@ public class FromGroupByTest {
                 + " group by name"
                 + " limit #{parameters._limit}";
         
-        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategies.MYBATIS3);
 
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -130,7 +130,7 @@ public class FromGroupByTest {
                 + " group by name"
                 + " offset #{parameters._offset} rows";
         
-        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategies.MYBATIS3);
 
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -149,7 +149,7 @@ public class FromGroupByTest {
                 + " group by name"
                 + " offset #{parameters._offset} rows";
         
-        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategies.MYBATIS3);
 
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -168,7 +168,7 @@ public class FromGroupByTest {
                 + " group by name"
                 + " offset #{parameters._offset} rows";
         
-        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategies.MYBATIS3);
 
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -187,7 +187,7 @@ public class FromGroupByTest {
                 + " group by name"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
         
-        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategies.MYBATIS3);
 
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -206,7 +206,7 @@ public class FromGroupByTest {
                 + " group by name"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
         
-        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategies.MYBATIS3);
 
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -225,7 +225,7 @@ public class FromGroupByTest {
                 + " group by name"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
         
-        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategies.MYBATIS3);
 
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -244,7 +244,7 @@ public class FromGroupByTest {
                 + " group by name"
                 + " order by name";
         
-        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategies.MYBATIS3);
 
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -263,7 +263,7 @@ public class FromGroupByTest {
                 + " group by name"
                 + " order by name";
         
-        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategies.MYBATIS3);
 
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -282,7 +282,7 @@ public class FromGroupByTest {
                 + " group by name"
                 + " order by name";
         
-        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategies.MYBATIS3);
 
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -304,7 +304,7 @@ public class FromGroupByTest {
                 + " order by name"
                 + " offset #{parameters._offset} rows";
         
-        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategies.MYBATIS3);
 
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -326,7 +326,7 @@ public class FromGroupByTest {
                 + " order by name"
                 + " offset #{parameters._offset} rows";
         
-        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategies.MYBATIS3);
 
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -348,7 +348,7 @@ public class FromGroupByTest {
                 + " order by name"
                 + " offset #{parameters._offset} rows";
         
-        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategies.MYBATIS3);
 
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -370,7 +370,7 @@ public class FromGroupByTest {
                 + " order by name"
                 + " offset #{parameters._offset} rows";
         
-        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategies.MYBATIS3);
 
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }

--- a/src/test/java/issues/gh100/FromJoinWhereTest.java
+++ b/src/test/java/issues/gh100/FromJoinWhereTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mybatis.dynamic.sql.SqlBuilder.*;
 
 import org.junit.jupiter.api.Test;
-import org.mybatis.dynamic.sql.render.RenderingStrategy;
+import org.mybatis.dynamic.sql.render.RenderingStrategies;
 import org.mybatis.dynamic.sql.select.QueryExpressionDSL;
 import org.mybatis.dynamic.sql.select.SelectDSL;
 import org.mybatis.dynamic.sql.select.SelectModel;
@@ -41,7 +41,7 @@ public class FromJoinWhereTest {
                 .limit(3)
                 .offset(2)
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
         
         String expected = "select student.id, student.name, student.idcard" 
                 + " from student"
@@ -65,7 +65,7 @@ public class FromJoinWhereTest {
         String expected = "select id, name, idcard" 
                 + " from student";
         
-        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -82,7 +82,7 @@ public class FromJoinWhereTest {
                 + " from student"
                 + " join student_reg on student.id = student_reg.studentId";
         
-        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategies.MYBATIS3);
 
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -99,7 +99,7 @@ public class FromJoinWhereTest {
                 + " from student"
                 + " join student_reg on student.id = student_reg.studentId";
         
-        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategies.MYBATIS3);
 
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -119,7 +119,7 @@ public class FromJoinWhereTest {
                 + " join student_reg on student.id = student_reg.studentId"
                 + " where student.idcard = #{parameters.p1}";
 
-        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategies.MYBATIS3);
 
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -139,7 +139,7 @@ public class FromJoinWhereTest {
                 + " join student_reg on student.id = student_reg.studentId"
                 + " where student.idcard = #{parameters.p1}";
 
-        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategies.MYBATIS3);
 
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -159,7 +159,7 @@ public class FromJoinWhereTest {
                 + " join student_reg on student.id = student_reg.studentId"
                 + " where student.idcard = #{parameters.p1}";
 
-        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategies.MYBATIS3);
 
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -186,7 +186,7 @@ public class FromJoinWhereTest {
                 + " select id, name, idcard"
                 + " from student";
 
-        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -213,7 +213,7 @@ public class FromJoinWhereTest {
                 + " select id, name, idcard"
                 + " from student";
 
-        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -240,7 +240,7 @@ public class FromJoinWhereTest {
                 + " select id, name, idcard"
                 + " from student";
 
-        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -267,7 +267,7 @@ public class FromJoinWhereTest {
                 + " select id, name, idcard"
                 + " from student";
 
-        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -305,7 +305,7 @@ public class FromJoinWhereTest {
                 + " from student"
                 + " where id is null";
 
-        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -343,7 +343,7 @@ public class FromJoinWhereTest {
                 + " from student"
                 + " where id is null";
 
-        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -381,7 +381,7 @@ public class FromJoinWhereTest {
                 + " from student"
                 + " where id is null";
 
-        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -419,7 +419,7 @@ public class FromJoinWhereTest {
                 + " from student"
                 + " where id is null";
 
-        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -457,7 +457,7 @@ public class FromJoinWhereTest {
                 + " from student"
                 + " where id is null";
 
-        SelectStatementProvider selectStatement = builder5.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder5.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -487,7 +487,7 @@ public class FromJoinWhereTest {
                 + " from student"
                 + " order by id";
 
-        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -517,7 +517,7 @@ public class FromJoinWhereTest {
                 + " from student"
                 + " order by id";
 
-        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -547,7 +547,7 @@ public class FromJoinWhereTest {
                 + " from student"
                 + " order by id";
 
-        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -577,7 +577,7 @@ public class FromJoinWhereTest {
                 + " from student"
                 + " order by id";
 
-        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -607,7 +607,7 @@ public class FromJoinWhereTest {
                 + " from student"
                 + " order by id";
 
-        SelectStatementProvider selectStatement = builder5.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder5.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -640,7 +640,7 @@ public class FromJoinWhereTest {
                 + " order by id"
                 + " limit #{parameters._limit}";
 
-        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -673,7 +673,7 @@ public class FromJoinWhereTest {
                 + " order by id"
                 + " limit #{parameters._limit}";
 
-        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -706,7 +706,7 @@ public class FromJoinWhereTest {
                 + " order by id"
                 + " limit #{parameters._limit}";
 
-        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -739,7 +739,7 @@ public class FromJoinWhereTest {
                 + " order by id"
                 + " limit #{parameters._limit}";
 
-        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -772,7 +772,7 @@ public class FromJoinWhereTest {
                 + " order by id"
                 + " limit #{parameters._limit}";
 
-        SelectStatementProvider selectStatement = builder5.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder5.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -805,7 +805,7 @@ public class FromJoinWhereTest {
                 + " order by id"
                 + " limit #{parameters._limit}";
 
-        SelectStatementProvider selectStatement = builder6.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder6.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -841,7 +841,7 @@ public class FromJoinWhereTest {
                 + " limit #{parameters._limit}"
                 + " offset #{parameters._offset}";
 
-        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -877,7 +877,7 @@ public class FromJoinWhereTest {
                 + " limit #{parameters._limit}"
                 + " offset #{parameters._offset}";
 
-        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -913,7 +913,7 @@ public class FromJoinWhereTest {
                 + " limit #{parameters._limit}"
                 + " offset #{parameters._offset}";
 
-        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -949,7 +949,7 @@ public class FromJoinWhereTest {
                 + " limit #{parameters._limit}"
                 + " offset #{parameters._offset}";
 
-        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -985,7 +985,7 @@ public class FromJoinWhereTest {
                 + " limit #{parameters._limit}"
                 + " offset #{parameters._offset}";
 
-        SelectStatementProvider selectStatement = builder5.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder5.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -1021,7 +1021,7 @@ public class FromJoinWhereTest {
                 + " limit #{parameters._limit}"
                 + " offset #{parameters._offset}";
 
-        SelectStatementProvider selectStatement = builder6.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder6.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -1057,7 +1057,7 @@ public class FromJoinWhereTest {
                 + " limit #{parameters._limit}"
                 + " offset #{parameters._offset}";
 
-        SelectStatementProvider selectStatement = builder7.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder7.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -1090,7 +1090,7 @@ public class FromJoinWhereTest {
                 + " order by id"
                 + " offset #{parameters._offset} rows";
 
-        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
         
@@ -1124,7 +1124,7 @@ public class FromJoinWhereTest {
                 + " order by id"
                 + " offset #{parameters._offset} rows";
 
-        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
         
@@ -1158,7 +1158,7 @@ public class FromJoinWhereTest {
                 + " order by id"
                 + " offset #{parameters._offset} rows";
 
-        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
         
@@ -1192,7 +1192,7 @@ public class FromJoinWhereTest {
                 + " order by id"
                 + " offset #{parameters._offset} rows";
 
-        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
         
@@ -1226,7 +1226,7 @@ public class FromJoinWhereTest {
                 + " order by id"
                 + " offset #{parameters._offset} rows";
 
-        SelectStatementProvider selectStatement = builder5.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder5.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
         
@@ -1260,7 +1260,7 @@ public class FromJoinWhereTest {
                 + " order by id"
                 + " offset #{parameters._offset} rows";
 
-        SelectStatementProvider selectStatement = builder6.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder6.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
         
@@ -1297,7 +1297,7 @@ public class FromJoinWhereTest {
                 + " offset #{parameters._offset} rows"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -1333,7 +1333,7 @@ public class FromJoinWhereTest {
                 + " offset #{parameters._offset} rows"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -1369,7 +1369,7 @@ public class FromJoinWhereTest {
                 + " offset #{parameters._offset} rows"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -1405,7 +1405,7 @@ public class FromJoinWhereTest {
                 + " offset #{parameters._offset} rows"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -1441,7 +1441,7 @@ public class FromJoinWhereTest {
                 + " offset #{parameters._offset} rows"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder5.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder5.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -1477,7 +1477,7 @@ public class FromJoinWhereTest {
                 + " offset #{parameters._offset} rows"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder6.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder6.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -1513,7 +1513,7 @@ public class FromJoinWhereTest {
                 + " offset #{parameters._offset} rows"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder7.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder7.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -1546,7 +1546,7 @@ public class FromJoinWhereTest {
                 + " order by id"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -1579,7 +1579,7 @@ public class FromJoinWhereTest {
                 + " order by id"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -1612,7 +1612,7 @@ public class FromJoinWhereTest {
                 + " order by id"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -1645,7 +1645,7 @@ public class FromJoinWhereTest {
                 + " order by id"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -1678,7 +1678,7 @@ public class FromJoinWhereTest {
                 + " order by id"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder5.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder5.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -1711,7 +1711,7 @@ public class FromJoinWhereTest {
                 + " order by id"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder6.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder6.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -1741,7 +1741,7 @@ public class FromJoinWhereTest {
                 + " from student"
                 + " limit #{parameters._limit}";
 
-        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -1771,7 +1771,7 @@ public class FromJoinWhereTest {
                 + " from student"
                 + " limit #{parameters._limit}";
 
-        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -1801,7 +1801,7 @@ public class FromJoinWhereTest {
                 + " from student"
                 + " limit #{parameters._limit}";
 
-        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -1831,7 +1831,7 @@ public class FromJoinWhereTest {
                 + " from student"
                 + " limit #{parameters._limit}";
 
-        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -1861,7 +1861,7 @@ public class FromJoinWhereTest {
                 + " from student"
                 + " limit #{parameters._limit}";
 
-        SelectStatementProvider selectStatement = builder5.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder5.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -1894,7 +1894,7 @@ public class FromJoinWhereTest {
                 + " limit #{parameters._limit}"
                 + " offset #{parameters._offset}";
 
-        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -1927,7 +1927,7 @@ public class FromJoinWhereTest {
                 + " limit #{parameters._limit}"
                 + " offset #{parameters._offset}";
 
-        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -1960,7 +1960,7 @@ public class FromJoinWhereTest {
                 + " limit #{parameters._limit}"
                 + " offset #{parameters._offset}";
 
-        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -1993,7 +1993,7 @@ public class FromJoinWhereTest {
                 + " limit #{parameters._limit}"
                 + " offset #{parameters._offset}";
 
-        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -2026,7 +2026,7 @@ public class FromJoinWhereTest {
                 + " limit #{parameters._limit}"
                 + " offset #{parameters._offset}";
 
-        SelectStatementProvider selectStatement = builder5.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder5.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -2059,7 +2059,7 @@ public class FromJoinWhereTest {
                 + " limit #{parameters._limit}"
                 + " offset #{parameters._offset}";
 
-        SelectStatementProvider selectStatement = builder6.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder6.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -2089,7 +2089,7 @@ public class FromJoinWhereTest {
                 + " from student"
                 + " offset #{parameters._offset} rows";
 
-        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -2119,7 +2119,7 @@ public class FromJoinWhereTest {
                 + " from student"
                 + " offset #{parameters._offset} rows";
 
-        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -2149,7 +2149,7 @@ public class FromJoinWhereTest {
                 + " from student"
                 + " offset #{parameters._offset} rows";
 
-        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -2179,7 +2179,7 @@ public class FromJoinWhereTest {
                 + " from student"
                 + " offset #{parameters._offset} rows";
 
-        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -2209,7 +2209,7 @@ public class FromJoinWhereTest {
                 + " from student"
                 + " offset #{parameters._offset} rows";
 
-        SelectStatementProvider selectStatement = builder5.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder5.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -2242,7 +2242,7 @@ public class FromJoinWhereTest {
                 + " offset #{parameters._offset} rows"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -2275,7 +2275,7 @@ public class FromJoinWhereTest {
                 + " offset #{parameters._offset} rows"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -2308,7 +2308,7 @@ public class FromJoinWhereTest {
                 + " offset #{parameters._offset} rows"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -2341,7 +2341,7 @@ public class FromJoinWhereTest {
                 + " offset #{parameters._offset} rows"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -2374,7 +2374,7 @@ public class FromJoinWhereTest {
                 + " offset #{parameters._offset} rows"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder5.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder5.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -2407,7 +2407,7 @@ public class FromJoinWhereTest {
                 + " offset #{parameters._offset} rows"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder6.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder6.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -2437,7 +2437,7 @@ public class FromJoinWhereTest {
                 + " from student"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -2467,7 +2467,7 @@ public class FromJoinWhereTest {
                 + " from student"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -2497,7 +2497,7 @@ public class FromJoinWhereTest {
                 + " from student"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -2527,7 +2527,7 @@ public class FromJoinWhereTest {
                 + " from student"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -2557,7 +2557,7 @@ public class FromJoinWhereTest {
                 + " from student"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder5.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder5.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -2580,7 +2580,7 @@ public class FromJoinWhereTest {
                 + " where student.idcard = #{parameters.p1}"
                 + " order by id";
 
-        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -2603,7 +2603,7 @@ public class FromJoinWhereTest {
                 + " where student.idcard = #{parameters.p1}"
                 + " order by id";
 
-        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -2626,7 +2626,7 @@ public class FromJoinWhereTest {
                 + " where student.idcard = #{parameters.p1}"
                 + " order by id";
 
-        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -2649,7 +2649,7 @@ public class FromJoinWhereTest {
                 + " where student.idcard = #{parameters.p1}"
                 + " order by id";
 
-        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -2675,7 +2675,7 @@ public class FromJoinWhereTest {
                 + " order by id"
                 + " limit #{parameters._limit}";
 
-        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -2701,7 +2701,7 @@ public class FromJoinWhereTest {
                 + " order by id"
                 + " limit #{parameters._limit}";
 
-        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -2727,7 +2727,7 @@ public class FromJoinWhereTest {
                 + " order by id"
                 + " limit #{parameters._limit}";
 
-        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -2753,7 +2753,7 @@ public class FromJoinWhereTest {
                 + " order by id"
                 + " limit #{parameters._limit}";
 
-        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -2779,7 +2779,7 @@ public class FromJoinWhereTest {
                 + " order by id"
                 + " limit #{parameters._limit}";
 
-        SelectStatementProvider selectStatement = builder5.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder5.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -2808,7 +2808,7 @@ public class FromJoinWhereTest {
                 + " limit #{parameters._limit}"
                 + " offset #{parameters._offset}";
 
-        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -2837,7 +2837,7 @@ public class FromJoinWhereTest {
                 + " limit #{parameters._limit}"
                 + " offset #{parameters._offset}";
 
-        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -2866,7 +2866,7 @@ public class FromJoinWhereTest {
                 + " limit #{parameters._limit}"
                 + " offset #{parameters._offset}";
 
-        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -2895,7 +2895,7 @@ public class FromJoinWhereTest {
                 + " limit #{parameters._limit}"
                 + " offset #{parameters._offset}";
 
-        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -2924,7 +2924,7 @@ public class FromJoinWhereTest {
                 + " limit #{parameters._limit}"
                 + " offset #{parameters._offset}";
 
-        SelectStatementProvider selectStatement = builder5.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder5.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -2953,7 +2953,7 @@ public class FromJoinWhereTest {
                 + " limit #{parameters._limit}"
                 + " offset #{parameters._offset}";
 
-        SelectStatementProvider selectStatement = builder6.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder6.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -2979,7 +2979,7 @@ public class FromJoinWhereTest {
                 + " order by id"
                 + " offset #{parameters._offset} rows";
 
-        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -3005,7 +3005,7 @@ public class FromJoinWhereTest {
                 + " order by id"
                 + " offset #{parameters._offset} rows";
 
-        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -3031,7 +3031,7 @@ public class FromJoinWhereTest {
                 + " order by id"
                 + " offset #{parameters._offset} rows";
 
-        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -3057,7 +3057,7 @@ public class FromJoinWhereTest {
                 + " order by id"
                 + " offset #{parameters._offset} rows";
 
-        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -3083,7 +3083,7 @@ public class FromJoinWhereTest {
                 + " order by id"
                 + " offset #{parameters._offset} rows";
 
-        SelectStatementProvider selectStatement = builder5.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder5.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -3112,7 +3112,7 @@ public class FromJoinWhereTest {
                 + " offset #{parameters._offset} rows"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -3141,7 +3141,7 @@ public class FromJoinWhereTest {
                 + " offset #{parameters._offset} rows"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -3170,7 +3170,7 @@ public class FromJoinWhereTest {
                 + " offset #{parameters._offset} rows"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -3199,7 +3199,7 @@ public class FromJoinWhereTest {
                 + " offset #{parameters._offset} rows"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -3228,7 +3228,7 @@ public class FromJoinWhereTest {
                 + " offset #{parameters._offset} rows"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder5.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder5.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -3257,7 +3257,7 @@ public class FromJoinWhereTest {
                 + " offset #{parameters._offset} rows"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder6.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder6.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -3283,7 +3283,7 @@ public class FromJoinWhereTest {
                 + " order by id"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -3309,7 +3309,7 @@ public class FromJoinWhereTest {
                 + " order by id"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -3335,7 +3335,7 @@ public class FromJoinWhereTest {
                 + " order by id"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -3361,7 +3361,7 @@ public class FromJoinWhereTest {
                 + " order by id"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -3387,7 +3387,7 @@ public class FromJoinWhereTest {
                 + " order by id"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder5.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder5.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -3410,7 +3410,7 @@ public class FromJoinWhereTest {
                 + " where student.idcard = #{parameters.p1}"
                 + " limit #{parameters._limit}";
 
-        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -3433,7 +3433,7 @@ public class FromJoinWhereTest {
                 + " where student.idcard = #{parameters.p1}"
                 + " limit #{parameters._limit}";
 
-        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -3456,7 +3456,7 @@ public class FromJoinWhereTest {
                 + " where student.idcard = #{parameters.p1}"
                 + " limit #{parameters._limit}";
 
-        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -3479,7 +3479,7 @@ public class FromJoinWhereTest {
                 + " where student.idcard = #{parameters.p1}"
                 + " limit #{parameters._limit}";
 
-        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -3505,7 +3505,7 @@ public class FromJoinWhereTest {
                 + " limit #{parameters._limit}"
                 + " offset #{parameters._offset}";
 
-        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -3531,7 +3531,7 @@ public class FromJoinWhereTest {
                 + " limit #{parameters._limit}"
                 + " offset #{parameters._offset}";
 
-        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -3557,7 +3557,7 @@ public class FromJoinWhereTest {
                 + " limit #{parameters._limit}"
                 + " offset #{parameters._offset}";
 
-        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -3583,7 +3583,7 @@ public class FromJoinWhereTest {
                 + " limit #{parameters._limit}"
                 + " offset #{parameters._offset}";
 
-        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -3609,7 +3609,7 @@ public class FromJoinWhereTest {
                 + " limit #{parameters._limit}"
                 + " offset #{parameters._offset}";
 
-        SelectStatementProvider selectStatement = builder5.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder5.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -3632,7 +3632,7 @@ public class FromJoinWhereTest {
                 + " where student.idcard = #{parameters.p1}"
                 + " offset #{parameters._offset} rows";
 
-        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -3655,7 +3655,7 @@ public class FromJoinWhereTest {
                 + " where student.idcard = #{parameters.p1}"
                 + " offset #{parameters._offset} rows";
 
-        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -3678,7 +3678,7 @@ public class FromJoinWhereTest {
                 + " where student.idcard = #{parameters.p1}"
                 + " offset #{parameters._offset} rows";
 
-        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -3701,7 +3701,7 @@ public class FromJoinWhereTest {
                 + " where student.idcard = #{parameters.p1}"
                 + " offset #{parameters._offset} rows";
 
-        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -3727,7 +3727,7 @@ public class FromJoinWhereTest {
                 + " offset #{parameters._offset} rows"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -3753,7 +3753,7 @@ public class FromJoinWhereTest {
                 + " offset #{parameters._offset} rows"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -3779,7 +3779,7 @@ public class FromJoinWhereTest {
                 + " offset #{parameters._offset} rows"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -3805,7 +3805,7 @@ public class FromJoinWhereTest {
                 + " offset #{parameters._offset} rows"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -3831,7 +3831,7 @@ public class FromJoinWhereTest {
                 + " offset #{parameters._offset} rows"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder5.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder5.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -3854,7 +3854,7 @@ public class FromJoinWhereTest {
                 + " where student.idcard = #{parameters.p1}"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder1.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -3877,7 +3877,7 @@ public class FromJoinWhereTest {
                 + " where student.idcard = #{parameters.p1}"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder2.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -3900,7 +3900,7 @@ public class FromJoinWhereTest {
                 + " where student.idcard = #{parameters.p1}"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder3.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
@@ -3923,7 +3923,7 @@ public class FromJoinWhereTest {
                 + " where student.idcard = #{parameters.p1}"
                 + " fetch first #{parameters._fetchFirstRows} rows only";
 
-        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategy.MYBATIS3);
+        SelectStatementProvider selectStatement = builder4.build().render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }

--- a/src/test/java/issues/gh100/Issue100Test.java
+++ b/src/test/java/issues/gh100/Issue100Test.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mybatis.dynamic.sql.SqlBuilder.*;
 
 import org.junit.jupiter.api.Test;
-import org.mybatis.dynamic.sql.render.RenderingStrategy;
+import org.mybatis.dynamic.sql.render.RenderingStrategies;
 import org.mybatis.dynamic.sql.select.QueryExpressionDSL;
 import org.mybatis.dynamic.sql.select.SelectModel;
 import org.mybatis.dynamic.sql.select.render.SelectStatementProvider;
@@ -40,7 +40,7 @@ public class Issue100Test {
                 .limit(3)
                 .offset(2)
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
         
         String expected = "select student.id, student.name, student.idcard" 
                 + " from student join student_reg on student.id = student_reg.studentId"
@@ -63,7 +63,7 @@ public class Issue100Test {
         .on(StudentDynamicSqlSupport.id, equalTo(StudentRegDynamicSqlSupport.studentid));
                 
         SelectStatementProvider selectStatement = builder.build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
         
         String expected = "select student.id, student.name, student.idcard" 
                 + " from student join student_reg on student.id = student_reg.studentId";
@@ -80,7 +80,7 @@ public class Issue100Test {
         .where(StudentDynamicSqlSupport.idcard, isEqualTo("fred"));
                 
         SelectStatementProvider selectStatement = builder.build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
         
         String expected = "select student.id, student.name, student.idcard" 
                 + " from student join student_reg on student.id = student_reg.studentId"
@@ -99,7 +99,7 @@ public class Issue100Test {
         .orderBy(StudentDynamicSqlSupport.id);
                 
         SelectStatementProvider selectStatement = builder.build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
         
         String expected = "select student.id, student.name, student.idcard" 
                 + " from student join student_reg on student.id = student_reg.studentId"
@@ -120,7 +120,7 @@ public class Issue100Test {
         .limit(3);
 
         SelectStatementProvider selectStatement = builder.build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
         
         String expected = "select student.id, student.name, student.idcard" 
                 + " from student join student_reg on student.id = student_reg.studentId"
@@ -143,7 +143,7 @@ public class Issue100Test {
         .offset(2);
 
         SelectStatementProvider selectStatement = builder.build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
         
         String expected = "select student.id, student.name, student.idcard" 
                 + " from student join student_reg on student.id = student_reg.studentId"
@@ -166,7 +166,7 @@ public class Issue100Test {
         .offset(2);
 
         SelectStatementProvider selectStatement = builder.build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
         
         String expected = "select student.id, student.name, student.idcard" 
                 + " from student join student_reg on student.id = student_reg.studentId"
@@ -189,7 +189,7 @@ public class Issue100Test {
         .fetchFirst(3).rowsOnly();
 
         SelectStatementProvider selectStatement = builder.build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
         
         String expected = "select student.id, student.name, student.idcard" 
                 + " from student join student_reg on student.id = student_reg.studentId"
@@ -212,7 +212,7 @@ public class Issue100Test {
         .fetchFirst(3).rowsOnly();
 
         SelectStatementProvider selectStatement = builder.build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
         
         String expected = "select student.id, student.name, student.idcard" 
                 + " from student join student_reg on student.id = student_reg.studentId"
@@ -233,7 +233,7 @@ public class Issue100Test {
         
         SelectStatementProvider selectStatement = on
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
         
         assertThat(selectStatement.getSelectStatement())
             .isEqualTo("select student.id, student.name, student.idcard from student join student_reg on student.id = student_reg.studentId where student.idcard = #{parameters.p1}");

--- a/src/test/java/issues/gh100/Issue100TestStartAfterJoin.java
+++ b/src/test/java/issues/gh100/Issue100TestStartAfterJoin.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mybatis.dynamic.sql.SqlBuilder.*;
 
 import org.junit.jupiter.api.Test;
-import org.mybatis.dynamic.sql.render.RenderingStrategy;
+import org.mybatis.dynamic.sql.render.RenderingStrategies;
 import org.mybatis.dynamic.sql.select.QueryExpressionDSL;
 import org.mybatis.dynamic.sql.select.SelectDSL;
 import org.mybatis.dynamic.sql.select.SelectModel;
@@ -37,7 +37,7 @@ public class Issue100TestStartAfterJoin {
         builder.where(StudentDynamicSqlSupport.idcard, isEqualTo("fred"));
                 
         SelectStatementProvider selectStatement = builder.build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
         
         String expected = "select student.id, student.name, student.idcard" 
                 + " from student join student_reg on student.id = student_reg.studentId"
@@ -55,14 +55,14 @@ public class Issue100TestStartAfterJoin {
         SelectDSL<SelectModel> selectModel = builder.orderBy(StudentDynamicSqlSupport.id);
                 
         SelectStatementProvider selectStatement = builder.build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
         
         String expected = "select student.id, student.name, student.idcard" 
                 + " from student join student_reg on student.id = student_reg.studentId"
                 + " order by id";
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
         
-        selectStatement = selectModel.build().render(RenderingStrategy.MYBATIS3);
+        selectStatement = selectModel.build().render(RenderingStrategies.MYBATIS3);
         assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
     }
 
@@ -76,7 +76,7 @@ public class Issue100TestStartAfterJoin {
         builder.limit(3);
 
         SelectStatementProvider selectStatement = builder.build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
         
         String expected = "select student.id, student.name, student.idcard" 
                 + " from student join student_reg on student.id = student_reg.studentId"
@@ -97,7 +97,7 @@ public class Issue100TestStartAfterJoin {
         .offset(2);
 
         SelectStatementProvider selectStatement = builder.build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
         
         String expected = "select student.id, student.name, student.idcard" 
                 + " from student join student_reg on student.id = student_reg.studentId"
@@ -120,7 +120,7 @@ public class Issue100TestStartAfterJoin {
         .offset(2);
 
         SelectStatementProvider selectStatement = builder.build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
         
         String expected = "select student.id, student.name, student.idcard" 
                 + " from student join student_reg on student.id = student_reg.studentId"
@@ -143,7 +143,7 @@ public class Issue100TestStartAfterJoin {
         .fetchFirst(3).rowsOnly();
 
         SelectStatementProvider selectStatement = builder.build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
         
         String expected = "select student.id, student.name, student.idcard" 
                 + " from student join student_reg on student.id = student_reg.studentId"
@@ -166,7 +166,7 @@ public class Issue100TestStartAfterJoin {
         .fetchFirst(3).rowsOnly();
 
         SelectStatementProvider selectStatement = builder.build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
         
         String expected = "select student.id, student.name, student.idcard" 
                 + " from student join student_reg on student.id = student_reg.studentId"

--- a/src/test/java/issues/gh105/Issue105Test.java
+++ b/src/test/java/issues/gh105/Issue105Test.java
@@ -22,7 +22,7 @@ import static org.mybatis.dynamic.sql.SqlBuilder.*;
 import java.util.Objects;
 
 import org.junit.jupiter.api.Test;
-import org.mybatis.dynamic.sql.render.RenderingStrategy;
+import org.mybatis.dynamic.sql.render.RenderingStrategies;
 import org.mybatis.dynamic.sql.select.render.SelectStatementProvider;
 import org.mybatis.dynamic.sql.util.Predicates;
 
@@ -38,7 +38,7 @@ public class Issue105Test {
                 .where(firstName, isLike(fName).when(Objects::nonNull).then(s -> "%" + s + "%"))
                 .and(lastName, isLike(lName).when(Objects::nonNull).then(s -> "%" + s + "%"))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person"
@@ -60,7 +60,7 @@ public class Issue105Test {
                 .where(firstName, isLike(fName).when(Objects::nonNull).then(SearchUtils::addWildcards))
                 .and(lastName, isLike(lName).when(Objects::nonNull).then(SearchUtils::addWildcards))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person"
@@ -80,7 +80,7 @@ public class Issue105Test {
                 .where(firstName, isLike(fName).when(Objects::nonNull).then(SearchUtils::addWildcards))
                 .and(lastName, isLike(lName).when(Objects::nonNull).then(SearchUtils::addWildcards))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person"
@@ -100,7 +100,7 @@ public class Issue105Test {
                 .where(firstName, isLike(fName).when(Objects::nonNull).then(SearchUtils::addWildcards))
                 .and(lastName, isLike(lName).when(Objects::nonNull).then(SearchUtils::addWildcards))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person";
@@ -116,7 +116,7 @@ public class Issue105Test {
                 .from(person)
                 .where(age, isBetween(1).and(10).then(i1 -> i1 + 1,  i2 -> i2 + 2))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person"
@@ -134,7 +134,7 @@ public class Issue105Test {
                 .from(person)
                 .where(age, isBetweenWhenPresent(1).and(10).then(i1 -> i1 + 1,  i2 -> i2 + 2))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person"
@@ -152,7 +152,7 @@ public class Issue105Test {
                 .from(person)
                 .where(age, isEqualTo(1).then(i -> i + 1))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person"
@@ -169,7 +169,7 @@ public class Issue105Test {
                 .from(person)
                 .where(age, isEqualToWhenPresent(1).then(i -> i + 1))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person"
@@ -186,7 +186,7 @@ public class Issue105Test {
                 .from(person)
                 .where(age, isGreaterThan(1).then(i -> i + 1))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person"
@@ -203,7 +203,7 @@ public class Issue105Test {
                 .from(person)
                 .where(age, isGreaterThanOrEqualTo(1).then(i -> i + 1))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person"
@@ -220,7 +220,7 @@ public class Issue105Test {
                 .from(person)
                 .where(age, isGreaterThanOrEqualToWhenPresent(1).then(i -> i + 1))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person"
@@ -237,7 +237,7 @@ public class Issue105Test {
                 .from(person)
                 .where(age, isGreaterThanWhenPresent(1).then(i -> i + 1))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person"
@@ -254,7 +254,7 @@ public class Issue105Test {
                 .from(person)
                 .where(age, isLessThan(1).then(i -> i + 1))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person"
@@ -271,7 +271,7 @@ public class Issue105Test {
                 .from(person)
                 .where(age, isLessThanOrEqualTo(1).then(i -> i + 1))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person"
@@ -288,7 +288,7 @@ public class Issue105Test {
                 .from(person)
                 .where(age, isLessThanOrEqualToWhenPresent(1).then(i -> i + 1))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person"
@@ -305,7 +305,7 @@ public class Issue105Test {
                 .from(person)
                 .where(age, isLessThanWhenPresent(1).then(i -> i + 1))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person"
@@ -322,7 +322,7 @@ public class Issue105Test {
                 .from(person)
                 .where(firstName, isLike("fred").then(SearchUtils::addWildcards))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person"
@@ -339,7 +339,7 @@ public class Issue105Test {
                 .from(person)
                 .where(firstName, isLikeCaseInsensitive("fred").then(SearchUtils::addWildcards))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person"
@@ -356,7 +356,7 @@ public class Issue105Test {
                 .from(person)
                 .where(firstName, isLikeCaseInsensitiveWhenPresent("fred").then(SearchUtils::addWildcards))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person"
@@ -373,7 +373,7 @@ public class Issue105Test {
                 .from(person)
                 .where(firstName, isLikeWhenPresent("fred").then(SearchUtils::addWildcards))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person"
@@ -390,7 +390,7 @@ public class Issue105Test {
                 .from(person)
                 .where(age, isNotBetween(1).and(10).then(i1 -> i1 + 1,  i2 -> i2 + 2))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person"
@@ -408,7 +408,7 @@ public class Issue105Test {
                 .from(person)
                 .where(age, isNotBetweenWhenPresent(1).and(10).then(i1 -> i1 + 1,  i2 -> i2 + 2))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person"
@@ -426,7 +426,7 @@ public class Issue105Test {
                 .from(person)
                 .where(age, isNotEqualTo(1).then(i -> i + 1))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person"
@@ -443,7 +443,7 @@ public class Issue105Test {
                 .from(person)
                 .where(age, isNotEqualToWhenPresent(1).then(i -> i + 1))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person"
@@ -460,7 +460,7 @@ public class Issue105Test {
                 .from(person)
                 .where(firstName, isNotLike("fred").then(SearchUtils::addWildcards))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person"
@@ -477,7 +477,7 @@ public class Issue105Test {
                 .from(person)
                 .where(firstName, isNotLikeCaseInsensitive("fred").then(SearchUtils::addWildcards))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person"
@@ -494,7 +494,7 @@ public class Issue105Test {
                 .from(person)
                 .where(firstName, isNotLikeCaseInsensitiveWhenPresent("fred").then(SearchUtils::addWildcards))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person"
@@ -511,7 +511,7 @@ public class Issue105Test {
                 .from(person)
                 .where(firstName, isNotLikeWhenPresent("fred").then(SearchUtils::addWildcards))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person"
@@ -528,7 +528,7 @@ public class Issue105Test {
                 .from(person)
                 .where(age, isBetween(1).and((Integer) null).when(Predicates.bothPresent()).then(i1 -> i1 + 1,  i2 -> i2 + 2))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person";
@@ -543,7 +543,7 @@ public class Issue105Test {
                 .from(person)
                 .where(age, isBetweenWhenPresent(1).and((Integer) null).then(i1 -> i1 + 1,  i2 -> i2 + 2))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person";
@@ -558,7 +558,7 @@ public class Issue105Test {
                 .from(person)
                 .where(age, isEqualTo((Integer) null).when(Objects::nonNull).then(i -> i + 1))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person";
@@ -573,7 +573,7 @@ public class Issue105Test {
                 .from(person)
                 .where(age, isEqualToWhenPresent((Integer) null).then(i -> i + 1))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person";
@@ -588,7 +588,7 @@ public class Issue105Test {
                 .from(person)
                 .where(age, isGreaterThan((Integer) null).when(Objects::nonNull).then(i -> i + 1))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person";
@@ -603,7 +603,7 @@ public class Issue105Test {
                 .from(person)
                 .where(age, isGreaterThanOrEqualTo((Integer) null).when(Objects::nonNull).then(i -> i + 1))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person";
@@ -618,7 +618,7 @@ public class Issue105Test {
                 .from(person)
                 .where(age, isGreaterThanOrEqualToWhenPresent((Integer) null).then(i -> i + 1))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person";
@@ -633,7 +633,7 @@ public class Issue105Test {
                 .from(person)
                 .where(age, isGreaterThanWhenPresent((Integer) null).then(i -> i + 1))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person";
@@ -648,7 +648,7 @@ public class Issue105Test {
                 .from(person)
                 .where(age, isLessThan((Integer) null).when(Objects::nonNull).then(i -> i + 1))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person";
@@ -663,7 +663,7 @@ public class Issue105Test {
                 .from(person)
                 .where(age, isLessThanOrEqualTo((Integer) null).when(Objects::nonNull).then(i -> i + 1))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person";
@@ -678,7 +678,7 @@ public class Issue105Test {
                 .from(person)
                 .where(age, isLessThanOrEqualToWhenPresent((Integer) null).then(i -> i + 1))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person";
@@ -693,7 +693,7 @@ public class Issue105Test {
                 .from(person)
                 .where(age, isLessThanWhenPresent((Integer) null).then(i -> i + 1))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person";
@@ -708,7 +708,7 @@ public class Issue105Test {
                 .from(person)
                 .where(firstName, isLike((String) null).when(Objects::nonNull).then(SearchUtils::addWildcards))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person";
@@ -723,7 +723,7 @@ public class Issue105Test {
                 .from(person)
                 .where(firstName, isLikeCaseInsensitive((String) null).when(Objects::nonNull).then(SearchUtils::addWildcards))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person";
@@ -738,7 +738,7 @@ public class Issue105Test {
                 .from(person)
                 .where(firstName, isLikeCaseInsensitiveWhenPresent((String) null).then(SearchUtils::addWildcards))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person";
@@ -753,7 +753,7 @@ public class Issue105Test {
                 .from(person)
                 .where(firstName, isLikeWhenPresent((String) null).then(SearchUtils::addWildcards))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person";
@@ -768,7 +768,7 @@ public class Issue105Test {
                 .from(person)
                 .where(age, isNotBetween((Integer) null).and(10).when(Predicates.bothPresent()).then(i1 -> i1 + 1,  i2 -> i2 + 2))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person";
@@ -783,7 +783,7 @@ public class Issue105Test {
                 .from(person)
                 .where(age, isNotBetweenWhenPresent(1).and((Integer) null).then(i1 -> i1 + 1,  i2 -> i2 + 2))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person";
@@ -798,7 +798,7 @@ public class Issue105Test {
                 .from(person)
                 .where(age, isNotEqualTo((Integer) null).when(Objects::nonNull).then(i -> i + 1))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person";
@@ -813,7 +813,7 @@ public class Issue105Test {
                 .from(person)
                 .where(age, isNotEqualToWhenPresent((Integer) null).then(i -> i + 1))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person";
@@ -828,7 +828,7 @@ public class Issue105Test {
                 .from(person)
                 .where(firstName, isNotLike((String) null).when(Objects::nonNull).then(SearchUtils::addWildcards))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person";
@@ -843,7 +843,7 @@ public class Issue105Test {
                 .from(person)
                 .where(firstName, isNotLikeCaseInsensitive((String) null).when(Objects::nonNull).then(SearchUtils::addWildcards))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person";
@@ -858,7 +858,7 @@ public class Issue105Test {
                 .from(person)
                 .where(firstName, isNotLikeCaseInsensitiveWhenPresent((String) null).then(SearchUtils::addWildcards))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person";
@@ -873,7 +873,7 @@ public class Issue105Test {
                 .from(person)
                 .where(firstName, isNotLikeWhenPresent((String) null).then(SearchUtils::addWildcards))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "select person_id, first_name, last_name"
                 + " from Person";

--- a/src/test/java/org/mybatis/dynamic/sql/delete/DeleteStatementTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/delete/DeleteStatementTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2016-2018 the original author or authors.
+ *    Copyright 2016-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.mybatis.dynamic.sql.SqlColumn;
 import org.mybatis.dynamic.sql.SqlTable;
 import org.mybatis.dynamic.sql.delete.render.DeleteStatementProvider;
-import org.mybatis.dynamic.sql.render.RenderingStrategy;
+import org.mybatis.dynamic.sql.render.RenderingStrategies;
 
 public class DeleteStatementTest {
     private static final SqlTable foo = SqlTable.of("foo");
@@ -38,7 +38,7 @@ public class DeleteStatementTest {
                 .where(id, isEqualTo(3), and(firstName, isEqualTo("Betty")))
                 .or(firstName, isLikeCaseInsensitive("%Fr%"))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expectedFullStatement = "delete from foo where (id = #{parameters.p1,jdbcType=INTEGER} and first_name = #{parameters.p2,jdbcType=VARCHAR}) or upper(first_name) like #{parameters.p3,jdbcType=VARCHAR}";
 
@@ -55,7 +55,7 @@ public class DeleteStatementTest {
     public void testFullStatementWithoutWhere() {
         DeleteStatementProvider deleteStatement = deleteFrom(foo)
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expectedFullStatement = "delete from foo";
 

--- a/src/test/java/org/mybatis/dynamic/sql/insert/InsertStatementTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/insert/InsertStatementTest.java
@@ -30,7 +30,7 @@ import org.mybatis.dynamic.sql.SqlTable;
 import org.mybatis.dynamic.sql.insert.render.FieldAndValue;
 import org.mybatis.dynamic.sql.insert.render.FieldAndValueCollector;
 import org.mybatis.dynamic.sql.insert.render.InsertStatementProvider;
-import org.mybatis.dynamic.sql.render.RenderingStrategy;
+import org.mybatis.dynamic.sql.render.RenderingStrategies;
 
 public class InsertStatementTest {
 
@@ -54,7 +54,7 @@ public class InsertStatementTest {
                 .map(lastName).toProperty("lastName")
                 .map(occupation).toProperty("occupation")
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
         
         String expectedStatement = "insert into foo "
                 + "(id, first_name, last_name, occupation) "
@@ -75,7 +75,7 @@ public class InsertStatementTest {
                 .map(lastName).toProperty("lastName")
                 .map(occupation).toNull()
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "insert into foo (id, first_name, last_name, occupation) "
                 + "values (#{record.id,jdbcType=INTEGER}, #{record.firstName,jdbcType=VARCHAR}, #{record.lastName,jdbcType=VARCHAR}, null)";
@@ -94,7 +94,7 @@ public class InsertStatementTest {
                 .map(lastName).toProperty("lastName")
                 .map(occupation).toStringConstant("Y")
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "insert into foo (id, first_name, last_name, occupation) "
                 + "values (3, #{record.firstName,jdbcType=VARCHAR}, #{record.lastName,jdbcType=VARCHAR}, 'Y')";
@@ -114,7 +114,7 @@ public class InsertStatementTest {
                 .map(lastName).toPropertyWhenPresent("lastName", record::getLastName)
                 .map(occupation).toPropertyWhenPresent("occupation", record::getOccupation)
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "insert into foo (last_name, occupation) "
                 + "values (#{record.lastName,jdbcType=VARCHAR}, #{record.occupation,jdbcType=VARCHAR})";

--- a/src/test/java/org/mybatis/dynamic/sql/mybatis3/CriterionRendererTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/mybatis3/CriterionRendererTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.mybatis.dynamic.sql.SqlColumn;
 import org.mybatis.dynamic.sql.SqlCriterion;
 import org.mybatis.dynamic.sql.SqlTable;
-import org.mybatis.dynamic.sql.render.RenderingStrategy;
+import org.mybatis.dynamic.sql.render.RenderingStrategies;
 import org.mybatis.dynamic.sql.render.TableAliasCalculator;
 import org.mybatis.dynamic.sql.util.FragmentAndParameters;
 import org.mybatis.dynamic.sql.where.condition.IsEqualTo;
@@ -47,7 +47,7 @@ public class CriterionRendererTest {
         AtomicInteger sequence = new AtomicInteger(1);
         FragmentAndParameters fp = CriterionRenderer.withCriterion(criterion)
                 .withSequence(sequence)
-                .withRenderingStrategy(RenderingStrategy.MYBATIS3)
+                .withRenderingStrategy(RenderingStrategies.MYBATIS3)
                 .withTableAliasCalculator(TableAliasCalculator.empty())
                 .build()
                 .render()
@@ -73,7 +73,7 @@ public class CriterionRendererTest {
         tableAliases.put(table, "a");
         FragmentAndParameters fp = CriterionRenderer.withCriterion(criterion)
                 .withSequence(sequence)
-                .withRenderingStrategy(RenderingStrategy.MYBATIS3)
+                .withRenderingStrategy(RenderingStrategies.MYBATIS3)
                 .withTableAliasCalculator(TableAliasCalculator.of(tableAliases))
                 .build()
                 .render()
@@ -101,7 +101,7 @@ public class CriterionRendererTest {
         AtomicInteger sequence = new AtomicInteger(1);
         FragmentAndParameters fp = CriterionRenderer.withCriterion(criterion)
                 .withSequence(sequence)
-                .withRenderingStrategy(RenderingStrategy.MYBATIS3)
+                .withRenderingStrategy(RenderingStrategies.MYBATIS3)
                 .withTableAliasCalculator(TableAliasCalculator.empty())
                 .build()
                 .render()
@@ -128,7 +128,7 @@ public class CriterionRendererTest {
         
         FragmentAndParameters fp = CriterionRenderer.withCriterion(criterion)
                 .withSequence(sequence)
-                .withRenderingStrategy(RenderingStrategy.MYBATIS3)
+                .withRenderingStrategy(RenderingStrategies.MYBATIS3)
                 .withTableAliasCalculator(TableAliasCalculator.of(tableAliases))
                 .build()
                 .render()

--- a/src/test/java/org/mybatis/dynamic/sql/mybatis3/InsertStatementTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/mybatis3/InsertStatementTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2016-2018 the original author or authors.
+ *    Copyright 2016-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.mybatis.dynamic.sql.SqlColumn;
 import org.mybatis.dynamic.sql.SqlTable;
 import org.mybatis.dynamic.sql.insert.render.InsertStatementProvider;
-import org.mybatis.dynamic.sql.render.RenderingStrategy;
+import org.mybatis.dynamic.sql.render.RenderingStrategies;
 
 public class InsertStatementTest {
     private static final SqlTable foo = SqlTable.of("foo");
@@ -46,7 +46,7 @@ public class InsertStatementTest {
                 .map(lastName).toProperty("lastName")
                 .map(occupation).toProperty("occupation")
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "insert into foo (id, first_name, last_name, occupation) "
                 + "values (#{record.id,jdbcType=INTEGER}, "
@@ -68,7 +68,7 @@ public class InsertStatementTest {
                 .map(lastName).toPropertyWhenPresent("lastName", record::getLastName)
                 .map(occupation).toPropertyWhenPresent("occupation", record::getOccupation)
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expected = "insert into foo (last_name, occupation) "
                 + "values (#{record.lastName,jdbcType=VARCHAR}, "

--- a/src/test/java/org/mybatis/dynamic/sql/mybatis3/SelectStatementTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/mybatis3/SelectStatementTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2016-2018 the original author or authors.
+ *    Copyright 2016-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.mybatis.dynamic.sql.SqlColumn;
 import org.mybatis.dynamic.sql.SqlTable;
-import org.mybatis.dynamic.sql.render.RenderingStrategy;
+import org.mybatis.dynamic.sql.render.RenderingStrategies;
 import org.mybatis.dynamic.sql.select.render.SelectStatementProvider;
 
 public class SelectStatementTest {
@@ -44,7 +44,7 @@ public class SelectStatementTest {
                 .or(column2, isEqualTo(4))
                 .and(column2, isLessThan(3))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         assertThat(selectStatement.getSelectStatement()).isEqualTo(
                 "select a.column1, a.column2 from foo a where a.column1 = #{parameters.p1,jdbcType=DATE} or a.column2 = #{parameters.p2,jdbcType=INTEGER} and a.column2 < #{parameters.p3,jdbcType=INTEGER}");
@@ -70,7 +70,7 @@ public class SelectStatementTest {
                 .or(column2, isEqualTo(4), and(column2, isEqualTo(6)))
                 .and(column2, isLessThan(3), or(column1, isEqualTo(d)))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
         
 
         String expected = "select a.column1, a.column2 "
@@ -105,7 +105,7 @@ public class SelectStatementTest {
                 .or(column2, isEqualTo(4))
                 .and(column2, isLessThan(3))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         Map<String, Object> parameters = selectStatement.getParameters();
 
@@ -130,7 +130,7 @@ public class SelectStatementTest {
                 .or(column2, isEqualTo(4), and(column2, isEqualTo(6), or(column2, isEqualTo(7))))
                 .and(column2, isLessThan(3), or(column1, isEqualTo(d), and(column2, isEqualTo(88))))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
         
 
         String expected = "select a.column1, a.column2 "

--- a/src/test/java/org/mybatis/dynamic/sql/mybatis3/UpdateStatementTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/mybatis3/UpdateStatementTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2016-2018 the original author or authors.
+ *    Copyright 2016-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import java.sql.JDBCType;
 import org.junit.jupiter.api.Test;
 import org.mybatis.dynamic.sql.SqlColumn;
 import org.mybatis.dynamic.sql.SqlTable;
-import org.mybatis.dynamic.sql.render.RenderingStrategy;
+import org.mybatis.dynamic.sql.render.RenderingStrategies;
 import org.mybatis.dynamic.sql.update.render.UpdateStatementProvider;
 
 public class UpdateStatementTest {
@@ -42,7 +42,7 @@ public class UpdateStatementTest {
                 .set(occupation).equalToNull()
                 .where(id, isEqualTo(3))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
         
         String expected = "update foo set firstName = #{parameters.p1,jdbcType=VARCHAR}, "
                 + "lastName = #{parameters.p2,jdbcType=VARCHAR}, "
@@ -65,7 +65,7 @@ public class UpdateStatementTest {
                 .where(id, isEqualTo(3))
                 .and(firstName, isEqualTo("barney"))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
         
         String expectedSetClause = "update foo set occupation = null, "
                 + "firstName = #{parameters.p1,jdbcType=VARCHAR}, "

--- a/src/test/java/org/mybatis/dynamic/sql/select/SelectStatementTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/select/SelectStatementTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2016-2018 the original author or authors.
+ *    Copyright 2016-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.mybatis.dynamic.sql.SqlColumn;
 import org.mybatis.dynamic.sql.SqlTable;
-import org.mybatis.dynamic.sql.render.RenderingStrategy;
+import org.mybatis.dynamic.sql.render.RenderingStrategies;
 import org.mybatis.dynamic.sql.select.render.SelectStatementProvider;
 
 public class SelectStatementTest {
@@ -45,7 +45,7 @@ public class SelectStatementTest {
                 .or(column2, isEqualTo(4))
                 .and(column2, isLessThan(3))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expectedFullStatement = "select a.column1 as A_COLUMN1, a.column2 "
                 + "from foo a "
@@ -74,7 +74,7 @@ public class SelectStatementTest {
                 .or(column2, isEqualTo(4), and(column2, isEqualTo(6)))
                 .and(column2, isLessThan(3), or(column1, isEqualTo(d)))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
         
         String expectedFullStatement = "select a.column1 as A_COLUMN1, a.column2 "
                 + "from foo a "
@@ -107,7 +107,7 @@ public class SelectStatementTest {
                 .where(column1, isEqualTo(d))
                 .orderBy(column1)
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expectedFullStatement = "select a.column1 as A_COLUMN1, a.column2 "
                 + "from foo a "
@@ -131,7 +131,7 @@ public class SelectStatementTest {
                 .where(column1, isEqualTo(d))
                 .orderBy(column2.descending())
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expectedFullStatement = "select a.column1 as A_COLUMN1, a.column2 "
                 + "from foo a "
@@ -155,7 +155,7 @@ public class SelectStatementTest {
                 .where(column1, isEqualTo(d))
                 .orderBy(column2.descending(), column1)
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expectedFullStatement = "select a.column1 as A_COLUMN1, a.column2 "
                 + "from foo a "
@@ -179,7 +179,7 @@ public class SelectStatementTest {
                 .where(column1, isEqualTo(d))
                 .orderBy(column2.descending(), column1)
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expectedFullStatement = "select distinct a.column1 as A_COLUMN1, a.column2 "
                 + "from foo a "
@@ -202,7 +202,7 @@ public class SelectStatementTest {
                 .from(table, "a")
                 .where(column1, isEqualTo(d))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expectedFullStatement = "select count(*) "
                 + "from foo a "
@@ -221,7 +221,7 @@ public class SelectStatementTest {
         SelectStatementProvider selectStatement = select(count())
                 .from(table, "a")
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expectedFullStatement = "select count(*) "
                 + "from foo a";
@@ -243,7 +243,7 @@ public class SelectStatementTest {
                 .where(column1, isEqualTo(d))
                 .groupBy(column2)
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
 
         String expectedFullStatement = "select a.column1 as A_COLUMN1, a.column2 "
                 + "from foo a "

--- a/src/test/java/org/mybatis/dynamic/sql/subselect/SubSelectTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/subselect/SubSelectTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2016-2018 the original author or authors.
+ *    Copyright 2016-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import java.util.Date;
 import org.junit.jupiter.api.Test;
 import org.mybatis.dynamic.sql.SqlColumn;
 import org.mybatis.dynamic.sql.SqlTable;
-import org.mybatis.dynamic.sql.render.RenderingStrategy;
+import org.mybatis.dynamic.sql.render.RenderingStrategies;
 import org.mybatis.dynamic.sql.select.render.SelectStatementProvider;
 
 public class SubSelectTest {
@@ -43,7 +43,7 @@ public class SubSelectTest {
                 .where(column2, isIn(select(column2).from(table).where(column2, isEqualTo(3))))
                 .and(column1, isLessThan(d))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
         
         String expectedFullStatement = "select a.column1 as A_COLUMN1, a.column2 "
                 + "from foo a "
@@ -66,7 +66,7 @@ public class SubSelectTest {
                 .where(column2, isNotIn(select(column2).from(table).where(column2, isEqualTo(3))))
                 .and(column1, isLessThan(d))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
         
         String expectedFullStatement = "select a.column1 as A_COLUMN1, a.column2 "
                 + "from foo a "

--- a/src/test/java/org/mybatis/dynamic/sql/update/UpdateStatementTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/update/UpdateStatementTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2016-2018 the original author or authors.
+ *    Copyright 2016-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import java.sql.JDBCType;
 import org.junit.jupiter.api.Test;
 import org.mybatis.dynamic.sql.SqlColumn;
 import org.mybatis.dynamic.sql.SqlTable;
-import org.mybatis.dynamic.sql.render.RenderingStrategy;
+import org.mybatis.dynamic.sql.render.RenderingStrategies;
 import org.mybatis.dynamic.sql.update.render.UpdateStatementProvider;
 
 public class UpdateStatementTest {
@@ -42,7 +42,7 @@ public class UpdateStatementTest {
                 .set(occupation).equalToNull()
                 .where(id, isEqualTo(3), or(id, isEqualTo(4)), or(id, isEqualTo(5)))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
         
         String expected = "update foo set firstName = #{parameters.p1,jdbcType=VARCHAR}, lastName = #{parameters.p2,jdbcType=VARCHAR}, occupation = null "
                 + "where (id = #{parameters.p3,jdbcType=INTEGER} or id = #{parameters.p4,jdbcType=INTEGER} or id = #{parameters.p5,jdbcType=INTEGER})";
@@ -66,7 +66,7 @@ public class UpdateStatementTest {
                 .set(occupation).equalToNull()
                 .where(id, isEqualTo(3), or(id, isEqualTo(4), or(id, isEqualTo(5))))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
         
         String expected = "update foo set firstName = #{parameters.p1,jdbcType=VARCHAR}, lastName = #{parameters.p2,jdbcType=VARCHAR}, occupation = null "
                 + "where (id = #{parameters.p3,jdbcType=INTEGER} or (id = #{parameters.p4,jdbcType=INTEGER} or id = #{parameters.p5,jdbcType=INTEGER}))";
@@ -91,7 +91,7 @@ public class UpdateStatementTest {
                 .where(id, isEqualTo(3))
                 .and(firstName, isEqualTo("barney"))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
         
         String expected = "update foo set occupation = null, firstName = #{parameters.p1,jdbcType=VARCHAR}, lastName = #{parameters.p2,jdbcType=VARCHAR} "
                 + "where id = #{parameters.p3,jdbcType=INTEGER} and firstName = #{parameters.p4,jdbcType=VARCHAR}";
@@ -116,7 +116,7 @@ public class UpdateStatementTest {
                 .where(id, isEqualTo(3))
                 .and(firstName, isEqualTo("barney"))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
         
         String expected = "update foo set occupation = 'Y', firstName = #{parameters.p1,jdbcType=VARCHAR}, lastName = #{parameters.p2,jdbcType=VARCHAR}, id = 4 "
                 + "where id = #{parameters.p3,jdbcType=INTEGER} and firstName = #{parameters.p4,jdbcType=VARCHAR}";
@@ -139,7 +139,7 @@ public class UpdateStatementTest {
                 .set(occupation).equalToNull()
                 .where(id, isEqualTo(3))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
         
         String expectedStatement = "update foo " 
                 + "set firstName = #{parameters.p1,jdbcType=VARCHAR}, lastName = #{parameters.p2,jdbcType=VARCHAR}, occupation = null "
@@ -161,7 +161,7 @@ public class UpdateStatementTest {
                 .set(lastName).equalTo("jones")
                 .set(occupation).equalToNull()
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
         
         String expectedStatement = "update foo " 
                 + "set firstName = #{parameters.p1,jdbcType=VARCHAR}, lastName = #{parameters.p2,jdbcType=VARCHAR}, occupation = null";
@@ -182,7 +182,7 @@ public class UpdateStatementTest {
                 .set(id).equalTo(multiply(id, constant("3")))
                 .set(id).equalTo(divide(id, constant("4")))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
         
         String expectedStatement = "update foo " 
                 + "set id = (id + 1), "
@@ -203,7 +203,7 @@ public class UpdateStatementTest {
                 .set(firstName).equalTo(select(firstName).from(foo).where(id, isEqualTo(4)))
                 .where(id, isEqualTo(3))
                 .build()
-                .render(RenderingStrategy.MYBATIS3);
+                .render(RenderingStrategies.MYBATIS3);
         
         String expectedStatement = "update foo " 
                 + "set lastName = #{parameters.p1,jdbcType=VARCHAR}, firstName = (select firstName from foo where id = #{parameters.p2,jdbcType=INTEGER}) "

--- a/src/test/java/org/mybatis/dynamic/sql/where/WhereModelTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/where/WhereModelTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2016-2018 the original author or authors.
+ *    Copyright 2016-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import java.sql.JDBCType;
 import org.junit.jupiter.api.Test;
 import org.mybatis.dynamic.sql.SqlColumn;
 import org.mybatis.dynamic.sql.SqlTable;
-import org.mybatis.dynamic.sql.render.RenderingStrategy;
+import org.mybatis.dynamic.sql.render.RenderingStrategies;
 import org.mybatis.dynamic.sql.where.render.WhereClauseProvider;
 
 public class WhereModelTest {
@@ -35,7 +35,7 @@ public class WhereModelTest {
         
         WhereClauseProvider wc = where(id, isEqualTo(3), or(id, isEqualTo(4)))
                 .build()
-                .render(RenderingStrategy.MYBATIS3, "myName");
+                .render(RenderingStrategies.MYBATIS3, "myName");
 
         assertThat(wc.getWhereClause()).isEqualTo("where (id = #{myName.parameters.p1,jdbcType=INTEGER} or id = #{myName.parameters.p2,jdbcType=INTEGER})");
     }

--- a/src/test/java/org/mybatis/dynamic/sql/where/render/CriterionRendererTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/where/render/CriterionRendererTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.mybatis.dynamic.sql.SqlColumn;
 import org.mybatis.dynamic.sql.SqlCriterion;
 import org.mybatis.dynamic.sql.SqlTable;
-import org.mybatis.dynamic.sql.render.RenderingStrategy;
+import org.mybatis.dynamic.sql.render.RenderingStrategies;
 import org.mybatis.dynamic.sql.render.TableAliasCalculator;
 import org.mybatis.dynamic.sql.util.FragmentAndParameters;
 import org.mybatis.dynamic.sql.where.condition.IsEqualTo;
@@ -45,7 +45,7 @@ public class CriterionRendererTest {
         AtomicInteger sequence = new AtomicInteger(1);
         FragmentAndParameters fp = CriterionRenderer.withCriterion(criterion)
                 .withSequence(sequence)
-                .withRenderingStrategy(RenderingStrategy.MYBATIS3)
+                .withRenderingStrategy(RenderingStrategies.MYBATIS3)
                 .withTableAliasCalculator(TableAliasCalculator.empty())
                 .build()
                 .render()
@@ -72,7 +72,7 @@ public class CriterionRendererTest {
         
         FragmentAndParameters fp = CriterionRenderer.withCriterion(criterion)
                 .withSequence(sequence)
-                .withRenderingStrategy(RenderingStrategy.MYBATIS3)
+                .withRenderingStrategy(RenderingStrategies.MYBATIS3)
                 .withTableAliasCalculator(TableAliasCalculator.of(tableAliases))
                 .build()
                 .render()

--- a/src/test/java/org/mybatis/dynamic/sql/where/render/OptionalCriterionRenderTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/where/render/OptionalCriterionRenderTest.java
@@ -24,7 +24,7 @@ import java.util.Objects;
 import org.junit.jupiter.api.Test;
 import org.mybatis.dynamic.sql.SqlColumn;
 import org.mybatis.dynamic.sql.SqlTable;
-import org.mybatis.dynamic.sql.render.RenderingStrategy;
+import org.mybatis.dynamic.sql.render.RenderingStrategies;
 
 public class OptionalCriterionRenderTest {
     private static SqlTable person = SqlTable.of("person");
@@ -38,7 +38,7 @@ public class OptionalCriterionRenderTest {
         
         WhereClauseProvider whereClause = where(id, isEqualToWhenPresent(nullId))
                 .build()
-                .render(RenderingStrategy.SPRING_NAMED_PARAMETER);
+                .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
  
         assertAll(
                 () -> assertThat(whereClause.getWhereClause()).isEqualTo(""),
@@ -52,7 +52,7 @@ public class OptionalCriterionRenderTest {
         
         WhereClauseProvider whereClause = where(id, isEqualTo(nullId).when(Objects::nonNull))
                 .build()
-                .render(RenderingStrategy.SPRING_NAMED_PARAMETER);
+                .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
  
         assertAll(
                 () -> assertThat(whereClause.getWhereClause()).isEqualTo(""),
@@ -64,7 +64,7 @@ public class OptionalCriterionRenderTest {
     public void testDisabledIsNull() {
         WhereClauseProvider whereClause = where(id, isNull().when(() -> false))
                 .build()
-                .render(RenderingStrategy.SPRING_NAMED_PARAMETER);
+                .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
  
         assertAll(
                 () -> assertThat(whereClause.getWhereClause()).isEqualTo(""),
@@ -76,7 +76,7 @@ public class OptionalCriterionRenderTest {
     public void testEnabledIsNull() {
         WhereClauseProvider whereClause = where(id, isNull().when(() -> true))
                 .build()
-                .render(RenderingStrategy.SPRING_NAMED_PARAMETER);
+                .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
  
         assertAll(
                 () -> assertThat(whereClause.getWhereClause()).isEqualTo("where id is null"),
@@ -88,7 +88,7 @@ public class OptionalCriterionRenderTest {
     public void testDisabledIsNotNull() {
         WhereClauseProvider whereClause = where(id, isNotNull().when(() -> false))
                 .build()
-                .render(RenderingStrategy.SPRING_NAMED_PARAMETER);
+                .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
  
         assertAll(
                 () -> assertThat(whereClause.getWhereClause()).isEqualTo(""),
@@ -100,7 +100,7 @@ public class OptionalCriterionRenderTest {
     public void testEnabledIsNotNull() {
         WhereClauseProvider whereClause = where(id, isNotNull().when(() -> true))
                 .build()
-                .render(RenderingStrategy.SPRING_NAMED_PARAMETER);
+                .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
  
         assertAll(
                 () -> assertThat(whereClause.getWhereClause()).isEqualTo("where id is not null"),
@@ -115,7 +115,7 @@ public class OptionalCriterionRenderTest {
         WhereClauseProvider whereClause = where(id, isEqualToWhenPresent(22))
                 .and(firstName, isEqualToWhenPresent(nullFirstName))
                 .build()
-                .render(RenderingStrategy.SPRING_NAMED_PARAMETER);
+                .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
  
         assertAll(
             () -> assertThat(whereClause.getParameters().size()).isEqualTo(1),
@@ -130,7 +130,7 @@ public class OptionalCriterionRenderTest {
         
         WhereClauseProvider whereClause = where(id, isEqualToWhenPresent(22), and(firstName, isEqualToWhenPresent(nullFirstName)))
                 .build()
-                .render(RenderingStrategy.SPRING_NAMED_PARAMETER);
+                .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
  
         assertAll(
             () -> assertThat(whereClause.getParameters().size()).isEqualTo(1),
@@ -146,7 +146,7 @@ public class OptionalCriterionRenderTest {
         WhereClauseProvider whereClause = where(id, isEqualToWhenPresent(nullId))
                 .and(firstName, isEqualToWhenPresent("fred"))
                 .build()
-                .render(RenderingStrategy.SPRING_NAMED_PARAMETER);
+                .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
  
         assertAll(
             () -> assertThat(whereClause.getParameters().size()).isEqualTo(1),
@@ -161,7 +161,7 @@ public class OptionalCriterionRenderTest {
         
         WhereClauseProvider whereClause = where(id, isEqualToWhenPresent(nullId), and(firstName, isEqualToWhenPresent("fred")))
                 .build()
-                .render(RenderingStrategy.SPRING_NAMED_PARAMETER);
+                .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
  
         assertAll(
             () -> assertThat(whereClause.getParameters().size()).isEqualTo(1),
@@ -176,7 +176,7 @@ public class OptionalCriterionRenderTest {
         
         WhereClauseProvider whereClause = where(id, isEqualToWhenPresent(nullId), and(firstName, isEqualToWhenPresent("fred")), or(lastName, isEqualTo("flintstone")))
                 .build()
-                .render(RenderingStrategy.SPRING_NAMED_PARAMETER);
+                .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
  
         assertAll(
             () -> assertThat(whereClause.getParameters().size()).isEqualTo(2),


### PR DESCRIPTION
- Deprecate the constants in RenderingStrategy as they are a code smell and mildly dangerous (SonarQube S2390)
- Deprecate the DeleteWithMapper, SelectWithMapper, and UpdateWithMapper methods in favor of the new style of MyBatis3 specific support (#128)