### PR TITLE
Add convenience methods for count and countDistinct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ If you have written your own set of functions to extend the library, you will no
 - Added the capability to specify a rendering strategy on a column to override the defaut rendering strategy for a statement. This will allow certain edge cases where a parameter marker needs to be formatted in a unique way (for example, "::jsonb" needs to be added to parameter markers for JSON fields in PostgreSQL) ([#200](https://github.com/mybatis/mybatis-dynamic-sql/issues/200))
 - Added the ability to write a function that will change the column data type ([#197](https://github.com/mybatis/mybatis-dynamic-sql/issues/197))
 - Added the `applyOperator` function to make it easy to use non-standard database operators in expressions ([#220](https://github.com/mybatis/mybatis-dynamic-sql/issues/220))
+- Added convenience methods for count(column) and count(distinct column)([#221](https://github.com/mybatis/mybatis-dynamic-sql/issues/221))
 
 ## Release 1.1.4 - November 23, 2019
 

--- a/src/main/java/org/mybatis/dynamic/sql/SqlBuilder.java
+++ b/src/main/java/org/mybatis/dynamic/sql/SqlBuilder.java
@@ -310,8 +310,8 @@ public interface SqlBuilder {
         return Concatenate.concatenate(firstColumn, secondColumn, subsequentColumns);
     }
     
-    static <T> OperatorFunction<T> applyOperator(String operator, BindableColumn<T> firstColumn, BasicColumn secondColumn,
-            BasicColumn... subsequentColumns) {
+    static <T> OperatorFunction<T> applyOperator(String operator, BindableColumn<T> firstColumn,
+            BasicColumn secondColumn, BasicColumn... subsequentColumns) {
         return OperatorFunction.of(operator, firstColumn, secondColumn, subsequentColumns);
     }
     

--- a/src/main/java/org/mybatis/dynamic/sql/SqlBuilder.java
+++ b/src/main/java/org/mybatis/dynamic/sql/SqlBuilder.java
@@ -110,29 +110,20 @@ public interface SqlBuilder {
 
     /**
      * Renders as select count(distinct column) from table...
-     * 
-     * @param table
-     * @return CountDSL for adding an optional where clause
      */
-    static CountDSL<SelectModel> countDistinctFrom(BasicColumn column, SqlTable table) {
-        return CountDSL.countDistinct(column).from(table);
+    static CountDSL.FromGatherer<SelectModel> countDistinctColumn(BasicColumn column) {
+        return CountDSL.countDistinct(column);
     }
     
     /**
      * Renders as select count(column) from table...
-     * 
-     * @param table
-     * @return CountDSL for adding an optional where clause
      */
-    static CountDSL<SelectModel> countFrom(BasicColumn column, SqlTable table) {
-        return CountDSL.count(column).from(table);
+    static CountDSL.FromGatherer<SelectModel> countColumn(BasicColumn column) {
+        return CountDSL.count(column);
     }
     
     /**
      * Renders as select count(*) from table...
-     * 
-     * @param table
-     * @return CountDSL for adding an optional where clause
      */
     static CountDSL<SelectModel> countFrom(SqlTable table) {
         return CountDSL.countFrom(table);

--- a/src/main/java/org/mybatis/dynamic/sql/SqlBuilder.java
+++ b/src/main/java/org/mybatis/dynamic/sql/SqlBuilder.java
@@ -107,6 +107,33 @@ import org.mybatis.dynamic.sql.where.condition.IsNull;
 public interface SqlBuilder {
 
     // statements
+
+    /**
+     * Renders as select count(distinct column) from table...
+     * 
+     * @param table
+     * @return CountDSL for adding an optional where clause
+     */
+    static CountDSL<SelectModel> countDistinctFrom(BasicColumn column, SqlTable table) {
+        return CountDSL.countDistinct(column).from(table);
+    }
+    
+    /**
+     * Renders as select count(column) from table...
+     * 
+     * @param table
+     * @return CountDSL for adding an optional where clause
+     */
+    static CountDSL<SelectModel> countFrom(BasicColumn column, SqlTable table) {
+        return CountDSL.count(column).from(table);
+    }
+    
+    /**
+     * Renders as select count(*) from table...
+     * 
+     * @param table
+     * @return CountDSL for adding an optional where clause
+     */
     static CountDSL<SelectModel> countFrom(SqlTable table) {
         return CountDSL.countFrom(table);
     }

--- a/src/main/java/org/mybatis/dynamic/sql/insert/render/BatchInsertRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/render/BatchInsertRenderer.java
@@ -36,7 +36,8 @@ public class BatchInsertRenderer<T> {
     
     public BatchInsert<T> render() {
         MultiRowValuePhraseVisitor visitor = new MultiRowValuePhraseVisitor(renderingStrategy, "record"); //$NON-NLS-1$)
-        List<FieldAndValue> fieldsAndValues = model.mapColumnMappings(MultiRowRenderingUtilities.toFieldAndValue(visitor))
+        List<FieldAndValue> fieldsAndValues = model
+                .mapColumnMappings(MultiRowRenderingUtilities.toFieldAndValue(visitor))
                 .collect(Collectors.toList());
         
         return BatchInsert.withRecords(model.records())

--- a/src/main/java/org/mybatis/dynamic/sql/insert/render/MultiRowInsertRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/render/MultiRowInsertRenderer.java
@@ -36,8 +36,10 @@ public class MultiRowInsertRenderer<T> {
     }
     
     public MultiRowInsertStatementProvider<T> render() {
-        MultiRowValuePhraseVisitor visitor = new MultiRowValuePhraseVisitor(renderingStrategy, "records[%s]"); //$NON-NLS-1$
-        List<FieldAndValue> fieldsAndValues = model.mapColumnMappings(MultiRowRenderingUtilities.toFieldAndValue(visitor))
+        MultiRowValuePhraseVisitor visitor =
+                new MultiRowValuePhraseVisitor(renderingStrategy, "records[%s]"); //$NON-NLS-1$
+        List<FieldAndValue> fieldsAndValues = model
+                .mapColumnMappings(MultiRowRenderingUtilities.toFieldAndValue(visitor))
                 .collect(Collectors.toList());
         
         return new DefaultMultiRowInsertStatementProvider.Builder<T>().withRecords(model.records())

--- a/src/main/java/org/mybatis/dynamic/sql/insert/render/MultiRowRenderingUtilities.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/render/MultiRowRenderingUtilities.java
@@ -29,7 +29,8 @@ public class MultiRowRenderingUtilities {
         return insertMapping -> MultiRowRenderingUtilities.toFieldAndValue(visitor, insertMapping);
     }
     
-    public static FieldAndValue toFieldAndValue(MultiRowValuePhraseVisitor visitor, AbstractColumnMapping insertMapping) {
+    public static FieldAndValue toFieldAndValue(MultiRowValuePhraseVisitor visitor,
+            AbstractColumnMapping insertMapping) {
         return insertMapping.accept(visitor);
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/select/CountDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/CountDSL.java
@@ -122,7 +122,7 @@ public class CountDSL<R> extends AbstractQueryExpressionDSL<CountDSL<R>, R> impl
         }
         
         public CountDSL<R> from(SqlTable table) {
-            return new CountDSL<> (column, table, adapterFunction);
+            return new CountDSL<>(column, table, adapterFunction);
         }
     }
     

--- a/src/main/java/org/mybatis/dynamic/sql/select/function/AbstractFunction.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/function/AbstractFunction.java
@@ -22,6 +22,8 @@ import java.util.Optional;
 import org.mybatis.dynamic.sql.BindableColumn;
 
 /**
+ * Represents a database function.
+ * 
  * @deprecated in favor of {@link AbstractUniTypeFunction}
  * 
  * @author Jeff Butler

--- a/src/main/java/org/mybatis/dynamic/sql/select/function/AbstractMultipleColumnArithmeticFunction.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/function/AbstractMultipleColumnArithmeticFunction.java
@@ -27,6 +27,8 @@ import org.mybatis.dynamic.sql.BindableColumn;
 import org.mybatis.dynamic.sql.render.TableAliasCalculator;
 
 /**
+ * Represents a function with multiple numeric columns.
+ * 
  * @deprecated in favor of {@link OperatorFunction}.
  * 
  * @author Jeff Butler

--- a/src/main/java/org/mybatis/dynamic/sql/update/render/SetPhraseVisitor.java
+++ b/src/main/java/org/mybatis/dynamic/sql/update/render/SetPhraseVisitor.java
@@ -80,24 +80,6 @@ public class SetPhraseVisitor extends UpdateMappingVisitor<Optional<FragmentAndP
         return mapping.value().flatMap(v -> buildFragment(mapping, v));
     }
     
-    private <T> Optional<FragmentAndParameters> buildFragment(AbstractColumnMapping mapping, T value) {
-        String mapKey = RenderingStrategy.formatParameterMapKey(sequence);
-
-        String jdbcPlaceholder = mapping.mapColumn(toJdbcPlaceholder(mapKey));
-        String setPhrase = mapping.mapColumn(SqlColumn::name)
-                + " = "  //$NON-NLS-1$
-                + jdbcPlaceholder;
-        
-        return FragmentAndParameters.withFragment(setPhrase)
-                .withParameter(mapKey, value)
-                .buildOptional();
-    }
-    
-    private Function<SqlColumn<?>, String> toJdbcPlaceholder(String parameterName) {
-        return column -> column.renderingStrategy().orElse(renderingStrategy)
-                .getFormattedJdbcPlaceholder(column, RenderingStrategy.DEFAULT_PARAMETER_PREFIX, parameterName);
-    }
-
     @Override
     public Optional<FragmentAndParameters> visit(SelectMapping mapping) {
         SelectStatementProvider selectStatement = SelectRenderer.withSelectModel(mapping.selectModel())
@@ -124,5 +106,23 @@ public class SetPhraseVisitor extends UpdateMappingVisitor<Optional<FragmentAndP
         
         return FragmentAndParameters.withFragment(setPhrase)
                 .buildOptional();
+    }
+
+    private <T> Optional<FragmentAndParameters> buildFragment(AbstractColumnMapping mapping, T value) {
+        String mapKey = RenderingStrategy.formatParameterMapKey(sequence);
+
+        String jdbcPlaceholder = mapping.mapColumn(toJdbcPlaceholder(mapKey));
+        String setPhrase = mapping.mapColumn(SqlColumn::name)
+                + " = "  //$NON-NLS-1$
+                + jdbcPlaceholder;
+        
+        return FragmentAndParameters.withFragment(setPhrase)
+                .withParameter(mapKey, value)
+                .buildOptional();
+    }
+    
+    private Function<SqlColumn<?>, String> toJdbcPlaceholder(String parameterName) {
+        return column -> column.renderingStrategy().orElse(renderingStrategy)
+                .getFormattedJdbcPlaceholder(column, RenderingStrategy.DEFAULT_PARAMETER_PREFIX, parameterName);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/update/render/UpdateRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/update/render/UpdateRenderer.java
@@ -60,7 +60,8 @@ public class UpdateRenderer {
 
     private UpdateStatementProvider renderWithWhereClause(List<Optional<FragmentAndParameters>> fragmentsAndParameters,
             WhereClauseProvider whereClause) {
-        return DefaultUpdateStatementProvider.withUpdateStatement(calculateUpdateStatement(fragmentsAndParameters, whereClause))
+        return DefaultUpdateStatementProvider
+                .withUpdateStatement(calculateUpdateStatement(fragmentsAndParameters, whereClause))
                 .withParameters(calculateParameters(fragmentsAndParameters))
                 .withParameters(whereClause.getParameters())
                 .build();
@@ -78,7 +79,8 @@ public class UpdateRenderer {
                 + spaceBefore(calculateSetPhrase(fragmentsAndParameters));
     }
     
-    private UpdateStatementProvider renderWithoutWhereClause(List<Optional<FragmentAndParameters>> fragmentsAndParameters) {
+    private UpdateStatementProvider renderWithoutWhereClause(
+            List<Optional<FragmentAndParameters>> fragmentsAndParameters) {
         return DefaultUpdateStatementProvider.withUpdateStatement(calculateUpdateStatement(fragmentsAndParameters))
                 .withParameters(calculateParameters(fragmentsAndParameters))
                 .build();
@@ -109,7 +111,8 @@ public class UpdateRenderer {
                 .render();
     }
 
-    private Function<AbstractColumnMapping, Optional<FragmentAndParameters>> toFragmentAndParameters(SetPhraseVisitor visitor) {
+    private Function<AbstractColumnMapping, Optional<FragmentAndParameters>> toFragmentAndParameters(
+            SetPhraseVisitor visitor) {
         return updateMapping -> toFragmentAndParameters(visitor, updateMapping);
     }
     

--- a/src/main/java/org/mybatis/dynamic/sql/util/mybatis3/MyBatis3Utils.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/mybatis3/MyBatis3Utils.java
@@ -52,6 +52,24 @@ import org.mybatis.dynamic.sql.update.render.UpdateStatementProvider;
 public class MyBatis3Utils {
     private MyBatis3Utils() {}
 
+    public static long count(ToLongFunction<SelectStatementProvider> mapper, BasicColumn column, SqlTable table,
+            CountDSLCompleter completer) {
+        return mapper.applyAsLong(count(column, table, completer));
+    }
+
+    public static SelectStatementProvider count(BasicColumn column, SqlTable table, CountDSLCompleter completer) {
+        return countFrom(SqlBuilder.countFrom(column, table), completer);
+    }
+
+    public static long countDistinct(ToLongFunction<SelectStatementProvider> mapper, BasicColumn column, SqlTable table,
+            CountDSLCompleter completer) {
+        return mapper.applyAsLong(countDistinct(column, table, completer));
+    }
+
+    public static SelectStatementProvider countDistinct(BasicColumn column, SqlTable table, CountDSLCompleter completer) {
+        return countFrom(SqlBuilder.countDistinctFrom(column, table), completer);
+    }
+
     public static SelectStatementProvider countFrom(SqlTable table, CountDSLCompleter completer) {
         return countFrom(SqlBuilder.countFrom(table), completer);
     }

--- a/src/main/java/org/mybatis/dynamic/sql/util/mybatis3/MyBatis3Utils.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/mybatis3/MyBatis3Utils.java
@@ -58,7 +58,7 @@ public class MyBatis3Utils {
     }
 
     public static SelectStatementProvider count(BasicColumn column, SqlTable table, CountDSLCompleter completer) {
-        return countFrom(SqlBuilder.countFrom(column, table), completer);
+        return countFrom(SqlBuilder.countColumn(column).from(table), completer);
     }
 
     public static long countDistinct(ToLongFunction<SelectStatementProvider> mapper, BasicColumn column, SqlTable table,
@@ -67,7 +67,7 @@ public class MyBatis3Utils {
     }
 
     public static SelectStatementProvider countDistinct(BasicColumn column, SqlTable table, CountDSLCompleter completer) {
-        return countFrom(SqlBuilder.countDistinctFrom(column, table), completer);
+        return countFrom(SqlBuilder.countDistinctColumn(column).from(table), completer);
     }
 
     public static SelectStatementProvider countFrom(SqlTable table, CountDSLCompleter completer) {

--- a/src/main/java/org/mybatis/dynamic/sql/util/mybatis3/MyBatis3Utils.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/mybatis3/MyBatis3Utils.java
@@ -66,7 +66,8 @@ public class MyBatis3Utils {
         return mapper.applyAsLong(countDistinct(column, table, completer));
     }
 
-    public static SelectStatementProvider countDistinct(BasicColumn column, SqlTable table, CountDSLCompleter completer) {
+    public static SelectStatementProvider countDistinct(BasicColumn column, SqlTable table,
+            CountDSLCompleter completer) {
         return countFrom(SqlBuilder.countDistinctColumn(column).from(table), completer);
     }
 

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/mybatis3/MapperSupportFunctions.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/mybatis3/MapperSupportFunctions.kt
@@ -28,6 +28,12 @@ import org.mybatis.dynamic.sql.select.render.SelectStatementProvider
 import org.mybatis.dynamic.sql.update.render.UpdateStatementProvider
 import org.mybatis.dynamic.sql.util.kotlin.*
 
+fun count(mapper: (SelectStatementProvider) -> Long, column: BasicColumn, table: SqlTable, completer: CountCompleter) =
+    mapper(SqlBuilder.countColumn(column).from(table, completer))
+
+fun countDistinct(mapper: (SelectStatementProvider) -> Long, column: BasicColumn, table: SqlTable, completer: CountCompleter) =
+    mapper(SqlBuilder.countDistinctColumn(column).from(table, completer))
+
 fun countFrom(mapper: (SelectStatementProvider) -> Long, table: SqlTable, completer: CountCompleter) =
     mapper(countFrom(table, completer))
 

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/mybatis3/ProviderBuilderFunctions.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/mybatis3/ProviderBuilderFunctions.kt
@@ -25,6 +25,7 @@ import org.mybatis.dynamic.sql.insert.render.GeneralInsertStatementProvider
 import org.mybatis.dynamic.sql.insert.render.InsertStatementProvider
 import org.mybatis.dynamic.sql.insert.render.MultiRowInsertStatementProvider
 import org.mybatis.dynamic.sql.render.RenderingStrategies
+import org.mybatis.dynamic.sql.select.CountDSL
 import org.mybatis.dynamic.sql.select.QueryExpressionDSL
 import org.mybatis.dynamic.sql.select.SelectModel
 import org.mybatis.dynamic.sql.select.render.SelectStatementProvider
@@ -51,6 +52,15 @@ fun <T> MultiRowInsertDSL.IntoGatherer<T>.into(
     completer: MultiRowInsertCompleter<T>
 ): MultiRowInsertStatementProvider<T> =
     completer(into(table)).build().render(RenderingStrategies.MYBATIS3)
+
+fun CountDSL.FromGatherer<SelectModel>.from(
+    table: SqlTable,
+    completer: CountCompleter
+): SelectStatementProvider {
+    val builder = KotlinCountBuilder(from(table))
+    completer(builder)
+    return builder.build().render(RenderingStrategies.MYBATIS3)
+}
 
 fun QueryExpressionDSL.FromGatherer<SelectModel>.from(
     table: SqlTable,

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/spring/ProviderBuilderFunctions.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/spring/ProviderBuilderFunctions.kt
@@ -23,17 +23,12 @@ import org.mybatis.dynamic.sql.insert.InsertDSL
 import org.mybatis.dynamic.sql.insert.render.GeneralInsertStatementProvider
 import org.mybatis.dynamic.sql.insert.render.InsertStatementProvider
 import org.mybatis.dynamic.sql.render.RenderingStrategies
+import org.mybatis.dynamic.sql.select.CountDSL
 import org.mybatis.dynamic.sql.select.QueryExpressionDSL
 import org.mybatis.dynamic.sql.select.SelectModel
 import org.mybatis.dynamic.sql.select.render.SelectStatementProvider
 import org.mybatis.dynamic.sql.update.render.UpdateStatementProvider
 import org.mybatis.dynamic.sql.util.kotlin.*
-
-fun countFrom(table: SqlTable, completer: CountCompleter): SelectStatementProvider {
-    val builder = KotlinCountBuilder(SqlBuilder.countFrom(table))
-    completer(builder)
-    return builder.build().render(RenderingStrategies.SPRING_NAMED_PARAMETER)
-}
 
 fun deleteFrom(table: SqlTable, completer: DeleteCompleter): DeleteStatementProvider {
     val builder = KotlinDeleteBuilder(SqlBuilder.deleteFrom(table))
@@ -41,8 +36,23 @@ fun deleteFrom(table: SqlTable, completer: DeleteCompleter): DeleteStatementProv
     return builder.build().render(RenderingStrategies.SPRING_NAMED_PARAMETER)
 }
 
+fun countFrom(table: SqlTable, completer: CountCompleter): SelectStatementProvider {
+    val builder = KotlinCountBuilder(SqlBuilder.countFrom(table))
+    completer(builder)
+    return builder.build().render(RenderingStrategies.SPRING_NAMED_PARAMETER)
+}
+
 fun <T> InsertDSL.IntoGatherer<T>.into(table: SqlTable, completer: InsertCompleter<T>): InsertStatementProvider<T> =
     completer(into(table)).build().render(RenderingStrategies.SPRING_NAMED_PARAMETER)
+
+fun CountDSL.FromGatherer<SelectModel>.from(
+    table: SqlTable,
+    completer: CountCompleter
+): SelectStatementProvider {
+    val builder = KotlinCountBuilder(from(table))
+    completer(builder)
+    return builder.build().render(RenderingStrategies.SPRING_NAMED_PARAMETER)
+}
 
 fun QueryExpressionDSL.FromGatherer<SelectModel>.from(
     table: SqlTable,

--- a/src/site/markdown/docs/kotlinMyBatis3.md
+++ b/src/site/markdown/docs/kotlinMyBatis3.md
@@ -80,7 +80,7 @@ A count query is a specialized select - it returns a single column - typically a
 
 Count method support enables the creation of methods that execute a count query allowing a user to specify a where clause at runtime, but abstracting away all other details.
 
-To use this support, we envision creating two methods - one standard mapper method, and one extension method. The first method is the standard MyBatis Dynamic SQL method that will execute a select:
+To use this support, we envision creating several methods - one standard mapper method, and other extension methods. The first method is the standard MyBatis Dynamic SQL method that will execute a select:
 
 ```kotlin
 @Mapper
@@ -90,14 +90,20 @@ interface PersonMapper {
 }
 ```
 
-This is a standard method for MyBatis Dynamic SQL that executes a query and returns a `Long`. The second method should be an extension maethod. It will reuse the abstract method and supply everything needed to build the select statement except the where clause:
+This is a standard method for MyBatis Dynamic SQL that executes a query and returns a `Long`. The other methods should be extension methods. They will reuse the abstract method and supply everything needed to build the select statement except the where clause:
 
 ```kotlin
-fun PersonMapper.count(completer: CountCompleter) =
+fun PersonMapper.count(completer: CountCompleter) = // count(*)
     countFrom(this::count, Person, completer)
+
+fun PersonMapper.count(column: BasicColumn, completer: CountCompleter) = // count(column)
+    count(this::count, column, Person, completer)
+
+fun PersonMapper.countDistinct(column: BasicColumn, completer: CountCompleter) = // count(distinct column)
+    countDistinct(this::count, column, Person, completer)
 ```
 
-This method shows the use of `CountCompleter` which is a Kotlin typealias for a function with a receiver that will allow a user to supply a where clause. This also shows use of the Kotlin `countFrom` method which is supplied by the library. That method will build and execute the select count statement with the supplied where clause. Clients can use the method as follows:
+These methods show the use of `CountCompleter` which is a Kotlin typealias for a function with a receiver that will allow a user to supply a where clause. This also shows use of the Kotlin `countFrom`, `count`, and `countDistinct` methods which are supplied by the library. Those methods will build and execute the select count statements with the supplied where clause. Clients can use the methods as follows:
 
 ```kotlin
 val rows = mapper.count {

--- a/src/site/markdown/docs/kotlinSpring.md
+++ b/src/site/markdown/docs/kotlinSpring.md
@@ -35,15 +35,34 @@ This object is a singleton containing the `SqlTable` and `SqlColumn` objects tha
 
 A count query is a specialized select - it returns a single column - typically a long - and supports joins and a where clause.
 
+The library supports three types of count statements:
+
+1. `count(*)` - counts the number of rows that match a where clause
+1. `count(column)` - counts the number of non-null column values that match a where clause
+1. `count(distinct column)` - counts the number of unique column values that match a where clause
+
 The DSL for count methods looks like this:
 
 ```kotlin
+    // count(*)
     val countStatement = countFrom(Person) {  // countStatement is a SelectStatementProvider
         where(id, isLessThan(4))
     }
+
+    // count(column)
+    val countStatement = countColumn(lastName).from(Person) {  // countStatement is a SelectStatementProvider
+        allRows()
+    }
+
+    // count(distinct column)
+    val countStatement = countDistinctColumn(lastName).from(Person) {  // countStatement is a SelectStatementProvider
+        allRows()
+    }
 ```
 
-This code creates a `SelectStatementProvider` that can be executed with an extension method for `NamedParameterJdbcTemplate` like this:
+Note the somewhat awkward method names `countColumn`, and `countDistinctColumn`. The methods are named this way to avoid a name collision with other methods in the `SqlBuilder`. This awkwardness can be avoided by using the one step method shown below.
+
+These methods create a `SelectStatementProvider` that can be executed with an extension method for `NamedParameterJdbcTemplate` like this:
 
 ```kotlin
     val template: NamedParameterJdbcTemplate = getTemplate() // not shown
@@ -54,6 +73,14 @@ This is the two step execution process. This can be combined into a single step 
 
 ```kotlin
     val rows = template.countFrom(Person) {
+        where(id, isLessThan(4))
+    }
+
+    val rows = template.count(lastName).from(Person) {
+        where(id, isLessThan(4))
+    }
+
+    val rows = template.countDistinct(lastName).from(Person) {
         where(id, isLessThan(4))
     }
 ```

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2016-2019 the original author or authors.
+       Copyright 2016-2020 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.

--- a/src/test/java/examples/simple/PersonMapper.java
+++ b/src/test/java/examples/simple/PersonMapper.java
@@ -100,6 +100,14 @@ public interface PersonMapper {
         return MyBatis3Utils.countFrom(this::count, person, completer);
     }
 
+    default long count(BasicColumn column, CountDSLCompleter completer) {
+        return MyBatis3Utils.count(this::count, column, person, completer);
+    }
+
+    default long countDistinct(BasicColumn column, CountDSLCompleter completer) {
+        return MyBatis3Utils.countDistinct(this::count, column, person, completer);
+    }
+
     default int delete(DeleteDSLCompleter completer) {
         return MyBatis3Utils.deleteFrom(this::delete, person, completer);
     }

--- a/src/test/java/examples/simple/PersonMapperTest.java
+++ b/src/test/java/examples/simple/PersonMapperTest.java
@@ -474,6 +474,26 @@ class PersonMapperTest {
     }
     
     @Test
+    void testCountLastName() {
+        try (SqlSession session = sqlSessionFactory.openSession()) {
+            PersonMapper mapper = session.getMapper(PersonMapper.class);
+            long rows = mapper.count(lastName, CountDSLCompleter.allRows());
+            
+            assertThat(rows).isEqualTo(6L);
+        }
+    }
+    
+    @Test
+    void testCountDistinctLastName() {
+        try (SqlSession session = sqlSessionFactory.openSession()) {
+            PersonMapper mapper = session.getMapper(PersonMapper.class);
+            long rows = mapper.countDistinct(lastName, CountDSLCompleter.allRows());
+            
+            assertThat(rows).isEqualTo(2L);
+        }
+    }
+    
+    @Test
     void testTypeHandledLike() {
         try (SqlSession session = sqlSessionFactory.openSession()) {
             PersonMapper mapper = session.getMapper(PersonMapper.class);

--- a/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonMapperExtensions.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonMapperExtensions.kt
@@ -23,9 +23,16 @@ import examples.kotlin.mybatis3.canonical.PersonDynamicSqlSupport.Person.firstNa
 import examples.kotlin.mybatis3.canonical.PersonDynamicSqlSupport.Person.id
 import examples.kotlin.mybatis3.canonical.PersonDynamicSqlSupport.Person.lastName
 import examples.kotlin.mybatis3.canonical.PersonDynamicSqlSupport.Person.occupation
+import org.mybatis.dynamic.sql.BasicColumn
 import org.mybatis.dynamic.sql.SqlBuilder.isEqualTo
 import org.mybatis.dynamic.sql.util.kotlin.*
 import org.mybatis.dynamic.sql.util.kotlin.mybatis3.*
+
+fun PersonMapper.count(column: BasicColumn, completer: CountCompleter) =
+    count(this::count, column, Person, completer)
+
+fun PersonMapper.countDistinct(column: BasicColumn, completer: CountCompleter) =
+    countDistinct(this::count, column, Person, completer)
 
 fun PersonMapper.count(completer: CountCompleter) =
     countFrom(this::count, Person, completer)

--- a/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonMapperTest.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonMapperTest.kt
@@ -484,6 +484,28 @@ class PersonMapperTest {
     }
 
     @Test
+    fun testCountLastName() {
+        newSession().use { session ->
+            val mapper = session.getMapper(PersonMapper::class.java)
+
+            val rows = mapper.count(lastName) { allRows() }
+
+            assertThat(rows).isEqualTo(6L)
+        }
+    }
+
+    @Test
+    fun testCountDistinctLastName() {
+        newSession().use { session ->
+            val mapper = session.getMapper(PersonMapper::class.java)
+
+            val rows = mapper.countDistinct(lastName) { allRows() }
+
+            assertThat(rows).isEqualTo(2L)
+        }
+    }
+
+    @Test
     fun testTypeHandledLike() {
         newSession().use { session ->
             val mapper = session.getMapper(PersonMapper::class.java)

--- a/src/test/kotlin/examples/kotlin/spring/canonical/CanonicalSpringKotlinTemplateDirectTest.kt
+++ b/src/test/kotlin/examples/kotlin/spring/canonical/CanonicalSpringKotlinTemplateDirectTest.kt
@@ -66,6 +66,24 @@ class CanonicalSpringKotlinTemplateDirectTest {
     }
 
     @Test
+    fun testCountLastName() {
+        val rows = template.count(lastName).from(Person) {
+            allRows()
+        }
+
+        assertThat(rows).isEqualTo(6)
+    }
+
+    @Test
+    fun testCountDistinctLastName() {
+        val rows = template.countDistinct(lastName).from(Person) {
+            allRows()
+        }
+
+        assertThat(rows).isEqualTo(2)
+    }
+
+    @Test
     fun testAllRows() {
         val rows = template.deleteFrom(Person) {
             allRows()

--- a/src/test/kotlin/examples/kotlin/spring/canonical/CanonicalSpringKotlinTest.kt
+++ b/src/test/kotlin/examples/kotlin/spring/canonical/CanonicalSpringKotlinTest.kt
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mybatis.dynamic.sql.SqlBuilder.*
 import org.mybatis.dynamic.sql.util.kotlin.spring.*
-import org.mybatis.dynamic.sql.util.kotlin.spring.from
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType
@@ -54,8 +53,10 @@ class CanonicalSpringKotlinTest {
             where(id, isLessThan(4))
         }
 
-        assertThat(countStatement.selectStatement).isEqualTo("select count(*) from Person" +
-            " where id < :p1")
+        assertThat(countStatement.selectStatement).isEqualTo(
+            "select count(*) from Person" +
+                    " where id < :p1"
+        )
 
         val rows = template.count(countStatement)
 
@@ -76,13 +77,41 @@ class CanonicalSpringKotlinTest {
     }
 
     @Test
+    fun testRawCountLastName() {
+        val countStatement = countColumn(lastName).from(Person) {
+            allRows()
+        }
+
+        assertThat(countStatement.selectStatement).isEqualTo("select count(last_name) from Person")
+
+        val rows = template.count(countStatement)
+
+        assertThat(rows).isEqualTo(6)
+    }
+
+    @Test
+    fun testRawCountDistinctLastName() {
+        val countStatement = countDistinctColumn(lastName).from(Person) {
+            allRows()
+        }
+
+        assertThat(countStatement.selectStatement).isEqualTo("select count(distinct last_name) from Person")
+
+        val rows = template.count(countStatement)
+
+        assertThat(rows).isEqualTo(2)
+    }
+
+    @Test
     fun testRawDelete1() {
         val deleteStatement = deleteFrom(Person) {
             where(id, isLessThan(4))
         }
 
-        assertThat(deleteStatement.deleteStatement).isEqualTo("delete from Person" +
-            " where id < :p1")
+        assertThat(deleteStatement.deleteStatement).isEqualTo(
+            "delete from Person" +
+                    " where id < :p1"
+        )
 
         val rows = template.delete(deleteStatement)
 
@@ -96,8 +125,10 @@ class CanonicalSpringKotlinTest {
             and(occupation, isNotNull())
         }
 
-        assertThat(deleteStatement.deleteStatement).isEqualTo("delete from Person" +
-            " where id < :p1 and occupation is not null")
+        assertThat(deleteStatement.deleteStatement).isEqualTo(
+            "delete from Person" +
+                    " where id < :p1 and occupation is not null"
+        )
 
         val rows = template.delete(deleteStatement)
 
@@ -112,8 +143,10 @@ class CanonicalSpringKotlinTest {
             or(occupation, isNotNull())
         }
 
-        assertThat(deleteStatement.deleteStatement).isEqualTo("delete from Person" +
-            " where id < :p1 or occupation is not null")
+        assertThat(deleteStatement.deleteStatement).isEqualTo(
+            "delete from Person" +
+                    " where id < :p1 or occupation is not null"
+        )
 
         val rows = template.delete(deleteStatement)
 
@@ -131,8 +164,8 @@ class CanonicalSpringKotlinTest {
         }
 
         val expected = "delete from Person" +
-            " where (id < :p1 or occupation is not null)" +
-            " and employed = :p2"
+                " where (id < :p1 or occupation is not null)" +
+                " and employed = :p2"
 
         assertThat(deleteStatement.deleteStatement).isEqualTo(expected)
 
@@ -151,9 +184,9 @@ class CanonicalSpringKotlinTest {
         }
 
         val expected = "delete from Person" +
-            " where id < :p1 or (occupation is not null" +
-            " and employed =" +
-            " :p2)"
+                " where id < :p1 or (occupation is not null" +
+                " and employed =" +
+                " :p2)"
 
         assertThat(deleteStatement.deleteStatement).isEqualTo(expected)
 
@@ -172,8 +205,8 @@ class CanonicalSpringKotlinTest {
         }
 
         val expected = "delete from Person where id < :p1" +
-            " and (occupation is not null and" +
-            " employed = :p2)"
+                " and (occupation is not null and" +
+                " employed = :p2)"
 
         assertThat(deleteStatement.deleteStatement).isEqualTo(expected)
 
@@ -198,11 +231,11 @@ class CanonicalSpringKotlinTest {
         }
 
         val expected = "insert into Person (id, first_name, last_name, birth_date, employed, occupation, address_id)" +
-            " values" +
-            " (:id, :firstName," +
-            " :lastName," +
-            " :birthDate, :employed," +
-            " :occupation, :addressId)"
+                " values" +
+                " (:id, :firstName," +
+                " :lastName," +
+                " :birthDate, :employed," +
+                " :occupation, :addressId)"
 
         assertThat(insertStatement.insertStatement).isEqualTo(expected)
 
@@ -259,8 +292,10 @@ class CanonicalSpringKotlinTest {
 
     @Test
     fun testRawSelect() {
-        val selectStatement = select(id.`as`("A_ID"), firstName, lastName, birthDate, employed, occupation,
-            addressId).from(Person) {
+        val selectStatement = select(
+            id.`as`("A_ID"), firstName, lastName, birthDate, employed, occupation,
+            addressId
+        ).from(Person) {
             where(id, isLessThan(4)) {
                 and(occupation, isNotNull())
             }
@@ -295,8 +330,10 @@ class CanonicalSpringKotlinTest {
 
     @Test
     fun testRawSelectByPrimaryKey() {
-        val selectStatement = select(id.`as`("A_ID"), firstName, lastName, birthDate, employed, occupation,
-            addressId).from(Person) {
+        val selectStatement = select(
+            id.`as`("A_ID"), firstName, lastName, birthDate, employed, occupation,
+            addressId
+        ).from(Person) {
             where(id, isEqualTo(1))
         }
 
@@ -325,8 +362,10 @@ class CanonicalSpringKotlinTest {
 
     @Test
     fun testRawSelectWithJoin() {
-        val selectStatement = select(id.`as`("A_ID"), firstName, lastName, birthDate, employed, occupation,
-            Address.id, Address.streetAddress, Address.city, Address.state)
+        val selectStatement = select(
+            id.`as`("A_ID"), firstName, lastName, birthDate, employed, occupation,
+            Address.id, Address.streetAddress, Address.city, Address.state
+        )
             .from(Person, "p") {
                 join(Address, "a") {
                     on(addressId, equalTo(Address.id))
@@ -337,9 +376,9 @@ class CanonicalSpringKotlinTest {
             }
 
         val expected = "select p.id as A_ID, p.first_name, p.last_name, p.birth_date, p.employed," +
-            " p.occupation, a.address_id, a.street_address, a.city, a.state" +
-            " from Person p join Address a on p.address_id = a.address_id" +
-            " where p.id < :p1 order by id limit :p2"
+                " p.occupation, a.address_id, a.street_address, a.city, a.state" +
+                " from Person p join Address a on p.address_id = a.address_id" +
+                " where p.id < :p1 order by id limit :p2"
 
         assertThat(selectStatement.selectStatement).isEqualTo(expected)
 
@@ -380,8 +419,10 @@ class CanonicalSpringKotlinTest {
 
     @Test
     fun testRawSelectWithComplexWhere1() {
-        val selectStatement = select(id.`as`("A_ID"), firstName, lastName, birthDate, employed, occupation,
-            addressId).from(Person) {
+        val selectStatement = select(
+            id.`as`("A_ID"), firstName, lastName, birthDate, employed, occupation,
+            addressId
+        ).from(Person) {
             where(id, isLessThan(5))
             and(id, isLessThan(4)) {
                 and(id, isLessThan(3)) {
@@ -393,11 +434,11 @@ class CanonicalSpringKotlinTest {
         }
 
         val expected = "select id as A_ID, first_name, last_name, birth_date, employed, occupation, address_id" +
-            " from Person" +
-            " where id < :p1" +
-            " and (id < :p2" +
-            " and (id < :p3 and id < :p4))" +
-            " order by id limit :p5"
+                " from Person" +
+                " where id < :p1" +
+                " and (id < :p2" +
+                " and (id < :p3 and id < :p4))" +
+                " order by id limit :p5"
 
         assertThat(selectStatement.selectStatement).isEqualTo(expected)
 
@@ -427,8 +468,10 @@ class CanonicalSpringKotlinTest {
 
     @Test
     fun testRawSelectWithComplexWhere2() {
-        val selectStatement = select(id.`as`("A_ID"), firstName, lastName, birthDate, employed, occupation,
-            addressId).from(Person) {
+        val selectStatement = select(
+            id.`as`("A_ID"), firstName, lastName, birthDate, employed, occupation,
+            addressId
+        ).from(Person) {
             where(id, isEqualTo(5))
             or(id, isEqualTo(4)) {
                 or(id, isEqualTo(3)) {
@@ -440,11 +483,11 @@ class CanonicalSpringKotlinTest {
         }
 
         val expected = "select id as A_ID, first_name, last_name, birth_date, employed, occupation, address_id" +
-            " from Person" +
-            " where id = :p1" +
-            " or (id = :p2" +
-            " or (id = :p3 or id = :p4))" +
-            " order by id limit :p5"
+                " from Person" +
+                " where id = :p1" +
+                " or (id = :p2" +
+                " or (id = :p3 or id = :p4))" +
+                " order by id limit :p5"
 
         assertThat(selectStatement.selectStatement).isEqualTo(expected)
 
@@ -479,9 +522,11 @@ class CanonicalSpringKotlinTest {
             where(firstName, isEqualTo("Fred"))
         }
 
-        assertThat(updateStatement.updateStatement).isEqualTo("update Person" +
-            " set first_name = :p1" +
-            " where first_name = :p2")
+        assertThat(updateStatement.updateStatement).isEqualTo(
+            "update Person" +
+                    " set first_name = :p1" +
+                    " where first_name = :p2"
+        )
 
         val rows = template.update(updateStatement)
 
@@ -497,9 +542,11 @@ class CanonicalSpringKotlinTest {
             }
         }
 
-        assertThat(updateStatement.updateStatement).isEqualTo("update Person" +
-            " set first_name = :p1" +
-            " where (first_name = :p2 or id > :p3)")
+        assertThat(updateStatement.updateStatement).isEqualTo(
+            "update Person" +
+                    " set first_name = :p1" +
+                    " where (first_name = :p2 or id > :p3)"
+        )
 
         val rows = template.update(updateStatement)
 
@@ -516,10 +563,12 @@ class CanonicalSpringKotlinTest {
             }
         }
 
-        assertThat(updateStatement.updateStatement).isEqualTo("update Person" +
-            " set first_name = :p1" +
-            " where first_name = :p2" +
-            " or (id = :p3 or id = :p4)")
+        assertThat(updateStatement.updateStatement).isEqualTo(
+            "update Person" +
+                    " set first_name = :p1" +
+                    " where first_name = :p2" +
+                    " or (id = :p3 or id = :p4)"
+        )
 
         val rows = template.update(updateStatement)
 
@@ -536,10 +585,12 @@ class CanonicalSpringKotlinTest {
             }
         }
 
-        assertThat(updateStatement.updateStatement).isEqualTo("update Person" +
-            " set first_name = :p1" +
-            " where first_name = :p2" +
-            " and (id = :p3 or id = :p4)")
+        assertThat(updateStatement.updateStatement).isEqualTo(
+            "update Person" +
+                    " set first_name = :p1" +
+                    " where first_name = :p2" +
+                    " and (id = :p3 or id = :p4)"
+        )
 
         val rows = template.update(updateStatement)
 
@@ -554,10 +605,12 @@ class CanonicalSpringKotlinTest {
             or(id, isEqualTo(3))
         }
 
-        assertThat(updateStatement.updateStatement).isEqualTo("update Person" +
-            " set first_name = :p1" +
-            " where first_name = :p2" +
-            " or id = :p3")
+        assertThat(updateStatement.updateStatement).isEqualTo(
+            "update Person" +
+                    " set first_name = :p1" +
+                    " where first_name = :p2" +
+                    " or id = :p3"
+        )
 
         val rows = template.update(updateStatement)
 


### PR DESCRIPTION
The existing count methods only support `count(*)`. With these additions we can support `count(column)` and `count(distinct column)`.

The Kotlin utilities are also updated.

Resolves #192 
