### PR TITLE
Add Support for Reusing Where Clauses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 This log will detail notable changes to MyBatis Dynamic SQL. Full details are available on the GitHub milestone pages.
 
+## Release 1.1.4 - Unreleased
+
+GitHub milestone: [https://github.com/mybatis/mybatis-dynamic-sql/issues?q=milestone%3A1.1.4+](https://github.com/mybatis/mybatis-dynamic-sql/issues?q=milestone%3A1.1.4+)
+
+### Added
+
+- Added support for reusing WHERE clauses among count, delete, select, and update statements ([#152](https://github.com/mybatis/mybatis-dynamic-sql/pull/152))
+
+
+### Bugs Fixed
+
+- Fixed issue where limit and offset in sub-queries could cause a parameter name collision ([#142](https://github.com/mybatis/mybatis-dynamic-sql/pull/142))
+
 ## Release 1.1.3 - September 16, 2019
 
 GitHub milestone: [https://github.com/mybatis/mybatis-dynamic-sql/issues?q=milestone%3A1.1.3+](https://github.com/mybatis/mybatis-dynamic-sql/issues?q=milestone%3A1.1.3+)

--- a/src/main/java/org/mybatis/dynamic/sql/SqlBuilder.java
+++ b/src/main/java/org/mybatis/dynamic/sql/SqlBuilder.java
@@ -162,12 +162,12 @@ public interface SqlBuilder {
     }
     
     static <T> WhereDSL where(BindableColumn<T> column, VisitableCondition<T> condition) {
-        return WhereDSL.where(column, condition);
+        return WhereDSL.where().where(column, condition);
     }
     
     static <T> WhereDSL where(BindableColumn<T> column, VisitableCondition<T> condition,
             SqlCriterion<?>... subCriteria) {
-        return WhereDSL.where(column, condition, subCriteria);
+        return WhereDSL.where().where(column, condition, subCriteria);
     }
     
     // where condition connectors

--- a/src/main/java/org/mybatis/dynamic/sql/delete/DeleteDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/delete/DeleteDSL.java
@@ -18,7 +18,6 @@ package org.mybatis.dynamic.sql.delete;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.ToIntFunction;
-import java.util.function.UnaryOperator;
 
 import org.mybatis.dynamic.sql.BindableColumn;
 import org.mybatis.dynamic.sql.SqlCriterion;
@@ -28,6 +27,7 @@ import org.mybatis.dynamic.sql.delete.render.DeleteStatementProvider;
 import org.mybatis.dynamic.sql.util.Buildable;
 import org.mybatis.dynamic.sql.util.mybatis3.MyBatis3Utils;
 import org.mybatis.dynamic.sql.where.AbstractWhereDSL;
+import org.mybatis.dynamic.sql.where.WhereApplier;
 import org.mybatis.dynamic.sql.where.WhereModel;
 
 public class DeleteDSL<R> implements Buildable<R> {
@@ -52,8 +52,8 @@ public class DeleteDSL<R> implements Buildable<R> {
     }
 
     @SuppressWarnings("unchecked")
-    public DeleteWhereBuilder applyWhere(UnaryOperator<AbstractWhereDSL<?>> whereApplyer) {
-        return (DeleteWhereBuilder) whereApplyer.apply(whereBuilder);
+    public DeleteWhereBuilder applyWhere(WhereApplier whereApplier) {
+        return (DeleteWhereBuilder) whereApplier.apply(whereBuilder);
     }
 
     /**

--- a/src/main/java/org/mybatis/dynamic/sql/delete/DeleteDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/delete/DeleteDSL.java
@@ -18,6 +18,7 @@ package org.mybatis.dynamic.sql.delete;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.ToIntFunction;
+import java.util.function.UnaryOperator;
 
 import org.mybatis.dynamic.sql.BindableColumn;
 import org.mybatis.dynamic.sql.SqlCriterion;
@@ -27,6 +28,7 @@ import org.mybatis.dynamic.sql.delete.render.DeleteStatementProvider;
 import org.mybatis.dynamic.sql.util.Buildable;
 import org.mybatis.dynamic.sql.util.mybatis3.MyBatis3Utils;
 import org.mybatis.dynamic.sql.where.AbstractWhereDSL;
+import org.mybatis.dynamic.sql.where.WhereModel;
 
 public class DeleteDSL<R> implements Buildable<R> {
 
@@ -45,8 +47,13 @@ public class DeleteDSL<R> implements Buildable<R> {
     
     public <T> DeleteWhereBuilder where(BindableColumn<T> column, VisitableCondition<T> condition,
             SqlCriterion<?>...subCriteria) {
-        whereBuilder.and(column, condition, subCriteria);
+        whereBuilder.where(column, condition, subCriteria);
         return whereBuilder;
+    }
+
+    @SuppressWarnings("unchecked")
+    public DeleteWhereBuilder applyWhere(UnaryOperator<AbstractWhereDSL<?>> whereApplyer) {
+        return (DeleteWhereBuilder) whereApplyer.apply(whereBuilder);
     }
 
     /**
@@ -101,6 +108,11 @@ public class DeleteDSL<R> implements Buildable<R> {
         @Override
         protected DeleteWhereBuilder getThis() {
             return this;
+        }
+
+        @Override
+        protected WhereModel buildWhereModel() {
+            return super.internalBuild();
         }
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/select/CountDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/CountDSL.java
@@ -17,6 +17,7 @@ package org.mybatis.dynamic.sql.select;
 
 import java.util.Objects;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import org.mybatis.dynamic.sql.BindableColumn;
 import org.mybatis.dynamic.sql.SqlBuilder;
@@ -25,6 +26,7 @@ import org.mybatis.dynamic.sql.SqlTable;
 import org.mybatis.dynamic.sql.VisitableCondition;
 import org.mybatis.dynamic.sql.util.Buildable;
 import org.mybatis.dynamic.sql.where.AbstractWhereDSL;
+import org.mybatis.dynamic.sql.where.WhereModel;
 
 /**
  * DSL for building count queries. Count queries are specializations of select queries. They have joins and where
@@ -51,8 +53,13 @@ public class CountDSL<R> extends AbstractQueryExpressionDSL<CountDSL<R>, R> impl
 
     public <T> CountWhereBuilder where(BindableColumn<T> column, VisitableCondition<T> condition,
             SqlCriterion<?>...subCriteria) {
-        whereBuilder.and(column, condition, subCriteria);
+        whereBuilder.where(column, condition, subCriteria);
         return whereBuilder;
+    }
+
+    @SuppressWarnings("unchecked")
+    public CountWhereBuilder applyWhere(UnaryOperator<AbstractWhereDSL<?>> whereApplyer) {
+        return (CountWhereBuilder) whereApplyer.apply(whereBuilder);
     }
 
     @Override
@@ -99,6 +106,11 @@ public class CountDSL<R> extends AbstractQueryExpressionDSL<CountDSL<R>, R> impl
         @Override
         protected CountWhereBuilder getThis() {
             return this;
+        }
+
+        @Override
+        protected WhereModel buildWhereModel() {
+            return super.internalBuild();
         }
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/select/CountDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/CountDSL.java
@@ -17,7 +17,6 @@ package org.mybatis.dynamic.sql.select;
 
 import java.util.Objects;
 import java.util.function.Function;
-import java.util.function.UnaryOperator;
 
 import org.mybatis.dynamic.sql.BindableColumn;
 import org.mybatis.dynamic.sql.SqlBuilder;
@@ -26,6 +25,7 @@ import org.mybatis.dynamic.sql.SqlTable;
 import org.mybatis.dynamic.sql.VisitableCondition;
 import org.mybatis.dynamic.sql.util.Buildable;
 import org.mybatis.dynamic.sql.where.AbstractWhereDSL;
+import org.mybatis.dynamic.sql.where.WhereApplier;
 import org.mybatis.dynamic.sql.where.WhereModel;
 
 /**
@@ -58,8 +58,8 @@ public class CountDSL<R> extends AbstractQueryExpressionDSL<CountDSL<R>, R> impl
     }
 
     @SuppressWarnings("unchecked")
-    public CountWhereBuilder applyWhere(UnaryOperator<AbstractWhereDSL<?>> whereApplyer) {
-        return (CountWhereBuilder) whereApplyer.apply(whereBuilder);
+    public CountWhereBuilder applyWhere(WhereApplier whereApplier) {
+        return (CountWhereBuilder) whereApplier.apply(whereBuilder);
     }
 
     @Override

--- a/src/main/java/org/mybatis/dynamic/sql/select/QueryExpressionDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/QueryExpressionDSL.java
@@ -20,7 +20,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import java.util.function.UnaryOperator;
 
 import org.mybatis.dynamic.sql.BasicColumn;
 import org.mybatis.dynamic.sql.BindableColumn;
@@ -34,6 +33,7 @@ import org.mybatis.dynamic.sql.select.join.JoinSpecification;
 import org.mybatis.dynamic.sql.select.join.JoinType;
 import org.mybatis.dynamic.sql.util.Buildable;
 import org.mybatis.dynamic.sql.where.AbstractWhereDSL;
+import org.mybatis.dynamic.sql.where.WhereApplier;
 import org.mybatis.dynamic.sql.where.WhereModel;
 
 public class QueryExpressionDSL<R> extends AbstractQueryExpressionDSL<QueryExpressionDSL<R>, R>
@@ -70,8 +70,8 @@ public class QueryExpressionDSL<R> extends AbstractQueryExpressionDSL<QueryExpre
     }
 
     @SuppressWarnings("unchecked")
-    public QueryExpressionWhereBuilder applyWhere(UnaryOperator<AbstractWhereDSL<?>> whereApplyer) {
-        return (QueryExpressionWhereBuilder) whereApplyer.apply(whereBuilder);
+    public QueryExpressionWhereBuilder applyWhere(WhereApplier whereApplier) {
+        return (QueryExpressionWhereBuilder) whereApplier.apply(whereBuilder);
     }
 
     @Override
@@ -334,8 +334,8 @@ public class QueryExpressionDSL<R> extends AbstractQueryExpressionDSL<QueryExpre
             return QueryExpressionDSL.this.where(column, condition, subCriteria);
         }
 
-        public QueryExpressionWhereBuilder applyWhere(UnaryOperator<AbstractWhereDSL<?>> whereApplyer) {
-            return QueryExpressionDSL.this.applyWhere(whereApplyer);
+        public QueryExpressionWhereBuilder applyWhere(WhereApplier whereApplier) {
+            return QueryExpressionDSL.this.applyWhere(whereApplier);
         }
         
         public JoinSpecificationFinisher and(BasicColumn joinColumn, JoinCondition joinCondition) {

--- a/src/main/java/org/mybatis/dynamic/sql/update/UpdateDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/update/UpdateDSL.java
@@ -21,7 +21,6 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.function.ToIntFunction;
-import java.util.function.UnaryOperator;
 
 import org.mybatis.dynamic.sql.BasicColumn;
 import org.mybatis.dynamic.sql.BindableColumn;
@@ -41,6 +40,7 @@ import org.mybatis.dynamic.sql.util.UpdateMapping;
 import org.mybatis.dynamic.sql.util.ValueMapping;
 import org.mybatis.dynamic.sql.util.mybatis3.MyBatis3Utils;
 import org.mybatis.dynamic.sql.where.AbstractWhereDSL;
+import org.mybatis.dynamic.sql.where.WhereApplier;
 import org.mybatis.dynamic.sql.where.WhereModel;
 
 public class UpdateDSL<R> implements Buildable<R> {
@@ -70,8 +70,8 @@ public class UpdateDSL<R> implements Buildable<R> {
     }
 
     @SuppressWarnings("unchecked")
-    public UpdateWhereBuilder applyWhere(UnaryOperator<AbstractWhereDSL<?>> whereApplyer) {
-        return (UpdateWhereBuilder) whereApplyer.apply(whereBuilder);
+    public UpdateWhereBuilder applyWhere(WhereApplier whereApplier) {
+        return (UpdateWhereBuilder) whereApplier.apply(whereBuilder);
     }
 
     /**

--- a/src/main/java/org/mybatis/dynamic/sql/update/UpdateDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/update/UpdateDSL.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.function.ToIntFunction;
+import java.util.function.UnaryOperator;
 
 import org.mybatis.dynamic.sql.BasicColumn;
 import org.mybatis.dynamic.sql.BindableColumn;
@@ -40,6 +41,7 @@ import org.mybatis.dynamic.sql.util.UpdateMapping;
 import org.mybatis.dynamic.sql.util.ValueMapping;
 import org.mybatis.dynamic.sql.util.mybatis3.MyBatis3Utils;
 import org.mybatis.dynamic.sql.where.AbstractWhereDSL;
+import org.mybatis.dynamic.sql.where.WhereModel;
 
 public class UpdateDSL<R> implements Buildable<R> {
 
@@ -63,8 +65,13 @@ public class UpdateDSL<R> implements Buildable<R> {
     
     public <T> UpdateWhereBuilder where(BindableColumn<T> column, VisitableCondition<T> condition,
             SqlCriterion<?>...subCriteria) {
-        whereBuilder.and(column, condition, subCriteria);
+        whereBuilder.where(column, condition, subCriteria);
         return whereBuilder;
+    }
+
+    @SuppressWarnings("unchecked")
+    public UpdateWhereBuilder applyWhere(UnaryOperator<AbstractWhereDSL<?>> whereApplyer) {
+        return (UpdateWhereBuilder) whereApplyer.apply(whereBuilder);
     }
 
     /**
@@ -174,6 +181,11 @@ public class UpdateDSL<R> implements Buildable<R> {
         @Override
         protected UpdateWhereBuilder getThis() {
             return this;
+        }
+
+        @Override
+        protected WhereModel buildWhereModel() {
+            return super.internalBuild();
         }
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/AbstractWhereDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/AbstractWhereDSL.java
@@ -30,20 +30,19 @@ public abstract class AbstractWhereDSL<T extends AbstractWhereDSL<T>> {
         super();
     }
     
-    protected <S> AbstractWhereDSL(BindableColumn<S> column, VisitableCondition<S> condition) {
-        SqlCriterion<S> criterion = SqlCriterion.withColumn(column)
-                .withCondition(condition)
-                .build();
-        criteria.add(criterion);
+    public <S> T where(BindableColumn<S> column, VisitableCondition<S> condition) {
+        addCriterion(column, condition);
+        return getThis();
     }
     
-    protected <S> AbstractWhereDSL(BindableColumn<S> column, VisitableCondition<S> condition,
-            SqlCriterion<?>...subCriteria) {
-        SqlCriterion<S> criterion = SqlCriterion.withColumn(column)
-                .withCondition(condition)
-                .withSubCriteria(Arrays.asList(subCriteria))
-                .build();
-        criteria.add(criterion);
+    public <S> T where(BindableColumn<S> column, VisitableCondition<S> condition, SqlCriterion<?>...subCriteria) {
+        addCriterion(column, condition, Arrays.asList(subCriteria));
+        return getThis();
+    }
+    
+    public <S> T where(BindableColumn<S> column, VisitableCondition<S> condition, List<SqlCriterion<?>> subCriteria) {
+        addCriterion(column, condition, subCriteria);
+        return getThis();
     }
     
     public <S> T and(BindableColumn<S> column, VisitableCondition<S> condition) {
@@ -76,10 +75,26 @@ public abstract class AbstractWhereDSL<T extends AbstractWhereDSL<T>> {
         return getThis();
     }
     
+    private <S> void addCriterion(BindableColumn<S> column, VisitableCondition<S> condition) {
+        SqlCriterion<S> criterion = SqlCriterion.withColumn(column)
+                .withCondition(condition)
+                .build();
+        criteria.add(criterion);
+    }
+    
     private <S> void addCriterion(String connector, BindableColumn<S> column, VisitableCondition<S> condition) {
         SqlCriterion<S> criterion = SqlCriterion.withColumn(column)
                 .withConnector(connector)
                 .withCondition(condition)
+                .build();
+        criteria.add(criterion);
+    }
+    
+    private <S> void addCriterion(BindableColumn<S> column, VisitableCondition<S> condition,
+            List<SqlCriterion<?>> subCriteria) {
+        SqlCriterion<S> criterion = SqlCriterion.withColumn(column)
+                .withCondition(condition)
+                .withSubCriteria(subCriteria)
                 .build();
         criteria.add(criterion);
     }
@@ -94,9 +109,11 @@ public abstract class AbstractWhereDSL<T extends AbstractWhereDSL<T>> {
         criteria.add(criterion);
     }
     
-    public WhereModel buildWhereModel() {
+    protected WhereModel internalBuild() {
         return WhereModel.of(criteria);
     }
+    
+    protected abstract WhereModel buildWhereModel();
     
     protected abstract T getThis();
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/WhereApplier.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/WhereApplier.java
@@ -1,0 +1,21 @@
+/**
+ *    Copyright 2016-2019 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.dynamic.sql.where;
+
+import java.util.function.UnaryOperator;
+
+@FunctionalInterface
+public interface WhereApplier extends UnaryOperator<AbstractWhereDSL<?>> {}

--- a/src/main/java/org/mybatis/dynamic/sql/where/WhereDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/WhereDSL.java
@@ -15,22 +15,10 @@
  */
 package org.mybatis.dynamic.sql.where;
 
-import org.mybatis.dynamic.sql.BindableColumn;
-import org.mybatis.dynamic.sql.SqlCriterion;
-import org.mybatis.dynamic.sql.VisitableCondition;
-
 public class WhereDSL extends AbstractWhereDSL<WhereDSL> {
 
     private WhereDSL() {
         super();
-    }
-
-    private <T> WhereDSL(BindableColumn<T> column, VisitableCondition<T> condition) {
-        super(column, condition);
-    }
-
-    private <T> WhereDSL(BindableColumn<T> column, VisitableCondition<T> condition, SqlCriterion<?>... subCriteria) {
-        super(column, condition, subCriteria);
     }
 
     @Override
@@ -42,16 +30,12 @@ public class WhereDSL extends AbstractWhereDSL<WhereDSL> {
         return new WhereDSL();
     }
 
-    public static <T> WhereDSL where(BindableColumn<T> column, VisitableCondition<T> condition) {
-        return new WhereDSL(column, condition);
-    }
-
-    public static <T> WhereDSL where(BindableColumn<T> column, VisitableCondition<T> condition,
-            SqlCriterion<?>... subCriteria) {
-        return new WhereDSL(column, condition, subCriteria);
+    @Override
+    protected WhereModel buildWhereModel() {
+        return super.internalBuild();
     }
 
     public WhereModel build() {
-        return super.buildWhereModel();
+        return buildWhereModel();
     }
 }

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/AbstractWhereDSLExtensions.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/AbstractWhereDSLExtensions.kt
@@ -19,6 +19,8 @@ import org.mybatis.dynamic.sql.BindableColumn
 import org.mybatis.dynamic.sql.VisitableCondition
 import org.mybatis.dynamic.sql.where.AbstractWhereDSL
 
+typealias WhereApplier = AbstractWhereDSL<*>.() -> AbstractWhereDSL<*>
+
 fun <T, M : AbstractWhereDSL<M>> AbstractWhereDSL<M>.where(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver): M {
     val collector = CriteriaCollector()
     collect(collector)

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/AbstractWhereDSLExtensions.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/AbstractWhereDSLExtensions.kt
@@ -19,6 +19,12 @@ import org.mybatis.dynamic.sql.BindableColumn
 import org.mybatis.dynamic.sql.VisitableCondition
 import org.mybatis.dynamic.sql.where.AbstractWhereDSL
 
+fun <T, M : AbstractWhereDSL<M>> AbstractWhereDSL<M>.where(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver): M {
+    val collector = CriteriaCollector()
+    collect(collector)
+    return where(column, condition, collector.criteria)
+}
+
 fun <T, M : AbstractWhereDSL<M>> AbstractWhereDSL<M>.and(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver): M {
     val collector = CriteriaCollector()
     collect(collector)

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/CountDSLExtensions.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/CountDSLExtensions.kt
@@ -25,7 +25,7 @@ typealias CountCompleter = CountDSL<SelectModel>.() -> Buildable<SelectModel>
 
 fun <T> CountDSL<SelectModel>.where(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
     apply {
-        where().and(column, condition, collect)
+        where().where(column, condition, collect)
     }
 
 fun <T> CountDSL<SelectModel>.and(column: BindableColumn<T>, condition: VisitableCondition<T>) =

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/DeleteDSLExtensions.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/DeleteDSLExtensions.kt
@@ -25,7 +25,7 @@ typealias DeleteCompleter = DeleteDSL<DeleteModel>.() -> Buildable<DeleteModel>
 
 fun <T> DeleteDSL<DeleteModel>.where(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
     apply {
-        where().and(column, condition, collect)
+        where().where(column, condition, collect)
     }
 
 fun <T> DeleteDSL<DeleteModel>.and(column: BindableColumn<T>, condition: VisitableCondition<T>) =

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/QueryExpressionDSLExtensions.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/QueryExpressionDSLExtensions.kt
@@ -25,7 +25,7 @@ typealias SelectCompleter = QueryExpressionDSL<SelectModel>.() -> Buildable<Sele
 
 fun <T> QueryExpressionDSL<SelectModel>.where(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
     apply {
-        where().and(column, condition, collect)
+        where().where(column, condition, collect)
     }
 
 fun <T> QueryExpressionDSL<SelectModel>.and(column: BindableColumn<T>, condition: VisitableCondition<T>) =

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/UpdateDSLExtensions.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/UpdateDSLExtensions.kt
@@ -31,7 +31,7 @@ typealias UpdateCompleter = UpdateDSL<UpdateModel>.() -> Buildable<UpdateModel>
 
 fun <T> UpdateDSL<UpdateModel>.where(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
     apply {
-        where().and(column, condition, collect)
+        where().where(column, condition, collect)
     }
 
 fun <T> UpdateDSL<UpdateModel>.and(column: BindableColumn<T>, condition: VisitableCondition<T>) =

--- a/src/test/java/examples/simple/ReusableWhereTest.java
+++ b/src/test/java/examples/simple/ReusableWhereTest.java
@@ -1,0 +1,115 @@
+/**
+ *    Copyright 2016-2019 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package examples.simple;
+
+import static examples.simple.PersonDynamicSqlSupport.id;
+import static examples.simple.PersonDynamicSqlSupport.occupation;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mybatis.dynamic.sql.SqlBuilder.isEqualTo;
+import static org.mybatis.dynamic.sql.SqlBuilder.isNull;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.util.List;
+
+import org.apache.ibatis.datasource.unpooled.UnpooledDataSource;
+import org.apache.ibatis.jdbc.ScriptRunner;
+import org.apache.ibatis.mapping.Environment;
+import org.apache.ibatis.session.Configuration;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mybatis.dynamic.sql.where.AbstractWhereDSL;
+
+public class ReusableWhereTest {
+
+    private static final String JDBC_URL = "jdbc:hsqldb:mem:aname";
+    private static final String JDBC_DRIVER = "org.hsqldb.jdbcDriver";
+
+    private SqlSessionFactory sqlSessionFactory;
+
+    @BeforeEach
+    public void setup() throws Exception {
+        Class.forName(JDBC_DRIVER);
+        InputStream is = getClass().getResourceAsStream("/examples/simple/CreateSimpleDB.sql");
+        try (Connection connection = DriverManager.getConnection(JDBC_URL, "sa", "")) {
+            ScriptRunner sr = new ScriptRunner(connection);
+            sr.setLogWriter(null);
+            sr.runScript(new InputStreamReader(is));
+        }
+
+        UnpooledDataSource ds = new UnpooledDataSource(JDBC_DRIVER, JDBC_URL, "sa", "");
+        Environment environment = new Environment("test", new JdbcTransactionFactory(), ds);
+        Configuration config = new Configuration(environment);
+        config.addMapper(PersonMapper.class);
+        config.addMapper(PersonWithAddressMapper.class);
+        sqlSessionFactory = new SqlSessionFactoryBuilder().build(config);
+    }
+
+    @Test
+    public void testCount() {
+        try (SqlSession session = sqlSessionFactory.openSession()) {
+            PersonMapper mapper = session.getMapper(PersonMapper.class);
+
+            long rows = mapper.count(c -> c.applyWhere(this::commonWhere));
+
+            assertThat(rows).isEqualTo(3);
+        }
+    }
+
+    @Test
+    public void testDelete() {
+        try (SqlSession session = sqlSessionFactory.openSession()) {
+            PersonMapper mapper = session.getMapper(PersonMapper.class);
+
+            int rows = mapper.delete(c -> c.applyWhere(this::commonWhere));
+
+            assertThat(rows).isEqualTo(3);
+        }
+    }
+
+    @Test
+    public void testSelect() {
+        try (SqlSession session = sqlSessionFactory.openSession()) {
+            PersonMapper mapper = session.getMapper(PersonMapper.class);
+
+            List<PersonRecord> rows = mapper.select(c -> c.applyWhere(this::commonWhere).orderBy(id));
+
+            assertThat(rows.size()).isEqualTo(3);
+        }
+    }
+
+    @Test
+    public void testUpdate() {
+        try (SqlSession session = sqlSessionFactory.openSession()) {
+            PersonMapper mapper = session.getMapper(PersonMapper.class);
+
+            int rows = mapper
+                    .update(c -> c.set(occupation).equalToStringConstant("worker").applyWhere(this::commonWhere));
+
+            assertThat(rows).isEqualTo(3);
+        }
+    }
+
+    private AbstractWhereDSL<?> commonWhere(AbstractWhereDSL<?> dsl) {
+        return dsl.where(id, isEqualTo(1)).or(occupation, isNull());
+    }
+}

--- a/src/test/java/examples/simple/ReusableWhereTest.java
+++ b/src/test/java/examples/simple/ReusableWhereTest.java
@@ -91,7 +91,9 @@ public class ReusableWhereTest {
         try (SqlSession session = sqlSessionFactory.openSession()) {
             PersonMapper mapper = session.getMapper(PersonMapper.class);
 
-            List<PersonRecord> rows = mapper.select(c -> c.applyWhere(this::commonWhere).orderBy(id));
+            List<PersonRecord> rows = mapper.select(c ->
+                c.applyWhere(this::commonWhere)
+                .orderBy(id));
 
             assertThat(rows.size()).isEqualTo(3);
         }
@@ -102,8 +104,9 @@ public class ReusableWhereTest {
         try (SqlSession session = sqlSessionFactory.openSession()) {
             PersonMapper mapper = session.getMapper(PersonMapper.class);
 
-            int rows = mapper
-                    .update(c -> c.set(occupation).equalToStringConstant("worker").applyWhere(this::commonWhere));
+            int rows = mapper.update(c ->
+                c.set(occupation).equalToStringConstant("worker")
+                .applyWhere(this::commonWhere));
 
             assertThat(rows).isEqualTo(3);
         }

--- a/src/test/java/examples/simple/ReusableWhereTest.java
+++ b/src/test/java/examples/simple/ReusableWhereTest.java
@@ -37,7 +37,7 @@ import org.apache.ibatis.session.SqlSessionFactoryBuilder;
 import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mybatis.dynamic.sql.where.AbstractWhereDSL;
+import org.mybatis.dynamic.sql.where.WhereApplier;
 
 public class ReusableWhereTest {
 
@@ -69,7 +69,7 @@ public class ReusableWhereTest {
         try (SqlSession session = sqlSessionFactory.openSession()) {
             PersonMapper mapper = session.getMapper(PersonMapper.class);
 
-            long rows = mapper.count(c -> c.applyWhere(this::commonWhere));
+            long rows = mapper.count(c -> c.applyWhere(commonWhere));
 
             assertThat(rows).isEqualTo(3);
         }
@@ -80,7 +80,7 @@ public class ReusableWhereTest {
         try (SqlSession session = sqlSessionFactory.openSession()) {
             PersonMapper mapper = session.getMapper(PersonMapper.class);
 
-            int rows = mapper.delete(c -> c.applyWhere(this::commonWhere));
+            int rows = mapper.delete(c -> c.applyWhere(commonWhere));
 
             assertThat(rows).isEqualTo(3);
         }
@@ -92,7 +92,7 @@ public class ReusableWhereTest {
             PersonMapper mapper = session.getMapper(PersonMapper.class);
 
             List<PersonRecord> rows = mapper.select(c ->
-                c.applyWhere(this::commonWhere)
+                c.applyWhere(commonWhere)
                 .orderBy(id));
 
             assertThat(rows.size()).isEqualTo(3);
@@ -106,13 +106,11 @@ public class ReusableWhereTest {
 
             int rows = mapper.update(c ->
                 c.set(occupation).equalToStringConstant("worker")
-                .applyWhere(this::commonWhere));
+                .applyWhere(commonWhere));
 
             assertThat(rows).isEqualTo(3);
         }
     }
 
-    private AbstractWhereDSL<?> commonWhere(AbstractWhereDSL<?> dsl) {
-        return dsl.where(id, isEqualTo(1)).or(occupation, isNull());
-    }
+    private WhereApplier commonWhere =  d -> d.where(id, isEqualTo(1)).or(occupation, isNull());
 }

--- a/src/test/kotlin/examples/kotlin/mybatis3/canonical/ReusableWhereTest.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/canonical/ReusableWhereTest.kt
@@ -1,0 +1,114 @@
+/**
+ *    Copyright 2016-2019 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package examples.kotlin.mybatis3.canonical
+
+import examples.kotlin.mybatis3.canonical.PersonDynamicSqlSupport.Person.id
+import examples.kotlin.mybatis3.canonical.PersonDynamicSqlSupport.Person.occupation
+import org.apache.ibatis.datasource.unpooled.UnpooledDataSource
+import org.apache.ibatis.jdbc.ScriptRunner
+import org.apache.ibatis.mapping.Environment
+import org.apache.ibatis.session.Configuration
+import org.apache.ibatis.session.SqlSession
+import org.apache.ibatis.session.SqlSessionFactoryBuilder
+import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mybatis.dynamic.sql.SqlBuilder.isEqualTo
+import org.mybatis.dynamic.sql.SqlBuilder.isNull
+import org.mybatis.dynamic.sql.where.AbstractWhereDSL
+import java.io.InputStreamReader
+import java.sql.DriverManager
+
+class ReusableWhereTest {
+    private fun newSession(): SqlSession {
+        Class.forName(JDBC_DRIVER)
+        val script = javaClass.getResourceAsStream("/examples/kotlin/mybatis3/CreateSimpleDB.sql")
+        DriverManager.getConnection(JDBC_URL, "sa", "").use { connection ->
+            val sr = ScriptRunner(connection)
+            sr.setLogWriter(null)
+            sr.runScript(InputStreamReader(script))
+        }
+
+        val ds = UnpooledDataSource(JDBC_DRIVER, JDBC_URL, "sa", "")
+        val environment = Environment("test", JdbcTransactionFactory(), ds)
+        val config = Configuration(environment)
+        config.typeHandlerRegistry.register(YesNoTypeHandler::class.java)
+        config.addMapper(PersonMapper::class.java)
+        config.addMapper(PersonWithAddressMapper::class.java)
+        return SqlSessionFactoryBuilder().build(config).openSession()
+    }
+
+    @Test
+    fun testCount() {
+        newSession().use { session ->
+            val mapper = session.getMapper(PersonMapper::class.java)
+
+            val rows = mapper.count {
+                applyWhere (::commonWhere)
+            }
+
+            assertThat(rows).isEqualTo(3)
+        }
+    }
+
+    @Test
+    fun testDelete() {
+        newSession().use { session ->
+            val mapper = session.getMapper(PersonMapper::class.java)
+
+            val rows = mapper.delete {
+                applyWhere (::commonWhere)
+            }
+
+            assertThat(rows).isEqualTo(3)
+        }
+    }
+
+    @Test
+    fun testSelect() {
+        newSession().use { session ->
+            val mapper = session.getMapper(PersonMapper::class.java)
+
+            val rows = mapper.select {
+                applyWhere (::commonWhere)
+            }
+
+            assertThat(rows.size).isEqualTo(3)
+        }
+    }
+
+    @Test
+    fun testUpdate() {
+        newSession().use { session ->
+            val mapper = session.getMapper(PersonMapper::class.java)
+
+            val rows = mapper.update {
+                set(occupation).equalToStringConstant("worker")
+                applyWhere (::commonWhere)
+            }
+
+            assertThat(rows).isEqualTo(3)
+        }
+    }
+
+    private fun commonWhere(dsl: AbstractWhereDSL<*>): AbstractWhereDSL<*> =
+            dsl.where(id, isEqualTo(1)).or(occupation, isNull());
+
+    companion object {
+        const val JDBC_URL = "jdbc:hsqldb:mem:aname"
+        const val JDBC_DRIVER = "org.hsqldb.jdbcDriver"
+    }
+}

--- a/src/test/kotlin/examples/kotlin/mybatis3/canonical/ReusableWhereTest.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/canonical/ReusableWhereTest.kt
@@ -28,7 +28,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mybatis.dynamic.sql.SqlBuilder.isEqualTo
 import org.mybatis.dynamic.sql.SqlBuilder.isNull
-import org.mybatis.dynamic.sql.where.AbstractWhereDSL
+import org.mybatis.dynamic.sql.util.kotlin.WhereApplier
 import java.io.InputStreamReader
 import java.sql.DriverManager
 
@@ -57,7 +57,7 @@ class ReusableWhereTest {
             val mapper = session.getMapper(PersonMapper::class.java)
 
             val rows = mapper.count {
-                applyWhere (::commonWhere)
+                applyWhere (commonWhere)
             }
 
             assertThat(rows).isEqualTo(3)
@@ -70,7 +70,7 @@ class ReusableWhereTest {
             val mapper = session.getMapper(PersonMapper::class.java)
 
             val rows = mapper.delete {
-                applyWhere (::commonWhere)
+                applyWhere (commonWhere)
             }
 
             assertThat(rows).isEqualTo(3)
@@ -83,7 +83,7 @@ class ReusableWhereTest {
             val mapper = session.getMapper(PersonMapper::class.java)
 
             val rows = mapper.select {
-                applyWhere (::commonWhere)
+                applyWhere (commonWhere)
                 orderBy(id)
             }
 
@@ -98,15 +98,16 @@ class ReusableWhereTest {
 
             val rows = mapper.update {
                 set(occupation).equalToStringConstant("worker")
-                applyWhere (::commonWhere)
+                applyWhere (commonWhere)
             }
 
             assertThat(rows).isEqualTo(3)
         }
     }
 
-    private fun commonWhere(dsl: AbstractWhereDSL<*>): AbstractWhereDSL<*> =
-            dsl.where(id, isEqualTo(1)).or(occupation, isNull());
+    private val commonWhere: WhereApplier = {
+        where(id, isEqualTo(1)).or(occupation, isNull<String>())
+    }
 
     companion object {
         const val JDBC_URL = "jdbc:hsqldb:mem:aname"

--- a/src/test/kotlin/examples/kotlin/mybatis3/canonical/ReusableWhereTest.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/canonical/ReusableWhereTest.kt
@@ -84,6 +84,7 @@ class ReusableWhereTest {
 
             val rows = mapper.select {
                 applyWhere (::commonWhere)
+                orderBy(id)
             }
 
             assertThat(rows.size).isEqualTo(3)


### PR DESCRIPTION
Count, Delete, Select, and Update statements all support a WHERE clause. With this PR, users can create a common where clause and reuse it in any statement.

For example, a where clause could be shared across a count and a select query. The count query could be used to return a total, and that value could be used to calculate paging queries.
