### PR TITLE
Improve Kotlin Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ GitHub milestone: [https://github.com/mybatis/mybatis-dynamic-sql/issues?q=miles
 ### Added
 
 - Added support for reusing WHERE clauses among count, delete, select, and update statements ([#152](https://github.com/mybatis/mybatis-dynamic-sql/pull/152))
-- Improved Kotlin support. Previously, several overloaded methods could collide causing queries to be fragile and very dependent on having the correct imports in a Kotlin file. With this improved support there is no longer any ambiguity.
+- Improved Kotlin support. Previously, several overloaded methods could collide causing queries to be fragile and very dependent on having the correct imports in a Kotlin file. With this improved support there is no longer any ambiguity. ([#154](https://github.com/mybatis/mybatis-dynamic-sql/pull/154))
 
 ### Bugs Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ GitHub milestone: [https://github.com/mybatis/mybatis-dynamic-sql/issues?q=miles
 ### Added
 
 - Added support for reusing WHERE clauses among count, delete, select, and update statements ([#152](https://github.com/mybatis/mybatis-dynamic-sql/pull/152))
-
+- Improved Kotlin support. Previously, several overloaded methods could collide causing queries to be fragile and very dependent on having the correct imports in a Kotlin file. With this improved support there is no longer any ambiguity.
 
 ### Bugs Fixed
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
     <sonar.sources>pom.xml,src/main/java,src/main/kotlin</sonar.sources>
     <sonar.tests>src/test/java,src/test/kotlin</sonar.tests>
     <jacoco.version>0.8.4</jacoco.version>
+    <kotlin.code.style>official</kotlin.code.style>
   </properties>
 
   <build>

--- a/src/main/java/org/mybatis/dynamic/sql/delete/DeleteDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/delete/DeleteDSL.java
@@ -15,7 +15,6 @@
  */
 package org.mybatis.dynamic.sql.delete;
 
-import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.ToIntFunction;
@@ -48,12 +47,6 @@ public class DeleteDSL<R> implements Buildable<R> {
     
     public <T> DeleteWhereBuilder where(BindableColumn<T> column, VisitableCondition<T> condition,
             SqlCriterion<?>...subCriteria) {
-        whereBuilder.where(column, condition, subCriteria);
-        return whereBuilder;
-    }
-
-    public <T> DeleteWhereBuilder where(BindableColumn<T> column, VisitableCondition<T> condition,
-            List<SqlCriterion<?>> subCriteria) {
         whereBuilder.where(column, condition, subCriteria);
         return whereBuilder;
     }

--- a/src/main/java/org/mybatis/dynamic/sql/delete/DeleteDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/delete/DeleteDSL.java
@@ -51,9 +51,8 @@ public class DeleteDSL<R> implements Buildable<R> {
         return whereBuilder;
     }
 
-    @SuppressWarnings("unchecked")
     public DeleteWhereBuilder applyWhere(WhereApplier whereApplier) {
-        return (DeleteWhereBuilder) whereApplier.apply(whereBuilder);
+        return whereBuilder.applyWhere(whereApplier);
     }
 
     /**
@@ -99,7 +98,7 @@ public class DeleteDSL<R> implements Buildable<R> {
         private DeleteWhereBuilder() {
             super();
         }
-        
+
         @Override
         public R build() {
             return DeleteDSL.this.build();

--- a/src/main/java/org/mybatis/dynamic/sql/delete/DeleteDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/delete/DeleteDSL.java
@@ -15,6 +15,7 @@
  */
 package org.mybatis.dynamic.sql.delete;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.ToIntFunction;
@@ -47,6 +48,12 @@ public class DeleteDSL<R> implements Buildable<R> {
     
     public <T> DeleteWhereBuilder where(BindableColumn<T> column, VisitableCondition<T> condition,
             SqlCriterion<?>...subCriteria) {
+        whereBuilder.where(column, condition, subCriteria);
+        return whereBuilder;
+    }
+
+    public <T> DeleteWhereBuilder where(BindableColumn<T> column, VisitableCondition<T> condition,
+            List<SqlCriterion<?>> subCriteria) {
         whereBuilder.where(column, condition, subCriteria);
         return whereBuilder;
     }

--- a/src/main/java/org/mybatis/dynamic/sql/select/CountDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/CountDSL.java
@@ -15,7 +15,6 @@
  */
 package org.mybatis.dynamic.sql.select;
 
-import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
 
@@ -54,12 +53,6 @@ public class CountDSL<R> extends AbstractQueryExpressionDSL<CountDSL<R>, R> impl
 
     public <T> CountWhereBuilder where(BindableColumn<T> column, VisitableCondition<T> condition,
             SqlCriterion<?>...subCriteria) {
-        whereBuilder.where(column, condition, subCriteria);
-        return whereBuilder;
-    }
-
-    public <T> CountWhereBuilder where(BindableColumn<T> column, VisitableCondition<T> condition,
-            List<SqlCriterion<?>> subCriteria) {
         whereBuilder.where(column, condition, subCriteria);
         return whereBuilder;
     }

--- a/src/main/java/org/mybatis/dynamic/sql/select/CountDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/CountDSL.java
@@ -57,9 +57,8 @@ public class CountDSL<R> extends AbstractQueryExpressionDSL<CountDSL<R>, R> impl
         return whereBuilder;
     }
 
-    @SuppressWarnings("unchecked")
     public CountWhereBuilder applyWhere(WhereApplier whereApplier) {
-        return (CountWhereBuilder) whereApplier.apply(whereBuilder);
+        return whereBuilder.applyWhere(whereApplier);
     }
 
     @Override

--- a/src/main/java/org/mybatis/dynamic/sql/select/CountDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/CountDSL.java
@@ -15,6 +15,7 @@
  */
 package org.mybatis.dynamic.sql.select;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
 
@@ -53,6 +54,12 @@ public class CountDSL<R> extends AbstractQueryExpressionDSL<CountDSL<R>, R> impl
 
     public <T> CountWhereBuilder where(BindableColumn<T> column, VisitableCondition<T> condition,
             SqlCriterion<?>...subCriteria) {
+        whereBuilder.where(column, condition, subCriteria);
+        return whereBuilder;
+    }
+
+    public <T> CountWhereBuilder where(BindableColumn<T> column, VisitableCondition<T> condition,
+            List<SqlCriterion<?>> subCriteria) {
         whereBuilder.where(column, condition, subCriteria);
         return whereBuilder;
     }

--- a/src/main/java/org/mybatis/dynamic/sql/select/QueryExpressionDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/QueryExpressionDSL.java
@@ -69,6 +69,12 @@ public class QueryExpressionDSL<R> extends AbstractQueryExpressionDSL<QueryExpre
         return whereBuilder;
     }
 
+    public <T> QueryExpressionWhereBuilder where(BindableColumn<T> column, VisitableCondition<T> condition,
+            List<SqlCriterion<?>> subCriteria) {
+        whereBuilder.where(column, condition, subCriteria);
+        return whereBuilder;
+    }
+
     @SuppressWarnings("unchecked")
     public QueryExpressionWhereBuilder applyWhere(WhereApplier whereApplier) {
         return (QueryExpressionWhereBuilder) whereApplier.apply(whereBuilder);

--- a/src/main/java/org/mybatis/dynamic/sql/select/QueryExpressionDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/QueryExpressionDSL.java
@@ -69,12 +69,6 @@ public class QueryExpressionDSL<R> extends AbstractQueryExpressionDSL<QueryExpre
         return whereBuilder;
     }
 
-    public <T> QueryExpressionWhereBuilder where(BindableColumn<T> column, VisitableCondition<T> condition,
-            List<SqlCriterion<?>> subCriteria) {
-        whereBuilder.where(column, condition, subCriteria);
-        return whereBuilder;
-    }
-
     @SuppressWarnings("unchecked")
     public QueryExpressionWhereBuilder applyWhere(WhereApplier whereApplier) {
         return (QueryExpressionWhereBuilder) whereApplier.apply(whereBuilder);

--- a/src/main/java/org/mybatis/dynamic/sql/select/QueryExpressionDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/QueryExpressionDSL.java
@@ -69,9 +69,8 @@ public class QueryExpressionDSL<R> extends AbstractQueryExpressionDSL<QueryExpre
         return whereBuilder;
     }
 
-    @SuppressWarnings("unchecked")
     public QueryExpressionWhereBuilder applyWhere(WhereApplier whereApplier) {
-        return (QueryExpressionWhereBuilder) whereApplier.apply(whereBuilder);
+        return whereBuilder.applyWhere(whereApplier);
     }
 
     @Override

--- a/src/main/java/org/mybatis/dynamic/sql/update/UpdateDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/update/UpdateDSL.java
@@ -69,12 +69,6 @@ public class UpdateDSL<R> implements Buildable<R> {
         return whereBuilder;
     }
 
-    public <T> UpdateWhereBuilder where(BindableColumn<T> column, VisitableCondition<T> condition,
-            List<SqlCriterion<?>> subCriteria) {
-        whereBuilder.where(column, condition, subCriteria);
-        return whereBuilder;
-    }
-
     @SuppressWarnings("unchecked")
     public UpdateWhereBuilder applyWhere(WhereApplier whereApplier) {
         return (UpdateWhereBuilder) whereApplier.apply(whereBuilder);

--- a/src/main/java/org/mybatis/dynamic/sql/update/UpdateDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/update/UpdateDSL.java
@@ -69,9 +69,8 @@ public class UpdateDSL<R> implements Buildable<R> {
         return whereBuilder;
     }
 
-    @SuppressWarnings("unchecked")
     public UpdateWhereBuilder applyWhere(WhereApplier whereApplier) {
-        return (UpdateWhereBuilder) whereApplier.apply(whereBuilder);
+        return whereBuilder.applyWhere(whereApplier);
     }
 
     /**

--- a/src/main/java/org/mybatis/dynamic/sql/update/UpdateDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/update/UpdateDSL.java
@@ -69,6 +69,12 @@ public class UpdateDSL<R> implements Buildable<R> {
         return whereBuilder;
     }
 
+    public <T> UpdateWhereBuilder where(BindableColumn<T> column, VisitableCondition<T> condition,
+            List<SqlCriterion<?>> subCriteria) {
+        whereBuilder.where(column, condition, subCriteria);
+        return whereBuilder;
+    }
+
     @SuppressWarnings("unchecked")
     public UpdateWhereBuilder applyWhere(WhereApplier whereApplier) {
         return (UpdateWhereBuilder) whereApplier.apply(whereBuilder);

--- a/src/main/java/org/mybatis/dynamic/sql/where/AbstractWhereDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/AbstractWhereDSL.java
@@ -44,7 +44,12 @@ public abstract class AbstractWhereDSL<T extends AbstractWhereDSL<T>> {
         addCriterion(column, condition, subCriteria);
         return getThis();
     }
-    
+
+    @SuppressWarnings("unchecked")
+    public T applyWhere(WhereApplier whereApplier) {
+        return (T) whereApplier.apply(this);
+    }
+
     public <S> T and(BindableColumn<S> column, VisitableCondition<S> condition) {
         addCriterion("and", column, condition); //$NON-NLS-1$
         return getThis();

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/CountDSLExtensions.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/CountDSLExtensions.kt
@@ -16,36 +16,113 @@
 package org.mybatis.dynamic.sql.util.kotlin
 
 import org.mybatis.dynamic.sql.BindableColumn
+import org.mybatis.dynamic.sql.SqlTable
 import org.mybatis.dynamic.sql.VisitableCondition
 import org.mybatis.dynamic.sql.select.CountDSL
 import org.mybatis.dynamic.sql.select.SelectModel
-import org.mybatis.dynamic.sql.util.Buildable
 
-typealias CountCompleter = CountDSL<SelectModel>.() -> Buildable<SelectModel>
+typealias CountCompleter = KotlinCountBuilder.() -> KotlinCountBuilder
 
-fun <T> CountDSL<SelectModel>.where(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
-    apply {
-        where().where(column, condition, collect)
-    }
+class KotlinCountBuilder(val dsl: CountDSL<SelectModel>) {
+    fun join(table: SqlTable, receiver: JoinReceiver) =
+            apply {
+                val collector = JoinCollector()
+                receiver(collector)
+                dsl.join(table, collector.onJoinCriterion, collector.andJoinCriteria)
+            }
 
-fun <T> CountDSL<SelectModel>.and(column: BindableColumn<T>, condition: VisitableCondition<T>) =
-    apply {
-        where().and(column, condition)
-    }
+    fun join(table: SqlTable, alias: String, receiver: JoinReceiver) =
+            apply {
+                val collector = JoinCollector()
+                receiver(collector)
+                dsl.join(table, alias, collector.onJoinCriterion, collector.andJoinCriteria)
+            }
 
-fun <T> CountDSL<SelectModel>.and(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
-    apply {
-        where().and(column, condition, collect)
-    }
+    fun fullJoin(table: SqlTable, receiver: JoinReceiver) =
+            apply {
+                val collector = JoinCollector()
+                receiver(collector)
+                dsl.fullJoin(table, collector.onJoinCriterion, collector.andJoinCriteria)
+            }
 
-fun <T> CountDSL<SelectModel>.or(column: BindableColumn<T>, condition: VisitableCondition<T>) =
-    apply {
-        where().or(column, condition)
-    }
+    fun fullJoin(table: SqlTable, alias: String, receiver: JoinReceiver) =
+            apply {
+                val collector = JoinCollector()
+                receiver(collector)
+                dsl.fullJoin(table, alias, collector.onJoinCriterion, collector.andJoinCriteria)
+            }
 
-fun <T> CountDSL<SelectModel>.or(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
-    apply {
-        where().or(column, condition, collect)
-    }
+    fun leftJoin(table: SqlTable, receiver: JoinReceiver) =
+            apply {
+                val collector = JoinCollector()
+                receiver(collector)
+                dsl.leftJoin(table, collector.onJoinCriterion, collector.andJoinCriteria)
+            }
 
-fun CountDSL<SelectModel>.allRows() = this as Buildable<SelectModel>
+    fun leftJoin(table: SqlTable, alias: String, receiver: JoinReceiver) =
+            apply {
+                val collector = JoinCollector()
+                receiver(collector)
+                dsl.leftJoin(table, alias, collector.onJoinCriterion, collector.andJoinCriteria)
+            }
+
+    fun rightJoin(table: SqlTable, receiver: JoinReceiver) =
+            apply {
+                val collector = JoinCollector()
+                receiver(collector)
+                dsl.rightJoin(table, collector.onJoinCriterion, collector.andJoinCriteria)
+            }
+
+    fun rightJoin(table: SqlTable, alias: String, receiver: JoinReceiver) =
+            apply {
+                val collector = JoinCollector()
+                receiver(collector)
+                dsl.rightJoin(table, alias, collector.onJoinCriterion, collector.andJoinCriteria)
+            }
+
+    fun <T> where(column: BindableColumn<T>, condition: VisitableCondition<T>) =
+            apply {
+                dsl.where(column, condition)
+            }
+
+    fun <T> where(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
+            apply {
+                val collector = CriteriaCollector()
+                collect(collector)
+                // TODO...awkward
+                dsl.where(column, condition, *collector.criteria.toTypedArray())
+            }
+
+    fun applyWhere(whereApplier: WhereApplier) =
+            apply {
+                dsl.applyWhere(whereApplier)
+            }
+
+    fun <T> and(column: BindableColumn<T>, condition: VisitableCondition<T>) =
+            apply {
+                dsl.where().and(column, condition)
+            }
+
+    fun <T> and(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
+            apply {
+                val collector = CriteriaCollector()
+                collect(collector)
+                // TODO...awkward
+                dsl.where().and(column, condition, *collector.criteria.toTypedArray())
+            }
+
+    fun <T> or(column: BindableColumn<T>, condition: VisitableCondition<T>) =
+            apply {
+                dsl.where().or(column, condition)
+            }
+
+    fun <T> or(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
+            apply {
+                val collector = CriteriaCollector()
+                collect(collector)
+                // TODO...awkward
+                dsl.where().or(column, condition, *collector.criteria.toTypedArray())
+            }
+
+    fun allRows() = this
+}

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/DeleteDSLExtensions.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/DeleteDSLExtensions.kt
@@ -19,33 +19,53 @@ import org.mybatis.dynamic.sql.BindableColumn
 import org.mybatis.dynamic.sql.VisitableCondition
 import org.mybatis.dynamic.sql.delete.DeleteDSL
 import org.mybatis.dynamic.sql.delete.DeleteModel
-import org.mybatis.dynamic.sql.util.Buildable
 
-typealias DeleteCompleter = DeleteDSL<DeleteModel>.() -> Buildable<DeleteModel>
+typealias DeleteCompleter = KotlinDeleteBuilder.() -> KotlinDeleteBuilder
 
-fun <T> DeleteDSL<DeleteModel>.where(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
-    apply {
-        where().where(column, condition, collect)
-    }
+class KotlinDeleteBuilder(val dsl: DeleteDSL<DeleteModel>) {
+    fun <T> where(column: BindableColumn<T>, condition: VisitableCondition<T>) =
+            apply {
+                dsl.where(column, condition)
+            }
 
-fun <T> DeleteDSL<DeleteModel>.and(column: BindableColumn<T>, condition: VisitableCondition<T>) =
-    apply {
-        where().and(column, condition)
-    }
+    fun <T> where(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
+            apply {
+                val collector = CriteriaCollector()
+                collect(collector)
+                // TODO...awkward
+                dsl.where(column, condition, *collector.criteria.toTypedArray())
+            }
 
-fun <T> DeleteDSL<DeleteModel>.and(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
-    apply {
-        where().and(column, condition, collect)
-    }
+    fun applyWhere(whereApplier: WhereApplier) =
+            apply {
+                dsl.applyWhere(whereApplier)
+            }
 
-fun <T> DeleteDSL<DeleteModel>.or(column: BindableColumn<T>, condition: VisitableCondition<T>) =
-    apply {
-        where().or(column, condition)
-    }
+    fun <T> and(column: BindableColumn<T>, condition: VisitableCondition<T>) =
+            apply {
+                dsl.where().and(column, condition)
+            }
 
-fun <T> DeleteDSL<DeleteModel>.or(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
-    apply {
-        where().or(column, condition, collect)
-    }
+    fun <T> and(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
+            apply {
+                val collector = CriteriaCollector()
+                collect(collector)
+                // TODO...awkward
+                dsl.where().and(column, condition, *collector.criteria.toTypedArray())
+            }
 
-fun DeleteDSL<DeleteModel>.allRows() = this as Buildable<DeleteModel>
+    fun <T> or(column: BindableColumn<T>, condition: VisitableCondition<T>) =
+            apply {
+                dsl.where().or(column, condition)
+            }
+
+    fun <T> or(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
+            apply {
+                val collector = CriteriaCollector()
+                collect(collector)
+                // TODO...awkward
+                dsl.where().or(column, condition, *collector.criteria.toTypedArray())
+            }
+
+    fun allRows() = this
+}

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinBaseBuilders.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinBaseBuilders.kt
@@ -1,0 +1,108 @@
+/**
+ *    Copyright 2016-2019 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.dynamic.sql.util.kotlin
+
+import org.mybatis.dynamic.sql.BindableColumn
+import org.mybatis.dynamic.sql.SqlTable
+import org.mybatis.dynamic.sql.VisitableCondition
+import org.mybatis.dynamic.sql.select.AbstractQueryExpressionDSL
+import org.mybatis.dynamic.sql.select.SelectModel
+import org.mybatis.dynamic.sql.util.Buildable
+import org.mybatis.dynamic.sql.where.AbstractWhereDSL
+
+abstract class KotlinBaseBuilder<M, W : AbstractWhereDSL<W>, B : KotlinBaseBuilder<M, W, B>> : Buildable<M> {
+    fun <T> where(column: BindableColumn<T>, condition: VisitableCondition<T>): B {
+        getWhere().where(column, condition)
+        return getThis()
+    }
+
+    fun <T> where(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver): B {
+        getWhere().where(column, condition, collect)
+        return getThis()
+    }
+
+    fun applyWhere(whereApplier: WhereApplier): B {
+        getWhere().applyWhere(whereApplier)
+        return getThis()
+    }
+
+    fun <T> and(column: BindableColumn<T>, condition: VisitableCondition<T>): B {
+        getWhere().and(column, condition)
+        return getThis()
+    }
+
+    fun <T> and(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver): B {
+        getWhere().and(column, condition, collect)
+        return getThis()
+    }
+
+    fun <T> or(column: BindableColumn<T>, condition: VisitableCondition<T>): B {
+        getWhere().or(column, condition)
+        return getThis()
+    }
+
+    fun <T> or(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver): B {
+        getWhere().or(column, condition, collect)
+        return getThis()
+    }
+
+    protected abstract fun getWhere(): W
+    protected abstract fun getThis(): B
+}
+
+abstract class KotlinBaseJoiningBuilder<T : AbstractQueryExpressionDSL<T, SelectModel>, W: AbstractWhereDSL<W>, B : KotlinBaseJoiningBuilder<T, W, B>>(private val dsl: AbstractQueryExpressionDSL<T, SelectModel>) :
+    KotlinBaseBuilder<SelectModel, W, B>() {
+
+    fun join(table: SqlTable, receiver: JoinReceiver) =
+            apply {
+                dsl.join(table, receiver)
+            }
+
+    fun join(table: SqlTable, alias: String, receiver: JoinReceiver) =
+            apply {
+                dsl.join(table, alias, receiver)
+            }
+
+    fun fullJoin(table: SqlTable, receiver: JoinReceiver) =
+            apply {
+                dsl.fullJoin(table, receiver)
+            }
+
+    fun fullJoin(table: SqlTable, alias: String, receiver: JoinReceiver) =
+            apply {
+                dsl.fullJoin(table, alias, receiver)
+            }
+
+    fun leftJoin(table: SqlTable, receiver: JoinReceiver) =
+            apply {
+                dsl.leftJoin(table, receiver)
+            }
+
+    fun leftJoin(table: SqlTable, alias: String, receiver: JoinReceiver) =
+            apply {
+                dsl.leftJoin(table, alias, receiver)
+            }
+
+    fun rightJoin(table: SqlTable, receiver: JoinReceiver) =
+            apply {
+                dsl.rightJoin(table, receiver)
+            }
+
+    fun rightJoin(table: SqlTable, alias: String, receiver: JoinReceiver) =
+            apply {
+                dsl.rightJoin(table, alias, receiver)
+            }
+}

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinCountBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinCountBuilder.kt
@@ -15,92 +15,20 @@
  */
 package org.mybatis.dynamic.sql.util.kotlin
 
-import org.mybatis.dynamic.sql.BindableColumn
-import org.mybatis.dynamic.sql.SqlTable
-import org.mybatis.dynamic.sql.VisitableCondition
 import org.mybatis.dynamic.sql.select.CountDSL
 import org.mybatis.dynamic.sql.select.SelectModel
 import org.mybatis.dynamic.sql.util.Buildable
 
 typealias CountCompleter = KotlinCountBuilder.() -> Buildable<SelectModel>
 
-class KotlinCountBuilder(private val dsl: CountDSL<SelectModel>): Buildable<SelectModel> {
-    fun join(table: SqlTable, receiver: JoinReceiver) =
-            apply {
-                dsl.join(table, receiver)
-            }
-
-    fun join(table: SqlTable, alias: String, receiver: JoinReceiver) =
-            apply {
-                dsl.join(table, alias, receiver)
-            }
-
-    fun fullJoin(table: SqlTable, receiver: JoinReceiver) =
-            apply {
-                dsl.fullJoin(table, receiver)
-            }
-
-    fun fullJoin(table: SqlTable, alias: String, receiver: JoinReceiver) =
-            apply {
-                dsl.fullJoin(table, alias, receiver)
-            }
-
-    fun leftJoin(table: SqlTable, receiver: JoinReceiver) =
-            apply {
-                dsl.leftJoin(table, receiver)
-            }
-
-    fun leftJoin(table: SqlTable, alias: String, receiver: JoinReceiver) =
-            apply {
-                dsl.leftJoin(table, alias, receiver)
-            }
-
-    fun rightJoin(table: SqlTable, receiver: JoinReceiver) =
-            apply {
-                dsl.rightJoin(table, receiver)
-            }
-
-    fun rightJoin(table: SqlTable, alias: String, receiver: JoinReceiver) =
-            apply {
-                dsl.rightJoin(table, alias, receiver)
-            }
-
-    fun <T> where(column: BindableColumn<T>, condition: VisitableCondition<T>) =
-            apply {
-                dsl.where(column, condition)
-            }
-
-    fun <T> where(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
-            apply {
-                dsl.where().where(column, condition, collect)
-            }
-
-    fun applyWhere(whereApplier: WhereApplier) =
-            apply {
-                dsl.applyWhere(whereApplier)
-            }
-
-    fun <T> and(column: BindableColumn<T>, condition: VisitableCondition<T>) =
-            apply {
-                dsl.where().and(column, condition)
-            }
-
-    fun <T> and(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
-            apply {
-                dsl.where().and(column, condition, collect)
-            }
-
-    fun <T> or(column: BindableColumn<T>, condition: VisitableCondition<T>) =
-            apply {
-                dsl.where().or(column, condition)
-            }
-
-    fun <T> or(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
-            apply {
-                dsl.where().or(column, condition, collect)
-            }
+class KotlinCountBuilder(private val dsl: CountDSL<SelectModel>) :
+    KotlinBaseJoiningBuilder<CountDSL<SelectModel>, CountDSL<SelectModel>.CountWhereBuilder, KotlinCountBuilder>(dsl) {
 
     fun allRows() = this
 
-    override fun build(): SelectModel = dsl.build()
+    override fun  build(): SelectModel = dsl.build()
+
+    override fun getWhere(): CountDSL<SelectModel>.CountWhereBuilder = dsl.where()
+
+    override fun getThis() = this
 }

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinCountBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinCountBuilder.kt
@@ -20,10 +20,11 @@ import org.mybatis.dynamic.sql.SqlTable
 import org.mybatis.dynamic.sql.VisitableCondition
 import org.mybatis.dynamic.sql.select.CountDSL
 import org.mybatis.dynamic.sql.select.SelectModel
+import org.mybatis.dynamic.sql.util.Buildable
 
-typealias CountCompleter = KotlinCountBuilder.() -> KotlinCountBuilder
+typealias CountCompleter = KotlinCountBuilder.() -> Buildable<SelectModel>
 
-class KotlinCountBuilder(val dsl: CountDSL<SelectModel>) {
+class KotlinCountBuilder(private val dsl: CountDSL<SelectModel>): Buildable<SelectModel> {
     fun join(table: SqlTable, receiver: JoinReceiver) =
             apply {
                 val collector = JoinCollector()
@@ -89,8 +90,7 @@ class KotlinCountBuilder(val dsl: CountDSL<SelectModel>) {
             apply {
                 val collector = CriteriaCollector()
                 collect(collector)
-                // TODO...awkward
-                dsl.where(column, condition, *collector.criteria.toTypedArray())
+                dsl.where(column, condition, collector.criteria)
             }
 
     fun applyWhere(whereApplier: WhereApplier) =
@@ -107,8 +107,7 @@ class KotlinCountBuilder(val dsl: CountDSL<SelectModel>) {
             apply {
                 val collector = CriteriaCollector()
                 collect(collector)
-                // TODO...awkward
-                dsl.where().and(column, condition, *collector.criteria.toTypedArray())
+                dsl.where().and(column, condition, collector.criteria)
             }
 
     fun <T> or(column: BindableColumn<T>, condition: VisitableCondition<T>) =
@@ -120,9 +119,10 @@ class KotlinCountBuilder(val dsl: CountDSL<SelectModel>) {
             apply {
                 val collector = CriteriaCollector()
                 collect(collector)
-                // TODO...awkward
-                dsl.where().or(column, condition, *collector.criteria.toTypedArray())
+                dsl.where().or(column, condition, collector.criteria)
             }
 
     fun allRows() = this
+
+    override fun build(): SelectModel = dsl.build()
 }

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinCountBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinCountBuilder.kt
@@ -27,58 +27,42 @@ typealias CountCompleter = KotlinCountBuilder.() -> Buildable<SelectModel>
 class KotlinCountBuilder(private val dsl: CountDSL<SelectModel>): Buildable<SelectModel> {
     fun join(table: SqlTable, receiver: JoinReceiver) =
             apply {
-                val collector = JoinCollector()
-                receiver(collector)
-                dsl.join(table, collector.onJoinCriterion, collector.andJoinCriteria)
+                dsl.join(table, receiver)
             }
 
     fun join(table: SqlTable, alias: String, receiver: JoinReceiver) =
             apply {
-                val collector = JoinCollector()
-                receiver(collector)
-                dsl.join(table, alias, collector.onJoinCriterion, collector.andJoinCriteria)
+                dsl.join(table, alias, receiver)
             }
 
     fun fullJoin(table: SqlTable, receiver: JoinReceiver) =
             apply {
-                val collector = JoinCollector()
-                receiver(collector)
-                dsl.fullJoin(table, collector.onJoinCriterion, collector.andJoinCriteria)
+                dsl.fullJoin(table, receiver)
             }
 
     fun fullJoin(table: SqlTable, alias: String, receiver: JoinReceiver) =
             apply {
-                val collector = JoinCollector()
-                receiver(collector)
-                dsl.fullJoin(table, alias, collector.onJoinCriterion, collector.andJoinCriteria)
+                dsl.fullJoin(table, alias, receiver)
             }
 
     fun leftJoin(table: SqlTable, receiver: JoinReceiver) =
             apply {
-                val collector = JoinCollector()
-                receiver(collector)
-                dsl.leftJoin(table, collector.onJoinCriterion, collector.andJoinCriteria)
+                dsl.leftJoin(table, receiver)
             }
 
     fun leftJoin(table: SqlTable, alias: String, receiver: JoinReceiver) =
             apply {
-                val collector = JoinCollector()
-                receiver(collector)
-                dsl.leftJoin(table, alias, collector.onJoinCriterion, collector.andJoinCriteria)
+                dsl.leftJoin(table, alias, receiver)
             }
 
     fun rightJoin(table: SqlTable, receiver: JoinReceiver) =
             apply {
-                val collector = JoinCollector()
-                receiver(collector)
-                dsl.rightJoin(table, collector.onJoinCriterion, collector.andJoinCriteria)
+                dsl.rightJoin(table, receiver)
             }
 
     fun rightJoin(table: SqlTable, alias: String, receiver: JoinReceiver) =
             apply {
-                val collector = JoinCollector()
-                receiver(collector)
-                dsl.rightJoin(table, alias, collector.onJoinCriterion, collector.andJoinCriteria)
+                dsl.rightJoin(table, alias, receiver)
             }
 
     fun <T> where(column: BindableColumn<T>, condition: VisitableCondition<T>) =
@@ -88,9 +72,7 @@ class KotlinCountBuilder(private val dsl: CountDSL<SelectModel>): Buildable<Sele
 
     fun <T> where(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
             apply {
-                val collector = CriteriaCollector()
-                collect(collector)
-                dsl.where(column, condition, collector.criteria)
+                dsl.where().where(column, condition, collect)
             }
 
     fun applyWhere(whereApplier: WhereApplier) =
@@ -105,9 +87,7 @@ class KotlinCountBuilder(private val dsl: CountDSL<SelectModel>): Buildable<Sele
 
     fun <T> and(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
             apply {
-                val collector = CriteriaCollector()
-                collect(collector)
-                dsl.where().and(column, condition, collector.criteria)
+                dsl.where().and(column, condition, collect)
             }
 
     fun <T> or(column: BindableColumn<T>, condition: VisitableCondition<T>) =
@@ -117,9 +97,7 @@ class KotlinCountBuilder(private val dsl: CountDSL<SelectModel>): Buildable<Sele
 
     fun <T> or(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
             apply {
-                val collector = CriteriaCollector()
-                collect(collector)
-                dsl.where().or(column, condition, collector.criteria)
+                dsl.where().or(column, condition, collect)
             }
 
     fun allRows() = this

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinDeleteBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinDeleteBuilder.kt
@@ -19,10 +19,11 @@ import org.mybatis.dynamic.sql.BindableColumn
 import org.mybatis.dynamic.sql.VisitableCondition
 import org.mybatis.dynamic.sql.delete.DeleteDSL
 import org.mybatis.dynamic.sql.delete.DeleteModel
+import org.mybatis.dynamic.sql.util.Buildable
 
-typealias DeleteCompleter = KotlinDeleteBuilder.() -> KotlinDeleteBuilder
+typealias DeleteCompleter = KotlinDeleteBuilder.() -> Buildable<DeleteModel>
 
-class KotlinDeleteBuilder(val dsl: DeleteDSL<DeleteModel>) {
+class KotlinDeleteBuilder(private val dsl: DeleteDSL<DeleteModel>): Buildable<DeleteModel> {
     fun <T> where(column: BindableColumn<T>, condition: VisitableCondition<T>) =
             apply {
                 dsl.where(column, condition)
@@ -32,8 +33,7 @@ class KotlinDeleteBuilder(val dsl: DeleteDSL<DeleteModel>) {
             apply {
                 val collector = CriteriaCollector()
                 collect(collector)
-                // TODO...awkward
-                dsl.where(column, condition, *collector.criteria.toTypedArray())
+                dsl.where(column, condition, collector.criteria)
             }
 
     fun applyWhere(whereApplier: WhereApplier) =
@@ -50,8 +50,7 @@ class KotlinDeleteBuilder(val dsl: DeleteDSL<DeleteModel>) {
             apply {
                 val collector = CriteriaCollector()
                 collect(collector)
-                // TODO...awkward
-                dsl.where().and(column, condition, *collector.criteria.toTypedArray())
+                dsl.where().and(column, condition, collector.criteria)
             }
 
     fun <T> or(column: BindableColumn<T>, condition: VisitableCondition<T>) =
@@ -63,9 +62,10 @@ class KotlinDeleteBuilder(val dsl: DeleteDSL<DeleteModel>) {
             apply {
                 val collector = CriteriaCollector()
                 collect(collector)
-                // TODO...awkward
-                dsl.where().or(column, condition, *collector.criteria.toTypedArray())
+                dsl.where().or(column, condition, collector.criteria)
             }
 
     fun allRows() = this
+
+    override fun build(): DeleteModel = dsl.build()
 }

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinDeleteBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinDeleteBuilder.kt
@@ -31,9 +31,7 @@ class KotlinDeleteBuilder(private val dsl: DeleteDSL<DeleteModel>): Buildable<De
 
     fun <T> where(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
             apply {
-                val collector = CriteriaCollector()
-                collect(collector)
-                dsl.where(column, condition, collector.criteria)
+                dsl.where().where(column, condition, collect)
             }
 
     fun applyWhere(whereApplier: WhereApplier) =
@@ -48,9 +46,7 @@ class KotlinDeleteBuilder(private val dsl: DeleteDSL<DeleteModel>): Buildable<De
 
     fun <T> and(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
             apply {
-                val collector = CriteriaCollector()
-                collect(collector)
-                dsl.where().and(column, condition, collector.criteria)
+                dsl.where().and(column, condition, collect)
             }
 
     fun <T> or(column: BindableColumn<T>, condition: VisitableCondition<T>) =
@@ -60,9 +56,7 @@ class KotlinDeleteBuilder(private val dsl: DeleteDSL<DeleteModel>): Buildable<De
 
     fun <T> or(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
             apply {
-                val collector = CriteriaCollector()
-                collect(collector)
-                dsl.where().or(column, condition, collector.criteria)
+                dsl.where().or(column, condition, collect)
             }
 
     fun allRows() = this

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinDeleteBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinDeleteBuilder.kt
@@ -15,51 +15,20 @@
  */
 package org.mybatis.dynamic.sql.util.kotlin
 
-import org.mybatis.dynamic.sql.BindableColumn
-import org.mybatis.dynamic.sql.VisitableCondition
 import org.mybatis.dynamic.sql.delete.DeleteDSL
 import org.mybatis.dynamic.sql.delete.DeleteModel
 import org.mybatis.dynamic.sql.util.Buildable
 
 typealias DeleteCompleter = KotlinDeleteBuilder.() -> Buildable<DeleteModel>
 
-class KotlinDeleteBuilder(private val dsl: DeleteDSL<DeleteModel>): Buildable<DeleteModel> {
-    fun <T> where(column: BindableColumn<T>, condition: VisitableCondition<T>) =
-            apply {
-                dsl.where(column, condition)
-            }
-
-    fun <T> where(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
-            apply {
-                dsl.where().where(column, condition, collect)
-            }
-
-    fun applyWhere(whereApplier: WhereApplier) =
-            apply {
-                dsl.applyWhere(whereApplier)
-            }
-
-    fun <T> and(column: BindableColumn<T>, condition: VisitableCondition<T>) =
-            apply {
-                dsl.where().and(column, condition)
-            }
-
-    fun <T> and(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
-            apply {
-                dsl.where().and(column, condition, collect)
-            }
-
-    fun <T> or(column: BindableColumn<T>, condition: VisitableCondition<T>) =
-            apply {
-                dsl.where().or(column, condition)
-            }
-
-    fun <T> or(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
-            apply {
-                dsl.where().or(column, condition, collect)
-            }
+class KotlinDeleteBuilder(private val dsl: DeleteDSL<DeleteModel>) :
+        KotlinBaseBuilder<DeleteModel, DeleteDSL<DeleteModel>.DeleteWhereBuilder, KotlinDeleteBuilder>() {
 
     fun allRows() = this
 
     override fun build(): DeleteModel = dsl.build()
+
+    override fun getWhere(): DeleteDSL<DeleteModel>.DeleteWhereBuilder = dsl.where()
+
+    override fun getThis(): KotlinDeleteBuilder = this
 }

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinQueryBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinQueryBuilder.kt
@@ -25,58 +25,42 @@ typealias SelectCompleter = KotlinQueryBuilder.() -> Buildable<SelectModel>
 class KotlinQueryBuilder(private val dsl: QueryExpressionDSL<SelectModel>): Buildable<SelectModel> {
     fun join(table: SqlTable, receiver: JoinReceiver) =
             apply {
-                val collector = JoinCollector()
-                receiver(collector)
-                dsl.join(table, collector.onJoinCriterion, collector.andJoinCriteria)
+                dsl.join(table, receiver)
             }
 
     fun join(table: SqlTable, alias: String, receiver: JoinReceiver) =
             apply {
-                val collector = JoinCollector()
-                receiver(collector)
-                dsl.join(table, alias, collector.onJoinCriterion, collector.andJoinCriteria)
+                dsl.join(table, alias, receiver)
             }
 
     fun fullJoin(table: SqlTable, receiver: JoinReceiver) =
             apply {
-                val collector = JoinCollector()
-                receiver(collector)
-                dsl.fullJoin(table, collector.onJoinCriterion, collector.andJoinCriteria)
+                dsl.fullJoin(table, receiver)
             }
 
     fun fullJoin(table: SqlTable, alias: String, receiver: JoinReceiver) =
             apply {
-                val collector = JoinCollector()
-                receiver(collector)
-                dsl.fullJoin(table, alias, collector.onJoinCriterion, collector.andJoinCriteria)
+                dsl.fullJoin(table, alias, receiver)
             }
 
     fun leftJoin(table: SqlTable, receiver: JoinReceiver) =
             apply {
-                val collector = JoinCollector()
-                receiver(collector)
-                dsl.leftJoin(table, collector.onJoinCriterion, collector.andJoinCriteria)
+                dsl.leftJoin(table, receiver)
             }
 
     fun leftJoin(table: SqlTable, alias: String, receiver: JoinReceiver) =
             apply {
-                val collector = JoinCollector()
-                receiver(collector)
-                dsl.leftJoin(table, alias, collector.onJoinCriterion, collector.andJoinCriteria)
+                dsl.leftJoin(table, alias, receiver)
             }
 
     fun rightJoin(table: SqlTable, receiver: JoinReceiver) =
             apply {
-                val collector = JoinCollector()
-                receiver(collector)
-                dsl.rightJoin(table, collector.onJoinCriterion, collector.andJoinCriteria)
+                dsl.rightJoin(table, receiver)
             }
 
     fun rightJoin(table: SqlTable, alias: String, receiver: JoinReceiver) =
             apply {
-                val collector = JoinCollector()
-                receiver(collector)
-                dsl.rightJoin(table, alias, collector.onJoinCriterion, collector.andJoinCriteria)
+                dsl.rightJoin(table, alias, receiver)
             }
 
     fun <T> where(column: BindableColumn<T>, condition: VisitableCondition<T>) =
@@ -86,9 +70,7 @@ class KotlinQueryBuilder(private val dsl: QueryExpressionDSL<SelectModel>): Buil
 
     fun <T> where(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
             apply {
-                val collector = CriteriaCollector()
-                collect(collector)
-                dsl.where(column, condition, collector.criteria)
+                dsl.where().where(column, condition, collect)
             }
 
     fun applyWhere(whereApplier: WhereApplier) =
@@ -103,9 +85,7 @@ class KotlinQueryBuilder(private val dsl: QueryExpressionDSL<SelectModel>): Buil
 
     fun <T> and(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
             apply {
-                val collector = CriteriaCollector()
-                collect(collector)
-                dsl.where().and(column, condition, collector.criteria)
+                dsl.where().and(column, condition, collect)
             }
 
     fun <T> or(column: BindableColumn<T>, condition: VisitableCondition<T>) =
@@ -115,9 +95,7 @@ class KotlinQueryBuilder(private val dsl: QueryExpressionDSL<SelectModel>): Buil
 
     fun <T> or(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
             apply {
-                val collector = CriteriaCollector()
-                collect(collector)
-                dsl.where().or(column, condition, collector.criteria)
+                dsl.where().or(column, condition, collect)
             }
 
     fun groupBy(vararg columns: BasicColumn) =

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinQueryBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinQueryBuilder.kt
@@ -17,86 +17,14 @@ package org.mybatis.dynamic.sql.util.kotlin
 
 import org.mybatis.dynamic.sql.*
 import org.mybatis.dynamic.sql.select.QueryExpressionDSL
+import org.mybatis.dynamic.sql.select.SelectDSL
 import org.mybatis.dynamic.sql.select.SelectModel
 import org.mybatis.dynamic.sql.util.Buildable
 
 typealias SelectCompleter = KotlinQueryBuilder.() -> Buildable<SelectModel>
 
-class KotlinQueryBuilder(private val dsl: QueryExpressionDSL<SelectModel>): Buildable<SelectModel> {
-    fun join(table: SqlTable, receiver: JoinReceiver) =
-            apply {
-                dsl.join(table, receiver)
-            }
-
-    fun join(table: SqlTable, alias: String, receiver: JoinReceiver) =
-            apply {
-                dsl.join(table, alias, receiver)
-            }
-
-    fun fullJoin(table: SqlTable, receiver: JoinReceiver) =
-            apply {
-                dsl.fullJoin(table, receiver)
-            }
-
-    fun fullJoin(table: SqlTable, alias: String, receiver: JoinReceiver) =
-            apply {
-                dsl.fullJoin(table, alias, receiver)
-            }
-
-    fun leftJoin(table: SqlTable, receiver: JoinReceiver) =
-            apply {
-                dsl.leftJoin(table, receiver)
-            }
-
-    fun leftJoin(table: SqlTable, alias: String, receiver: JoinReceiver) =
-            apply {
-                dsl.leftJoin(table, alias, receiver)
-            }
-
-    fun rightJoin(table: SqlTable, receiver: JoinReceiver) =
-            apply {
-                dsl.rightJoin(table, receiver)
-            }
-
-    fun rightJoin(table: SqlTable, alias: String, receiver: JoinReceiver) =
-            apply {
-                dsl.rightJoin(table, alias, receiver)
-            }
-
-    fun <T> where(column: BindableColumn<T>, condition: VisitableCondition<T>) =
-            apply {
-                dsl.where(column, condition)
-            }
-
-    fun <T> where(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
-            apply {
-                dsl.where().where(column, condition, collect)
-            }
-
-    fun applyWhere(whereApplier: WhereApplier) =
-            apply {
-                dsl.applyWhere(whereApplier)
-            }
-
-    fun <T> and(column: BindableColumn<T>, condition: VisitableCondition<T>) =
-            apply {
-                dsl.where().and(column, condition)
-            }
-
-    fun <T> and(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
-            apply {
-                dsl.where().and(column, condition, collect)
-            }
-
-    fun <T> or(column: BindableColumn<T>, condition: VisitableCondition<T>) =
-            apply {
-                dsl.where().or(column, condition)
-            }
-
-    fun <T> or(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
-            apply {
-                dsl.where().or(column, condition, collect)
-            }
+class KotlinQueryBuilder(private val dsl: QueryExpressionDSL<SelectModel>) :
+    KotlinBaseJoiningBuilder<QueryExpressionDSL<SelectModel>, QueryExpressionDSL<SelectModel>.QueryExpressionWhereBuilder, KotlinQueryBuilder>(dsl) {
 
     fun groupBy(vararg columns: BasicColumn) =
             apply {
@@ -118,12 +46,13 @@ class KotlinQueryBuilder(private val dsl: QueryExpressionDSL<SelectModel>): Buil
                 dsl.offset(offset)
             }
 
-    fun fetchFirst(fetchFirstRows: Long) =
-            apply {
-                dsl.fetchFirst(fetchFirstRows)
-            }
+    fun fetchFirst(fetchFirstRows: Long): SelectDSL<SelectModel>.FetchFirstFinisher = dsl.fetchFirst(fetchFirstRows)
 
     fun allRows() = this
 
     override fun build(): SelectModel = dsl.build()
+
+    override fun getWhere(): QueryExpressionDSL<SelectModel>.QueryExpressionWhereBuilder = dsl.where()
+
+    override fun getThis() = this
 }

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinQueryBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinQueryBuilder.kt
@@ -18,10 +18,11 @@ package org.mybatis.dynamic.sql.util.kotlin
 import org.mybatis.dynamic.sql.*
 import org.mybatis.dynamic.sql.select.QueryExpressionDSL
 import org.mybatis.dynamic.sql.select.SelectModel
+import org.mybatis.dynamic.sql.util.Buildable
 
-typealias SelectCompleter = KotlinQueryBuilder.() -> KotlinQueryBuilder
+typealias SelectCompleter = KotlinQueryBuilder.() -> Buildable<SelectModel>
 
-class KotlinQueryBuilder(val dsl: QueryExpressionDSL<SelectModel>) {
+class KotlinQueryBuilder(private val dsl: QueryExpressionDSL<SelectModel>): Buildable<SelectModel> {
     fun join(table: SqlTable, receiver: JoinReceiver) =
             apply {
                 val collector = JoinCollector()
@@ -87,8 +88,7 @@ class KotlinQueryBuilder(val dsl: QueryExpressionDSL<SelectModel>) {
             apply {
                 val collector = CriteriaCollector()
                 collect(collector)
-                // TODO...awkward
-                dsl.where(column, condition, *collector.criteria.toTypedArray())
+                dsl.where(column, condition, collector.criteria)
             }
 
     fun applyWhere(whereApplier: WhereApplier) =
@@ -105,8 +105,7 @@ class KotlinQueryBuilder(val dsl: QueryExpressionDSL<SelectModel>) {
             apply {
                 val collector = CriteriaCollector()
                 collect(collector)
-                // TODO...awkward
-                dsl.where().and(column, condition, *collector.criteria.toTypedArray())
+                dsl.where().and(column, condition, collector.criteria)
             }
 
     fun <T> or(column: BindableColumn<T>, condition: VisitableCondition<T>) =
@@ -118,8 +117,7 @@ class KotlinQueryBuilder(val dsl: QueryExpressionDSL<SelectModel>) {
             apply {
                 val collector = CriteriaCollector()
                 collect(collector)
-                // TODO...awkward
-                dsl.where().or(column, condition, *collector.criteria.toTypedArray())
+                dsl.where().or(column, condition, collector.criteria)
             }
 
     fun groupBy(vararg columns: BasicColumn) =
@@ -148,4 +146,6 @@ class KotlinQueryBuilder(val dsl: QueryExpressionDSL<SelectModel>) {
             }
 
     fun allRows() = this
+
+    override fun build(): SelectModel = dsl.build()
 }

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinUpdateBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinUpdateBuilder.kt
@@ -15,9 +15,7 @@
  */
 package org.mybatis.dynamic.sql.util.kotlin
 
-import org.mybatis.dynamic.sql.BindableColumn
 import org.mybatis.dynamic.sql.SqlColumn
-import org.mybatis.dynamic.sql.VisitableCondition
 import org.mybatis.dynamic.sql.insert.InsertDSL
 import org.mybatis.dynamic.sql.insert.MultiRowInsertDSL
 import org.mybatis.dynamic.sql.update.UpdateDSL
@@ -31,43 +29,14 @@ typealias MultiRowInsertCompleter<T> = MultiRowInsertDSL<T>.() -> MultiRowInsert
 
 typealias UpdateCompleter = KotlinUpdateBuilder.() -> Buildable<UpdateModel>
 
-class KotlinUpdateBuilder(private val dsl: UpdateDSL<UpdateModel>) : Buildable<UpdateModel> {
-    fun <T> where(column: BindableColumn<T>, condition: VisitableCondition<T>) =
-            apply {
-                dsl.where(column, condition)
-            }
-
-    fun <T> where(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
-            apply {
-                dsl.where().where(column, condition, collect)
-            }
-
-    fun applyWhere(whereApplier: WhereApplier) =
-            apply {
-                dsl.applyWhere(whereApplier)
-            }
-
-    fun <T> and(column: BindableColumn<T>, condition: VisitableCondition<T>) =
-            apply {
-                dsl.where().and(column, condition)
-            }
-
-    fun <T> and(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
-            apply {
-                dsl.where().and(column, condition, collect)
-            }
-
-    fun <T> or(column: BindableColumn<T>, condition: VisitableCondition<T>) =
-            apply {
-                dsl.where().or(column, condition)
-            }
-
-    fun <T> or(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
-            apply {
-                dsl.where().or(column, condition, collect)
-            }
+class KotlinUpdateBuilder(private val dsl: UpdateDSL<UpdateModel>) :
+        KotlinBaseBuilder<UpdateModel, UpdateDSL<UpdateModel>.UpdateWhereBuilder, KotlinUpdateBuilder>() {
 
     fun <T> set(column: SqlColumn<T>): UpdateDSL<UpdateModel>.SetClauseFinisher<T> = dsl.set(column)
 
     override fun build(): UpdateModel = dsl.build()
+
+    override fun getWhere(): UpdateDSL<UpdateModel>.UpdateWhereBuilder = dsl.where()
+
+    override fun getThis(): KotlinUpdateBuilder = this
 }

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinUpdateBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinUpdateBuilder.kt
@@ -39,9 +39,7 @@ class KotlinUpdateBuilder(private val dsl: UpdateDSL<UpdateModel>) : Buildable<U
 
     fun <T> where(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
             apply {
-                val collector = CriteriaCollector()
-                collect(collector)
-                dsl.where(column, condition, collector.criteria)
+                dsl.where().where(column, condition, collect)
             }
 
     fun applyWhere(whereApplier: WhereApplier) =
@@ -56,9 +54,7 @@ class KotlinUpdateBuilder(private val dsl: UpdateDSL<UpdateModel>) : Buildable<U
 
     fun <T> and(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
             apply {
-                val collector = CriteriaCollector()
-                collect(collector)
-                dsl.where().and(column, condition, collector.criteria)
+                dsl.where().and(column, condition, collect)
             }
 
     fun <T> or(column: BindableColumn<T>, condition: VisitableCondition<T>) =
@@ -68,14 +64,10 @@ class KotlinUpdateBuilder(private val dsl: UpdateDSL<UpdateModel>) : Buildable<U
 
     fun <T> or(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
             apply {
-                val collector = CriteriaCollector()
-                collect(collector)
-                dsl.where().or(column, condition, collector.criteria)
+                dsl.where().or(column, condition, collect)
             }
 
-    fun <T> set(column: SqlColumn<T>): UpdateDSL<UpdateModel>.SetClauseFinisher<T> {
-        return dsl.set(column)
-    }
+    fun <T> set(column: SqlColumn<T>): UpdateDSL<UpdateModel>.SetClauseFinisher<T> = dsl.set(column)
 
     override fun build(): UpdateModel = dsl.build()
 }

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/QueryExpressionDSLExtensions.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/QueryExpressionDSLExtensions.kt
@@ -15,37 +15,137 @@
  */
 package org.mybatis.dynamic.sql.util.kotlin
 
-import org.mybatis.dynamic.sql.BindableColumn
-import org.mybatis.dynamic.sql.VisitableCondition
+import org.mybatis.dynamic.sql.*
 import org.mybatis.dynamic.sql.select.QueryExpressionDSL
 import org.mybatis.dynamic.sql.select.SelectModel
-import org.mybatis.dynamic.sql.util.Buildable
 
-typealias SelectCompleter = QueryExpressionDSL<SelectModel>.() -> Buildable<SelectModel>
+typealias SelectCompleter = KotlinQueryBuilder.() -> KotlinQueryBuilder
 
-fun <T> QueryExpressionDSL<SelectModel>.where(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
-    apply {
-        where().where(column, condition, collect)
-    }
+class KotlinQueryBuilder(val dsl: QueryExpressionDSL<SelectModel>) {
+    fun join(table: SqlTable, receiver: JoinReceiver) =
+            apply {
+                val collector = JoinCollector()
+                receiver(collector)
+                dsl.join(table, collector.onJoinCriterion, collector.andJoinCriteria)
+            }
 
-fun <T> QueryExpressionDSL<SelectModel>.and(column: BindableColumn<T>, condition: VisitableCondition<T>) =
-    apply {
-        where().and(column, condition)
-    }
+    fun join(table: SqlTable, alias: String, receiver: JoinReceiver) =
+            apply {
+                val collector = JoinCollector()
+                receiver(collector)
+                dsl.join(table, alias, collector.onJoinCriterion, collector.andJoinCriteria)
+            }
 
-fun <T> QueryExpressionDSL<SelectModel>.and(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
-    apply {
-        where().and(column, condition, collect)
-    }
+    fun fullJoin(table: SqlTable, receiver: JoinReceiver) =
+            apply {
+                val collector = JoinCollector()
+                receiver(collector)
+                dsl.fullJoin(table, collector.onJoinCriterion, collector.andJoinCriteria)
+            }
 
-fun <T> QueryExpressionDSL<SelectModel>.or(column: BindableColumn<T>, condition: VisitableCondition<T>) =
-    apply {
-        where().or(column, condition)
-    }
+    fun fullJoin(table: SqlTable, alias: String, receiver: JoinReceiver) =
+            apply {
+                val collector = JoinCollector()
+                receiver(collector)
+                dsl.fullJoin(table, alias, collector.onJoinCriterion, collector.andJoinCriteria)
+            }
 
-fun <T> QueryExpressionDSL<SelectModel>.or(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
-    apply {
-        where().or(column, condition, collect)
-    }
+    fun leftJoin(table: SqlTable, receiver: JoinReceiver) =
+            apply {
+                val collector = JoinCollector()
+                receiver(collector)
+                dsl.leftJoin(table, collector.onJoinCriterion, collector.andJoinCriteria)
+            }
 
-fun QueryExpressionDSL<SelectModel>.allRows() = this as Buildable<SelectModel>
+    fun leftJoin(table: SqlTable, alias: String, receiver: JoinReceiver) =
+            apply {
+                val collector = JoinCollector()
+                receiver(collector)
+                dsl.leftJoin(table, alias, collector.onJoinCriterion, collector.andJoinCriteria)
+            }
+
+    fun rightJoin(table: SqlTable, receiver: JoinReceiver) =
+            apply {
+                val collector = JoinCollector()
+                receiver(collector)
+                dsl.rightJoin(table, collector.onJoinCriterion, collector.andJoinCriteria)
+            }
+
+    fun rightJoin(table: SqlTable, alias: String, receiver: JoinReceiver) =
+            apply {
+                val collector = JoinCollector()
+                receiver(collector)
+                dsl.rightJoin(table, alias, collector.onJoinCriterion, collector.andJoinCriteria)
+            }
+
+    fun <T> where(column: BindableColumn<T>, condition: VisitableCondition<T>) =
+            apply {
+                dsl.where(column, condition)
+            }
+
+    fun <T> where(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
+            apply {
+                val collector = CriteriaCollector()
+                collect(collector)
+                // TODO...awkward
+                dsl.where(column, condition, *collector.criteria.toTypedArray())
+            }
+
+    fun applyWhere(whereApplier: WhereApplier) =
+            apply {
+                dsl.applyWhere(whereApplier)
+            }
+
+    fun <T> and(column: BindableColumn<T>, condition: VisitableCondition<T>) =
+            apply {
+                dsl.where().and(column, condition)
+            }
+
+    fun <T> and(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
+            apply {
+                val collector = CriteriaCollector()
+                collect(collector)
+                // TODO...awkward
+                dsl.where().and(column, condition, *collector.criteria.toTypedArray())
+            }
+
+    fun <T> or(column: BindableColumn<T>, condition: VisitableCondition<T>) =
+            apply {
+                dsl.where().or(column, condition)
+            }
+
+    fun <T> or(column: BindableColumn<T>, condition: VisitableCondition<T>, collect: CriteriaReceiver) =
+            apply {
+                val collector = CriteriaCollector()
+                collect(collector)
+                // TODO...awkward
+                dsl.where().or(column, condition, *collector.criteria.toTypedArray())
+            }
+
+    fun groupBy(vararg columns: BasicColumn) =
+            apply {
+                dsl.groupBy(*columns)
+            }
+
+    fun orderBy(vararg columns: SortSpecification) =
+            apply {
+                dsl.orderBy(*columns)
+            }
+
+    fun limit(limit: Long) =
+            apply {
+                dsl.limit(limit)
+            }
+
+    fun offset(offset: Long) =
+            apply {
+                dsl.offset(offset)
+            }
+
+    fun fetchFirst(fetchFirstRows: Long) =
+            apply {
+                dsl.fetchFirst(fetchFirstRows)
+            }
+
+    fun allRows() = this
+}

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/mybatis3/ProviderBuilderFunctions.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/mybatis3/ProviderBuilderFunctions.kt
@@ -32,13 +32,13 @@ import org.mybatis.dynamic.sql.util.kotlin.*
 fun countFrom(table: SqlTable, completer: CountCompleter): SelectStatementProvider {
     val builder = KotlinCountBuilder(SqlBuilder.countFrom(table))
     completer(builder)
-    return builder.dsl.build().render(RenderingStrategies.MYBATIS3)
+    return builder.build().render(RenderingStrategies.MYBATIS3)
 }
 
 fun deleteFrom(table: SqlTable, completer: DeleteCompleter): DeleteStatementProvider {
     val builder = KotlinDeleteBuilder(SqlBuilder.deleteFrom(table))
     completer(builder)
-    return builder.dsl.build().render(RenderingStrategies.MYBATIS3)
+    return builder.build().render(RenderingStrategies.MYBATIS3)
 }
 
 fun <T> InsertDSL.IntoGatherer<T>.into(table: SqlTable, completer: InsertCompleter<T>): InsertStatementProvider<T> =
@@ -50,23 +50,23 @@ fun <T> MultiRowInsertDSL.IntoGatherer<T>.into(table: SqlTable, completer: Multi
 fun QueryExpressionDSL.FromGatherer<SelectModel>.from(table: SqlTable, completer: SelectCompleter): SelectStatementProvider {
     val builder = KotlinQueryBuilder(from(table))
     completer(builder)
-    return builder.dsl.build().render(RenderingStrategies.MYBATIS3)
+    return builder.build().render(RenderingStrategies.MYBATIS3)
 }
 
 fun QueryExpressionDSL.FromGatherer<SelectModel>.from(table: SqlTable, alias: String, completer: SelectCompleter): SelectStatementProvider {
     val builder = KotlinQueryBuilder(from(table, alias))
     completer(builder)
-    return builder.dsl.build().render(RenderingStrategies.MYBATIS3)
+    return builder.build().render(RenderingStrategies.MYBATIS3)
 }
 
 fun select(start: QueryExpressionDSL<SelectModel>, completer: SelectCompleter): SelectStatementProvider {
     val builder = KotlinQueryBuilder(start)
     completer(builder)
-    return builder.dsl.build().render(RenderingStrategies.MYBATIS3)
+    return builder.build().render(RenderingStrategies.MYBATIS3)
 }
 
 fun update(table: SqlTable, completer: UpdateCompleter): UpdateStatementProvider {
     val builder = KotlinUpdateBuilder(SqlBuilder.update(table))
     completer(builder)
-    return builder.dsl.build().render(RenderingStrategies.MYBATIS3)
+    return builder.build().render(RenderingStrategies.MYBATIS3)
 }

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/mybatis3/ProviderBuilderFunctions.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/mybatis3/ProviderBuilderFunctions.kt
@@ -17,6 +17,7 @@ package org.mybatis.dynamic.sql.util.kotlin.mybatis3
 
 import org.mybatis.dynamic.sql.SqlBuilder
 import org.mybatis.dynamic.sql.SqlTable
+import org.mybatis.dynamic.sql.delete.render.DeleteStatementProvider
 import org.mybatis.dynamic.sql.insert.InsertDSL
 import org.mybatis.dynamic.sql.insert.MultiRowInsertDSL
 import org.mybatis.dynamic.sql.insert.render.InsertStatementProvider
@@ -24,28 +25,48 @@ import org.mybatis.dynamic.sql.insert.render.MultiRowInsertStatementProvider
 import org.mybatis.dynamic.sql.render.RenderingStrategies
 import org.mybatis.dynamic.sql.select.QueryExpressionDSL
 import org.mybatis.dynamic.sql.select.SelectModel
+import org.mybatis.dynamic.sql.select.render.SelectStatementProvider
+import org.mybatis.dynamic.sql.update.render.UpdateStatementProvider
 import org.mybatis.dynamic.sql.util.kotlin.*
 
-fun countFrom(table: SqlTable, completer: CountCompleter) =
-    completer(SqlBuilder.countFrom(table)).build().render(RenderingStrategies.MYBATIS3)
+fun countFrom(table: SqlTable, completer: CountCompleter): SelectStatementProvider {
+    val builder = KotlinCountBuilder(SqlBuilder.countFrom(table))
+    completer(builder)
+    return builder.dsl.build().render(RenderingStrategies.MYBATIS3)
+}
 
-fun deleteFrom(table: SqlTable, completer: DeleteCompleter) =
-    completer(SqlBuilder.deleteFrom(table)).build().render(RenderingStrategies.MYBATIS3)
+fun deleteFrom(table: SqlTable, completer: DeleteCompleter): DeleteStatementProvider {
+    val builder = KotlinDeleteBuilder(SqlBuilder.deleteFrom(table))
+    completer(builder)
+    return builder.dsl.build().render(RenderingStrategies.MYBATIS3)
+}
 
 fun <T> InsertDSL.IntoGatherer<T>.into(table: SqlTable, completer: InsertCompleter<T>): InsertStatementProvider<T> =
-    completer(into(table)).build().render(RenderingStrategies.MYBATIS3)
+        completer(into(table)).build().render(RenderingStrategies.MYBATIS3)
 
 fun <T> MultiRowInsertDSL.IntoGatherer<T>.into(table: SqlTable, completer: MultiRowInsertCompleter<T>): MultiRowInsertStatementProvider<T> =
-    completer(into(table)).build().render(RenderingStrategies.MYBATIS3)
+        completer(into(table)).build().render(RenderingStrategies.MYBATIS3)
 
-fun QueryExpressionDSL.FromGatherer<SelectModel>.from(table: SqlTable, completer: SelectCompleter) =
-    completer(from(table)).build().render(RenderingStrategies.MYBATIS3)
+fun QueryExpressionDSL.FromGatherer<SelectModel>.from(table: SqlTable, completer: SelectCompleter): SelectStatementProvider {
+    val builder = KotlinQueryBuilder(from(table))
+    completer(builder)
+    return builder.dsl.build().render(RenderingStrategies.MYBATIS3)
+}
 
-fun QueryExpressionDSL.FromGatherer<SelectModel>.from(table: SqlTable, alias: String, completer: SelectCompleter) =
-    completer(from(table, alias)).build().render(RenderingStrategies.MYBATIS3)
+fun QueryExpressionDSL.FromGatherer<SelectModel>.from(table: SqlTable, alias: String, completer: SelectCompleter): SelectStatementProvider {
+    val builder = KotlinQueryBuilder(from(table, alias))
+    completer(builder)
+    return builder.dsl.build().render(RenderingStrategies.MYBATIS3)
+}
 
-fun select(start: QueryExpressionDSL<SelectModel>, completer: SelectCompleter) =
-    completer(start).build().render(RenderingStrategies.MYBATIS3)
+fun select(start: QueryExpressionDSL<SelectModel>, completer: SelectCompleter): SelectStatementProvider {
+    val builder = KotlinQueryBuilder(start)
+    completer(builder)
+    return builder.dsl.build().render(RenderingStrategies.MYBATIS3)
+}
 
-fun update(table: SqlTable, completer: UpdateCompleter) =
-    completer(SqlBuilder.update(table)).build().render(RenderingStrategies.MYBATIS3)
+fun update(table: SqlTable, completer: UpdateCompleter): UpdateStatementProvider {
+    val builder = KotlinUpdateBuilder(SqlBuilder.update(table))
+    completer(builder)
+    return builder.dsl.build().render(RenderingStrategies.MYBATIS3)
+}

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/spring/ProviderBuilderFunctions.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/spring/ProviderBuilderFunctions.kt
@@ -54,12 +54,6 @@ fun QueryExpressionDSL.FromGatherer<SelectModel>.from(table: SqlTable, alias: St
     return builder.build().render(RenderingStrategies.SPRING_NAMED_PARAMETER)
 }
 
-fun select(start: QueryExpressionDSL<SelectModel>, completer: SelectCompleter): SelectStatementProvider {
-    val builder = KotlinQueryBuilder(start)
-    completer(builder)
-    return builder.build().render(RenderingStrategies.SPRING_NAMED_PARAMETER)
-}
-
 fun update(table: SqlTable, completer: UpdateCompleter): UpdateStatementProvider {
     val builder = KotlinUpdateBuilder(SqlBuilder.update(table))
     completer(builder)

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/spring/ProviderBuilderFunctions.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/spring/ProviderBuilderFunctions.kt
@@ -17,27 +17,51 @@ package org.mybatis.dynamic.sql.util.kotlin.spring
 
 import org.mybatis.dynamic.sql.SqlBuilder
 import org.mybatis.dynamic.sql.SqlTable
+import org.mybatis.dynamic.sql.delete.render.DeleteStatementProvider
 import org.mybatis.dynamic.sql.insert.InsertDSL
 import org.mybatis.dynamic.sql.insert.render.InsertStatementProvider
 import org.mybatis.dynamic.sql.render.RenderingStrategies
 import org.mybatis.dynamic.sql.select.QueryExpressionDSL
 import org.mybatis.dynamic.sql.select.SelectModel
+import org.mybatis.dynamic.sql.select.render.SelectStatementProvider
+import org.mybatis.dynamic.sql.update.render.UpdateStatementProvider
 import org.mybatis.dynamic.sql.util.kotlin.*
 
-fun countFrom(table: SqlTable, completer: CountCompleter) =
-    completer(SqlBuilder.countFrom(table)).build().render(RenderingStrategies.SPRING_NAMED_PARAMETER)
+fun countFrom(table: SqlTable, completer: CountCompleter): SelectStatementProvider {
+    val builder = KotlinCountBuilder(SqlBuilder.countFrom(table))
+    completer(builder)
+    return builder.dsl.build().render(RenderingStrategies.SPRING_NAMED_PARAMETER)
+}
 
-fun deleteFrom(table: SqlTable, completer: DeleteCompleter) =
-    completer(SqlBuilder.deleteFrom(table)).build().render(RenderingStrategies.SPRING_NAMED_PARAMETER)
+fun deleteFrom(table: SqlTable, completer: DeleteCompleter): DeleteStatementProvider {
+    val builder = KotlinDeleteBuilder(SqlBuilder.deleteFrom(table))
+    completer(builder)
+    return builder.dsl.build().render(RenderingStrategies.SPRING_NAMED_PARAMETER)
+}
 
 fun <T> InsertDSL.IntoGatherer<T>.into(table: SqlTable, completer: InsertCompleter<T>): InsertStatementProvider<T> =
-    completer(into(table)).build().render(RenderingStrategies.SPRING_NAMED_PARAMETER)
+        completer(into(table)).build().render(RenderingStrategies.SPRING_NAMED_PARAMETER)
 
-fun QueryExpressionDSL.FromGatherer<SelectModel>.from(table: SqlTable, completer: SelectCompleter) =
-    completer(from(table)).build().render(RenderingStrategies.SPRING_NAMED_PARAMETER)
+fun QueryExpressionDSL.FromGatherer<SelectModel>.from(table: SqlTable, completer: SelectCompleter): SelectStatementProvider {
+    val builder = KotlinQueryBuilder(from(table))
+    completer(builder)
+    return builder.dsl.build().render(RenderingStrategies.SPRING_NAMED_PARAMETER)
+}
 
-fun QueryExpressionDSL.FromGatherer<SelectModel>.from(table: SqlTable, alias: String, completer: SelectCompleter) =
-    completer(from(table, alias)).build().render(RenderingStrategies.SPRING_NAMED_PARAMETER)
+fun QueryExpressionDSL.FromGatherer<SelectModel>.from(table: SqlTable, alias: String, completer: SelectCompleter): SelectStatementProvider {
+    val builder = KotlinQueryBuilder(from(table, alias))
+    completer(builder)
+    return builder.dsl.build().render(RenderingStrategies.SPRING_NAMED_PARAMETER)
+}
 
-fun update(table: SqlTable, completer: UpdateCompleter) =
-    completer(SqlBuilder.update(table)).build().render(RenderingStrategies.SPRING_NAMED_PARAMETER)
+fun select(start: QueryExpressionDSL<SelectModel>, completer: SelectCompleter): SelectStatementProvider {
+    val builder = KotlinQueryBuilder(start)
+    completer(builder)
+    return builder.dsl.build().render(RenderingStrategies.SPRING_NAMED_PARAMETER)
+}
+
+fun update(table: SqlTable, completer: UpdateCompleter): UpdateStatementProvider {
+    val builder = KotlinUpdateBuilder(SqlBuilder.update(table))
+    completer(builder)
+    return builder.dsl.build().render(RenderingStrategies.SPRING_NAMED_PARAMETER)
+}

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/spring/ProviderBuilderFunctions.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/spring/ProviderBuilderFunctions.kt
@@ -30,13 +30,13 @@ import org.mybatis.dynamic.sql.util.kotlin.*
 fun countFrom(table: SqlTable, completer: CountCompleter): SelectStatementProvider {
     val builder = KotlinCountBuilder(SqlBuilder.countFrom(table))
     completer(builder)
-    return builder.dsl.build().render(RenderingStrategies.SPRING_NAMED_PARAMETER)
+    return builder.build().render(RenderingStrategies.SPRING_NAMED_PARAMETER)
 }
 
 fun deleteFrom(table: SqlTable, completer: DeleteCompleter): DeleteStatementProvider {
     val builder = KotlinDeleteBuilder(SqlBuilder.deleteFrom(table))
     completer(builder)
-    return builder.dsl.build().render(RenderingStrategies.SPRING_NAMED_PARAMETER)
+    return builder.build().render(RenderingStrategies.SPRING_NAMED_PARAMETER)
 }
 
 fun <T> InsertDSL.IntoGatherer<T>.into(table: SqlTable, completer: InsertCompleter<T>): InsertStatementProvider<T> =
@@ -45,23 +45,23 @@ fun <T> InsertDSL.IntoGatherer<T>.into(table: SqlTable, completer: InsertComplet
 fun QueryExpressionDSL.FromGatherer<SelectModel>.from(table: SqlTable, completer: SelectCompleter): SelectStatementProvider {
     val builder = KotlinQueryBuilder(from(table))
     completer(builder)
-    return builder.dsl.build().render(RenderingStrategies.SPRING_NAMED_PARAMETER)
+    return builder.build().render(RenderingStrategies.SPRING_NAMED_PARAMETER)
 }
 
 fun QueryExpressionDSL.FromGatherer<SelectModel>.from(table: SqlTable, alias: String, completer: SelectCompleter): SelectStatementProvider {
     val builder = KotlinQueryBuilder(from(table, alias))
     completer(builder)
-    return builder.dsl.build().render(RenderingStrategies.SPRING_NAMED_PARAMETER)
+    return builder.build().render(RenderingStrategies.SPRING_NAMED_PARAMETER)
 }
 
 fun select(start: QueryExpressionDSL<SelectModel>, completer: SelectCompleter): SelectStatementProvider {
     val builder = KotlinQueryBuilder(start)
     completer(builder)
-    return builder.dsl.build().render(RenderingStrategies.SPRING_NAMED_PARAMETER)
+    return builder.build().render(RenderingStrategies.SPRING_NAMED_PARAMETER)
 }
 
 fun update(table: SqlTable, completer: UpdateCompleter): UpdateStatementProvider {
     val builder = KotlinUpdateBuilder(SqlBuilder.update(table))
     completer(builder)
-    return builder.dsl.build().render(RenderingStrategies.SPRING_NAMED_PARAMETER)
+    return builder.build().render(RenderingStrategies.SPRING_NAMED_PARAMETER)
 }

--- a/src/site/markdown/docs/kotlinMyBatis3.md
+++ b/src/site/markdown/docs/kotlinMyBatis3.md
@@ -340,7 +340,7 @@ val rows = mapper.update {
 It is also possible to write a utility method that will set values. For example:
 
 ```kotlin
-fun UpdateDSL<UpdateModel>.updateSelectiveColumns(record: PersonRecord) =
+fun KotlinUpdateBuilder.updateSelectiveColumns(record: PersonRecord) =
     apply {
         set(id).equalToWhenPresent(record::id)
         set(firstName).equalToWhenPresent(record::firstName)

--- a/src/site/markdown/docs/kotlinSpring.md
+++ b/src/site/markdown/docs/kotlinSpring.md
@@ -280,7 +280,7 @@ This is the two step execution process. This can be combined into a single step 
     }
 ```
 
-There a many different set mappings the allow setting values to null, constantats, etc. There is also a maping that will only set the column value if the passed value is non null.
+There a many different set mappings the allow setting values to null, constants, etc. There is also a mapping that will only set the column value if the passed value is non null.
 
 If you wish to update all rows in a table, simply omit the where clause:
 

--- a/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonMapperExtensions.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonMapperExtensions.kt
@@ -24,12 +24,7 @@ import examples.kotlin.mybatis3.canonical.PersonDynamicSqlSupport.Person.id
 import examples.kotlin.mybatis3.canonical.PersonDynamicSqlSupport.Person.lastName
 import examples.kotlin.mybatis3.canonical.PersonDynamicSqlSupport.Person.occupation
 import org.mybatis.dynamic.sql.SqlBuilder.isEqualTo
-import org.mybatis.dynamic.sql.update.UpdateDSL
-import org.mybatis.dynamic.sql.update.UpdateModel
-import org.mybatis.dynamic.sql.util.kotlin.CountCompleter
-import org.mybatis.dynamic.sql.util.kotlin.DeleteCompleter
-import org.mybatis.dynamic.sql.util.kotlin.SelectCompleter
-import org.mybatis.dynamic.sql.util.kotlin.UpdateCompleter
+import org.mybatis.dynamic.sql.util.kotlin.*
 import org.mybatis.dynamic.sql.util.kotlin.mybatis3.*
 
 fun PersonMapper.count(completer: CountCompleter) =
@@ -98,7 +93,7 @@ fun PersonMapper.selectByPrimaryKey(id_: Int) =
 fun PersonMapper.update(completer: UpdateCompleter) =
     update(this::update, Person, completer)
 
-fun UpdateDSL<UpdateModel>.updateAllColumns(record: PersonRecord) =
+fun KotlinUpdateBuilder.updateAllColumns(record: PersonRecord) =
     apply {
         set(id).equalTo(record::id)
         set(firstName).equalTo(record::firstName)
@@ -109,7 +104,7 @@ fun UpdateDSL<UpdateModel>.updateAllColumns(record: PersonRecord) =
         set(addressId).equalTo(record::addressId)
     }
 
-fun UpdateDSL<UpdateModel>.updateSelectiveColumns(record: PersonRecord) =
+fun KotlinUpdateBuilder.updateSelectiveColumns(record: PersonRecord) =
     apply {
         set(id).equalToWhenPresent(record::id)
         set(firstName).equalToWhenPresent(record::firstName)

--- a/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonMapperTest.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonMapperTest.kt
@@ -309,6 +309,27 @@ class PersonMapperTest {
     }
 
     @Test
+    fun testUpdateOneFieldInAllRows() {
+        newSession().use { session ->
+            val mapper = session.getMapper(PersonMapper::class.java)
+
+            val record = PersonRecord(100, "Joe", LastName("Jones"), Date(), true, "Developer", 1)
+
+            var rows = mapper.insert(record)
+            assertThat(rows).isEqualTo(1)
+
+            rows = mapper.update {
+                set(occupation).equalTo("Programmer")
+            }
+
+            assertThat(rows).isEqualTo(7)
+
+            val newRecord = mapper.selectByPrimaryKey(100)
+            assertThat(newRecord?.occupation).isEqualTo("Programmer")
+        }
+    }
+
+    @Test
     fun testUpdateAll() {
         newSession().use { session ->
             val mapper = session.getMapper(PersonMapper::class.java)

--- a/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonMapperTest.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonMapperTest.kt
@@ -30,10 +30,6 @@ import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mybatis.dynamic.sql.SqlBuilder.*
-import org.mybatis.dynamic.sql.util.kotlin.allRows
-import org.mybatis.dynamic.sql.util.kotlin.and
-import org.mybatis.dynamic.sql.util.kotlin.or
-import org.mybatis.dynamic.sql.util.kotlin.where
 import java.io.InputStreamReader
 import java.sql.DriverManager
 import java.util.*

--- a/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonMapperTest.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonMapperTest.kt
@@ -456,7 +456,7 @@ class PersonMapperTest {
         newSession().use { session ->
             val mapper = session.getMapper(PersonMapper::class.java)
 
-            val rows = mapper.count { allRows() }
+            val rows = mapper.count { allRows()  }
 
             assertThat(rows).isEqualTo(6L)
         }

--- a/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonMapperTest.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonMapperTest.kt
@@ -456,7 +456,7 @@ class PersonMapperTest {
         newSession().use { session ->
             val mapper = session.getMapper(PersonMapper::class.java)
 
-            val rows = mapper.count { allRows()  }
+            val rows = mapper.count { allRows() }
 
             assertThat(rows).isEqualTo(6L)
         }

--- a/src/test/kotlin/examples/kotlin/mybatis3/general/GeneralKotlinTest.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/general/GeneralKotlinTest.kt
@@ -573,6 +573,24 @@ class GeneralKotlinTest {
     }
 
     @Test
+    fun testRawSelectWithGroupBy() {
+
+        val ss = select(lastName, count())
+            .from(Person) {
+                where(firstName, isNotEqualTo("Bamm Bamm"))
+                groupBy(lastName)
+                orderBy(lastName)
+            }
+
+        val expected = "select last_name, count(*) from Person " +
+                "where first_name <> #{parameters.p1,jdbcType=VARCHAR} " +
+                "group by last_name " +
+                "order by last_name"
+
+        assertThat(ss.selectStatement).isEqualTo(expected)
+    }
+
+    @Test
     fun testRawUpdate1() {
         newSession().use { session ->
             val mapper = session.getMapper(PersonMapper::class.java)

--- a/src/test/kotlin/examples/kotlin/mybatis3/general/GeneralKotlinTest.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/general/GeneralKotlinTest.kt
@@ -548,6 +548,31 @@ class GeneralKotlinTest {
     }
 
     @Test
+    fun testSelectWithFetchFirst() {
+        newSession().use { session ->
+            val mapper = session.getMapper(PersonMapper::class.java)
+
+            val rows = mapper.select {
+                allRows()
+                orderBy(id)
+                offset(2)
+                fetchFirst(3).rowsOnly()
+            }
+
+            assertThat(rows.size).isEqualTo(3)
+            with(rows[0]) {
+                assertThat(id).isEqualTo(3)
+                assertThat(firstName).isEqualTo("Pebbles")
+                assertThat(lastName?.name).isEqualTo("Flintstone")
+                assertThat(birthDate).isNotNull()
+                assertThat(employed).isFalse()
+                assertThat(occupation).isNull()
+                assertThat(addressId).isEqualTo(1)
+            }
+        }
+    }
+
+    @Test
     fun testRawUpdate1() {
         newSession().use { session ->
             val mapper = session.getMapper(PersonMapper::class.java)

--- a/src/test/kotlin/examples/kotlin/mybatis3/joins/JoinMapperTest.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/joins/JoinMapperTest.kt
@@ -29,11 +29,7 @@ import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mybatis.dynamic.sql.SqlBuilder.*
-import org.mybatis.dynamic.sql.util.kotlin.fullJoin
-import org.mybatis.dynamic.sql.util.kotlin.join
-import org.mybatis.dynamic.sql.util.kotlin.leftJoin
 import org.mybatis.dynamic.sql.util.kotlin.mybatis3.from
-import org.mybatis.dynamic.sql.util.kotlin.rightJoin
 import java.io.InputStreamReader
 import java.sql.DriverManager
 
@@ -62,14 +58,14 @@ class JoinMapperTest {
             val mapper = session.getMapper(JoinMapper::class.java)
 
             val selectStatement = select(OrderMaster.orderId, OrderMaster.orderDate, OrderDetail.lineNumber,
-                OrderDetail.description, OrderDetail.quantity).from(OrderMaster, "om") {
+                    OrderDetail.description, OrderDetail.quantity).from(OrderMaster, "om") {
                 join(OrderDetail, "od") {
                     on(OrderMaster.orderId, equalTo(OrderDetail.orderId))
                 }
             }
 
             val expectedStatement = "select om.order_id, om.order_date, od.line_number, od.description, od.quantity" +
-                " from OrderMaster om join OrderDetail od on om.order_id = od.order_id"
+                    " from OrderMaster om join OrderDetail od on om.order_id = od.order_id"
             assertThat(selectStatement.selectStatement).isEqualTo(expectedStatement)
 
             val rows = mapper.selectMany(selectStatement)
@@ -95,7 +91,7 @@ class JoinMapperTest {
     fun testCompoundJoin1() {
         // this is a nonsensical join, but it does test the "and" capability
         val selectStatement = select(OrderMaster.orderId, OrderMaster.orderDate, OrderDetail.lineNumber,
-            OrderDetail.description, OrderDetail.quantity).from(OrderMaster, "om") {
+                OrderDetail.description, OrderDetail.quantity).from(OrderMaster, "om") {
             join(OrderDetail, "od") {
                 on(OrderMaster.orderId, equalTo(OrderDetail.orderId))
                 and(OrderMaster.orderId, equalTo(OrderDetail.orderId))
@@ -103,7 +99,7 @@ class JoinMapperTest {
         }
 
         val expectedStatement = "select om.order_id, om.order_date, od.line_number, od.description, od.quantity" +
-            " from OrderMaster om join OrderDetail od on om.order_id = od.order_id and om.order_id = od.order_id"
+                " from OrderMaster om join OrderDetail od on om.order_id = od.order_id and om.order_id = od.order_id"
         assertThat(selectStatement.selectStatement).isEqualTo(expectedStatement)
     }
 
@@ -111,7 +107,7 @@ class JoinMapperTest {
     fun testCompoundJoin2() {
         // this is a nonsensical join, but it does test the "and" capability
         val selectStatement = select(OrderMaster.orderId, OrderMaster.orderDate, OrderDetail.lineNumber,
-            OrderDetail.description, OrderDetail.quantity).from(OrderMaster, "om") {
+                OrderDetail.description, OrderDetail.quantity).from(OrderMaster, "om") {
             join(OrderDetail, "od") {
                 on(OrderMaster.orderId, equalTo(OrderDetail.orderId))
                 and(OrderMaster.orderId, equalTo(OrderDetail.orderId))
@@ -120,8 +116,8 @@ class JoinMapperTest {
         }
 
         val expectedStatement = "select om.order_id, om.order_date, od.line_number, od.description, od.quantity" +
-            " from OrderMaster om join OrderDetail od on om.order_id = od.order_id and om.order_id = od.order_id" +
-            " where om.order_id = #{parameters.p1,jdbcType=INTEGER}"
+                " from OrderMaster om join OrderDetail od on om.order_id = od.order_id and om.order_id = od.order_id" +
+                " where om.order_id = #{parameters.p1,jdbcType=INTEGER}"
         assertThat(selectStatement.selectStatement).isEqualTo(expectedStatement)
     }
 
@@ -131,7 +127,7 @@ class JoinMapperTest {
             val mapper = session.getMapper(JoinMapper::class.java)
 
             val selectStatement = select(OrderMaster.orderId, OrderMaster.orderDate, OrderLine.lineNumber,
-                ItemMaster.description, OrderLine.quantity).from(OrderMaster, "om") {
+                    ItemMaster.description, OrderLine.quantity).from(OrderMaster, "om") {
                 join(OrderLine, "ol") {
                     on(OrderMaster.orderId, equalTo(OrderLine.orderId))
                 }
@@ -142,9 +138,9 @@ class JoinMapperTest {
             }
 
             val expectedStatement = "select om.order_id, om.order_date, ol.line_number, im.description, ol.quantity" +
-                " from OrderMaster om join OrderLine ol" +
-                " on om.order_id = ol.order_id join ItemMaster im on ol.item_id = im.item_id" +
-                " where om.order_id = #{parameters.p1,jdbcType=INTEGER}"
+                    " from OrderMaster om join OrderLine ol" +
+                    " on om.order_id = ol.order_id join ItemMaster im on ol.item_id = im.item_id" +
+                    " where om.order_id = #{parameters.p1,jdbcType=INTEGER}"
             assertThat(selectStatement.selectStatement).isEqualTo(expectedStatement)
 
             val rows = mapper.selectMany(selectStatement)
@@ -165,7 +161,7 @@ class JoinMapperTest {
             val mapper = session.getMapper(JoinMapper::class.java)
 
             val selectStatement = select(OrderLine.orderId, OrderLine.quantity, ItemMaster.itemId,
-                ItemMaster.description).from(OrderMaster, "om") {
+                    ItemMaster.description).from(OrderMaster, "om") {
                 join(OrderLine, "ol") {
                     on(OrderMaster.orderId, equalTo(OrderLine.orderId))
                 }
@@ -176,9 +172,9 @@ class JoinMapperTest {
             }
 
             val expectedStatement = "select ol.order_id, ol.quantity, im.item_id, im.description" +
-                " from OrderMaster om join OrderLine ol on om.order_id = ol.order_id" +
-                " full join ItemMaster im on ol.item_id = im.item_id" +
-                " order by order_id, item_id"
+                    " from OrderMaster om join OrderLine ol on om.order_id = ol.order_id" +
+                    " full join ItemMaster im on ol.item_id = im.item_id" +
+                    " order by order_id, item_id"
 
             assertThat(selectStatement.selectStatement).isEqualTo(expectedStatement)
 
@@ -215,7 +211,7 @@ class JoinMapperTest {
             val mapper = session.getMapper(JoinMapper::class.java)
 
             val selectStatement = select(OrderLine.orderId, OrderLine.quantity, ItemMaster.itemId,
-                ItemMaster.description).from(OrderMaster, "om") {
+                    ItemMaster.description).from(OrderMaster, "om") {
                 join(OrderLine, "ol") {
                     on(OrderMaster.orderId, equalTo(OrderLine.orderId))
                 }
@@ -226,9 +222,9 @@ class JoinMapperTest {
             }
 
             val expectedStatement = "select ol.order_id, ol.quantity, ItemMaster.item_id, ItemMaster.description" +
-                " from OrderMaster om join OrderLine ol on om.order_id = ol.order_id" +
-                " full join ItemMaster on ol.item_id = ItemMaster.item_id" +
-                " order by order_id, item_id"
+                    " from OrderMaster om join OrderLine ol on om.order_id = ol.order_id" +
+                    " full join ItemMaster on ol.item_id = ItemMaster.item_id" +
+                    " order by order_id, item_id"
 
             assertThat(selectStatement.selectStatement).isEqualTo(expectedStatement)
 
@@ -265,7 +261,7 @@ class JoinMapperTest {
             val mapper = session.getMapper(JoinMapper::class.java)
 
             val selectStatement = select(OrderLine.orderId, OrderLine.quantity, ItemMaster.itemId,
-                ItemMaster.description).from(OrderMaster, "om") {
+                    ItemMaster.description).from(OrderMaster, "om") {
                 join(OrderLine, "ol") {
                     on(OrderMaster.orderId, equalTo(OrderLine.orderId))
                 }
@@ -276,9 +272,9 @@ class JoinMapperTest {
             }
 
             val expectedStatement = "select ol.order_id, ol.quantity, im.item_id, im.description" +
-                " from OrderMaster om join OrderLine ol on om.order_id = ol.order_id" +
-                " left join ItemMaster im on ol.item_id = im.item_id" +
-                " order by order_id, item_id"
+                    " from OrderMaster om join OrderLine ol on om.order_id = ol.order_id" +
+                    " left join ItemMaster im on ol.item_id = im.item_id" +
+                    " order by order_id, item_id"
 
             assertThat(selectStatement.selectStatement).isEqualTo(expectedStatement)
 
@@ -308,7 +304,7 @@ class JoinMapperTest {
             val mapper = session.getMapper(JoinMapper::class.java)
 
             val selectStatement = select(OrderLine.orderId, OrderLine.quantity, ItemMaster.itemId,
-                ItemMaster.description).from(OrderMaster, "om") {
+                    ItemMaster.description).from(OrderMaster, "om") {
                 join(OrderLine, "ol") {
                     on(OrderMaster.orderId, equalTo(OrderLine.orderId))
                 }
@@ -319,9 +315,9 @@ class JoinMapperTest {
             }
 
             val expectedStatement = "select ol.order_id, ol.quantity, ItemMaster.item_id, ItemMaster.description" +
-                " from OrderMaster om join OrderLine ol on om.order_id = ol.order_id" +
-                " left join ItemMaster on ol.item_id = ItemMaster.item_id" +
-                " order by order_id, item_id"
+                    " from OrderMaster om join OrderLine ol on om.order_id = ol.order_id" +
+                    " left join ItemMaster on ol.item_id = ItemMaster.item_id" +
+                    " order by order_id, item_id"
 
             assertThat(selectStatement.selectStatement).isEqualTo(expectedStatement)
 
@@ -351,7 +347,7 @@ class JoinMapperTest {
             val mapper = session.getMapper(JoinMapper::class.java)
 
             val selectStatement = select(OrderLine.orderId, OrderLine.quantity, ItemMaster.itemId,
-                ItemMaster.description).from(OrderMaster, "om") {
+                    ItemMaster.description).from(OrderMaster, "om") {
                 join(OrderLine, "ol") {
                     on(OrderMaster.orderId, equalTo(OrderLine.orderId))
                 }
@@ -362,9 +358,9 @@ class JoinMapperTest {
             }
 
             val expectedStatement = "select ol.order_id, ol.quantity, im.item_id, im.description" +
-                " from OrderMaster om join OrderLine ol on om.order_id = ol.order_id" +
-                " right join ItemMaster im on ol.item_id = im.item_id" +
-                " order by order_id, item_id"
+                    " from OrderMaster om join OrderLine ol on om.order_id = ol.order_id" +
+                    " right join ItemMaster im on ol.item_id = im.item_id" +
+                    " order by order_id, item_id"
 
             assertThat(selectStatement.selectStatement).isEqualTo(expectedStatement)
 
@@ -393,7 +389,7 @@ class JoinMapperTest {
             val mapper = session.getMapper(JoinMapper::class.java)
 
             val selectStatement = select(OrderLine.orderId, OrderLine.quantity, ItemMaster.itemId,
-                ItemMaster.description).from(OrderMaster, "om") {
+                    ItemMaster.description).from(OrderMaster, "om") {
                 join(OrderLine, "ol") {
                     on(OrderMaster.orderId, equalTo(OrderLine.orderId))
                 }
@@ -404,9 +400,9 @@ class JoinMapperTest {
             }
 
             val expectedStatement = "select ol.order_id, ol.quantity, ItemMaster.item_id, ItemMaster.description" +
-                " from OrderMaster om join OrderLine ol on om.order_id = ol.order_id" +
-                " right join ItemMaster on ol.item_id = ItemMaster.item_id" +
-                " order by order_id, item_id"
+                    " from OrderMaster om join OrderLine ol on om.order_id = ol.order_id" +
+                    " right join ItemMaster on ol.item_id = ItemMaster.item_id" +
+                    " order by order_id, item_id"
 
             assertThat(selectStatement.selectStatement).isEqualTo(expectedStatement)
 


### PR DESCRIPTION
Previously, several overloaded methods could collide. This causes queries to be fragile and very dependent on having the correct imports in a Kotlin file. With this improved support there is no longer any ambiguity.
