### PR TITLE
Stop the license plugin from generating dangling JavaDoc comments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,16 @@
           <sourceDirectories>src/main/java,src/main/kotlin</sourceDirectories>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <configuration>
+          <mapping>
+            <java>SLASHSTAR_STYLE</java>
+            <kt>SLASHSTAR_STYLE</kt>
+          </mapping>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/src/main/java/org/mybatis/dynamic/sql/AbstractColumnComparisonCondition.java
+++ b/src/main/java/org/mybatis/dynamic/sql/AbstractColumnComparisonCondition.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/AbstractListValueCondition.java
+++ b/src/main/java/org/mybatis/dynamic/sql/AbstractListValueCondition.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/AbstractNoValueCondition.java
+++ b/src/main/java/org/mybatis/dynamic/sql/AbstractNoValueCondition.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/AbstractSingleValueCondition.java
+++ b/src/main/java/org/mybatis/dynamic/sql/AbstractSingleValueCondition.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/AbstractSubselectCondition.java
+++ b/src/main/java/org/mybatis/dynamic/sql/AbstractSubselectCondition.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/AbstractTwoValueCondition.java
+++ b/src/main/java/org/mybatis/dynamic/sql/AbstractTwoValueCondition.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/BasicColumn.java
+++ b/src/main/java/org/mybatis/dynamic/sql/BasicColumn.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/BindableColumn.java
+++ b/src/main/java/org/mybatis/dynamic/sql/BindableColumn.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/Callback.java
+++ b/src/main/java/org/mybatis/dynamic/sql/Callback.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/ConditionVisitor.java
+++ b/src/main/java/org/mybatis/dynamic/sql/ConditionVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/Constant.java
+++ b/src/main/java/org/mybatis/dynamic/sql/Constant.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/ParameterTypeConverter.java
+++ b/src/main/java/org/mybatis/dynamic/sql/ParameterTypeConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/SortSpecification.java
+++ b/src/main/java/org/mybatis/dynamic/sql/SortSpecification.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/SqlBuilder.java
+++ b/src/main/java/org/mybatis/dynamic/sql/SqlBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/SqlColumn.java
+++ b/src/main/java/org/mybatis/dynamic/sql/SqlColumn.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/SqlCriterion.java
+++ b/src/main/java/org/mybatis/dynamic/sql/SqlCriterion.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/SqlTable.java
+++ b/src/main/java/org/mybatis/dynamic/sql/SqlTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/StringConstant.java
+++ b/src/main/java/org/mybatis/dynamic/sql/StringConstant.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/VisitableCondition.java
+++ b/src/main/java/org/mybatis/dynamic/sql/VisitableCondition.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2018 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/delete/DeleteDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/delete/DeleteDSL.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/delete/DeleteDSLCompleter.java
+++ b/src/main/java/org/mybatis/dynamic/sql/delete/DeleteDSLCompleter.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/delete/DeleteModel.java
+++ b/src/main/java/org/mybatis/dynamic/sql/delete/DeleteModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/delete/MyBatis3DeleteModelAdapter.java
+++ b/src/main/java/org/mybatis/dynamic/sql/delete/MyBatis3DeleteModelAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/delete/render/DefaultDeleteStatementProvider.java
+++ b/src/main/java/org/mybatis/dynamic/sql/delete/render/DefaultDeleteStatementProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/delete/render/DeleteRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/delete/render/DeleteRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/delete/render/DeleteStatementProvider.java
+++ b/src/main/java/org/mybatis/dynamic/sql/delete/render/DeleteStatementProvider.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2018 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/insert/AbstractMultiRowInsertModel.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/AbstractMultiRowInsertModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/insert/BatchInsertDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/BatchInsertDSL.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/insert/BatchInsertModel.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/BatchInsertModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/insert/GeneralInsertDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/GeneralInsertDSL.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/insert/GeneralInsertModel.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/GeneralInsertModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/insert/InsertColumnListModel.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/InsertColumnListModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/insert/InsertDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/InsertDSL.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/insert/InsertModel.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/InsertModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/insert/InsertSelectDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/InsertSelectDSL.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/insert/InsertSelectModel.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/InsertSelectModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/insert/MultiRowInsertDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/MultiRowInsertDSL.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/insert/MultiRowInsertModel.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/MultiRowInsertModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/insert/render/AbstractMultiRowValuePhraseVisitor.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/render/AbstractMultiRowValuePhraseVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/insert/render/BatchInsert.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/render/BatchInsert.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/insert/render/BatchInsertRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/render/BatchInsertRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/insert/render/BatchValuePhraseVisitor.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/render/BatchValuePhraseVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/insert/render/DefaultGeneralInsertStatementProvider.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/render/DefaultGeneralInsertStatementProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/insert/render/DefaultInsertStatementProvider.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/render/DefaultInsertStatementProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/insert/render/DefaultMultiRowInsertStatementProvider.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/render/DefaultMultiRowInsertStatementProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/insert/render/FieldAndValue.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/render/FieldAndValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/insert/render/FieldAndValueAndParameters.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/render/FieldAndValueAndParameters.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/insert/render/GeneralInsertRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/render/GeneralInsertRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/insert/render/GeneralInsertStatementProvider.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/render/GeneralInsertStatementProvider.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/insert/render/GeneralInsertValuePhraseVisitor.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/render/GeneralInsertValuePhraseVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/insert/render/InsertRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/render/InsertRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/insert/render/InsertSelectRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/render/InsertSelectRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/insert/render/InsertSelectStatementProvider.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/render/InsertSelectStatementProvider.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2018 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/insert/render/InsertStatementProvider.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/render/InsertStatementProvider.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2018 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/insert/render/MultiRowInsertRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/render/MultiRowInsertRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/insert/render/MultiRowInsertStatementProvider.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/render/MultiRowInsertStatementProvider.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/insert/render/MultiRowValuePhraseVisitor.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/render/MultiRowValuePhraseVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/insert/render/ValuePhraseVisitor.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/render/ValuePhraseVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/render/GuaranteedTableAliasCalculator.java
+++ b/src/main/java/org/mybatis/dynamic/sql/render/GuaranteedTableAliasCalculator.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/render/MyBatis3RenderingStrategy.java
+++ b/src/main/java/org/mybatis/dynamic/sql/render/MyBatis3RenderingStrategy.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/render/RenderingStrategies.java
+++ b/src/main/java/org/mybatis/dynamic/sql/render/RenderingStrategies.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/render/RenderingStrategy.java
+++ b/src/main/java/org/mybatis/dynamic/sql/render/RenderingStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/render/SpringNamedParameterRenderingStrategy.java
+++ b/src/main/java/org/mybatis/dynamic/sql/render/SpringNamedParameterRenderingStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/render/TableAliasCalculator.java
+++ b/src/main/java/org/mybatis/dynamic/sql/render/TableAliasCalculator.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/select/AbstractQueryExpressionDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/AbstractQueryExpressionDSL.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/select/CountDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/CountDSL.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/select/CountDSLCompleter.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/CountDSLCompleter.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/select/GroupByModel.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/GroupByModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/select/MyBatis3SelectModelAdapter.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/MyBatis3SelectModelAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/select/OrderByModel.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/OrderByModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/select/PagingModel.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/PagingModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/select/QueryExpressionDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/QueryExpressionDSL.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/select/QueryExpressionModel.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/QueryExpressionModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/select/SelectDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/SelectDSL.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/select/SelectDSLCompleter.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/SelectDSLCompleter.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/select/SelectModel.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/SelectModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/select/SimpleSortSpecification.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/SimpleSortSpecification.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/select/aggregate/AbstractAggregate.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/aggregate/AbstractAggregate.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/select/aggregate/Avg.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/aggregate/Avg.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2017 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/select/aggregate/Count.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/aggregate/Count.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2017 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/select/aggregate/CountAll.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/aggregate/CountAll.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2018 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/select/aggregate/CountDistinct.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/aggregate/CountDistinct.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/select/aggregate/Max.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/aggregate/Max.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2017 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/select/aggregate/Min.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/aggregate/Min.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2017 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/select/aggregate/Sum.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/aggregate/Sum.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2017 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/select/function/AbstractFunction.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/function/AbstractFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/select/function/AbstractMultipleColumnArithmeticFunction.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/function/AbstractMultipleColumnArithmeticFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/select/function/AbstractTypeConvertingFunction.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/function/AbstractTypeConvertingFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/select/function/AbstractUniTypeFunction.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/function/AbstractUniTypeFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/select/function/Add.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/function/Add.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/select/function/Concatenate.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/function/Concatenate.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/select/function/Divide.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/function/Divide.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/select/function/Lower.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/function/Lower.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/select/function/Multiply.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/function/Multiply.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/select/function/OperatorFunction.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/function/OperatorFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/select/function/Substring.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/function/Substring.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/select/function/Subtract.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/function/Subtract.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/select/function/Upper.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/function/Upper.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/select/join/EqualTo.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/join/EqualTo.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2017 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/select/join/JoinCondition.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/join/JoinCondition.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/select/join/JoinCriterion.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/join/JoinCriterion.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/select/join/JoinModel.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/join/JoinModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/select/join/JoinSpecification.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/join/JoinSpecification.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/select/join/JoinType.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/join/JoinType.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/select/render/DefaultSelectStatementProvider.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/render/DefaultSelectStatementProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/select/render/FetchFirstPagingModelRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/render/FetchFirstPagingModelRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/select/render/JoinRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/render/JoinRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/select/render/LimitAndOffsetPagingModelRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/render/LimitAndOffsetPagingModelRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/select/render/PagingModelRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/render/PagingModelRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/select/render/QueryExpressionRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/render/QueryExpressionRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/select/render/SelectRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/render/SelectRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/select/render/SelectStatementProvider.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/render/SelectStatementProvider.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2018 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/update/MyBatis3UpdateModelAdapter.java
+++ b/src/main/java/org/mybatis/dynamic/sql/update/MyBatis3UpdateModelAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/update/UpdateDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/update/UpdateDSL.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/update/UpdateDSLCompleter.java
+++ b/src/main/java/org/mybatis/dynamic/sql/update/UpdateDSLCompleter.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/update/UpdateModel.java
+++ b/src/main/java/org/mybatis/dynamic/sql/update/UpdateModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/update/render/DefaultUpdateStatementProvider.java
+++ b/src/main/java/org/mybatis/dynamic/sql/update/render/DefaultUpdateStatementProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/update/render/SetPhraseVisitor.java
+++ b/src/main/java/org/mybatis/dynamic/sql/update/render/SetPhraseVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/update/render/UpdateRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/update/render/UpdateRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/update/render/UpdateStatementProvider.java
+++ b/src/main/java/org/mybatis/dynamic/sql/update/render/UpdateStatementProvider.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2018 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/util/AbstractColumnMapping.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/AbstractColumnMapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/util/Buildable.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/Buildable.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/util/ColumnMappingVisitor.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/ColumnMappingVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/util/ColumnToColumnMapping.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/ColumnToColumnMapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/util/ConstantMapping.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/ConstantMapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/util/CustomCollectors.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/CustomCollectors.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2017 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/util/FragmentAndParameters.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/FragmentAndParameters.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/util/FragmentCollector.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/FragmentCollector.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/util/GeneralInsertMappingVisitor.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/GeneralInsertMappingVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/util/InsertMappingVisitor.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/InsertMappingVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/util/MultiRowInsertMappingVisitor.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/MultiRowInsertMappingVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/util/NullMapping.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/NullMapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/util/Predicates.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/Predicates.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2018 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/util/PropertyMapping.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/PropertyMapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/util/PropertyWhenPresentMapping.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/PropertyWhenPresentMapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/util/SelectMapping.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/SelectMapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/util/SqlProviderAdapter.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/SqlProviderAdapter.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/util/StringConstantMapping.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/StringConstantMapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/util/StringUtilities.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/StringUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/util/UpdateMappingVisitor.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/UpdateMappingVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/util/ValueMapping.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/ValueMapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/util/ValueWhenPresentMapping.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/ValueWhenPresentMapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/util/mybatis3/MyBatis3Utils.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/mybatis3/MyBatis3Utils.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/util/spring/NamedParameterJdbcTemplateExtensions.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/spring/NamedParameterJdbcTemplateExtensions.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/util/springbatch/SpringBatchCursorReaderSelectModel.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/springbatch/SpringBatchCursorReaderSelectModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/util/springbatch/SpringBatchPagingReaderSelectModel.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/springbatch/SpringBatchPagingReaderSelectModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/util/springbatch/SpringBatchProviderAdapter.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/springbatch/SpringBatchProviderAdapter.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/util/springbatch/SpringBatchReaderRenderingStrategy.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/springbatch/SpringBatchReaderRenderingStrategy.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/util/springbatch/SpringBatchUtility.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/springbatch/SpringBatchUtility.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/AbstractWhereDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/AbstractWhereDSL.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/where/WhereApplier.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/WhereApplier.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/WhereDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/WhereDSL.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/WhereModel.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/WhereModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/AndGatherer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/AndGatherer.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsBetween.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsBetween.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsBetweenWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsBetweenWhenPresent.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsEqualTo.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsEqualTo.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsEqualToColumn.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsEqualToColumn.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2018 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsEqualToWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsEqualToWhenPresent.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsEqualToWithSubselect.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsEqualToWithSubselect.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2017 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThan.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThan.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThanColumn.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThanColumn.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2018 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThanOrEqualTo.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThanOrEqualTo.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThanOrEqualToColumn.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThanOrEqualToColumn.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2018 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThanOrEqualToWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThanOrEqualToWhenPresent.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThanOrEqualToWithSubselect.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThanOrEqualToWithSubselect.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2017 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThanWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThanWhenPresent.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThanWithSubselect.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThanWithSubselect.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2017 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsIn.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsIn.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInCaseInsensitive.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInCaseInsensitive.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInCaseInsensitiveWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInCaseInsensitiveWhenPresent.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInWhenPresent.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInWithSubselect.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInWithSubselect.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2017 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThan.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThan.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThanColumn.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThanColumn.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2018 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThanOrEqualTo.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThanOrEqualTo.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThanOrEqualToColumn.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThanOrEqualToColumn.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2018 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThanOrEqualToWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThanOrEqualToWhenPresent.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThanOrEqualToWithSubselect.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThanOrEqualToWithSubselect.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2017 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThanWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThanWhenPresent.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThanWithSubselect.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThanWithSubselect.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2017 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLike.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLike.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLikeCaseInsensitive.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLikeCaseInsensitive.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLikeCaseInsensitiveWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLikeCaseInsensitiveWhenPresent.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLikeWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLikeWhenPresent.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotBetween.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotBetween.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotBetweenWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotBetweenWhenPresent.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotEqualTo.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotEqualTo.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotEqualToColumn.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotEqualToColumn.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2018 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotEqualToWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotEqualToWhenPresent.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotEqualToWithSubselect.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotEqualToWithSubselect.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2017 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotIn.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotIn.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInCaseInsensitive.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInCaseInsensitive.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInCaseInsensitiveWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInCaseInsensitiveWhenPresent.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInWhenPresent.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInWithSubselect.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInWithSubselect.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2017 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotLike.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotLike.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotLikeCaseInsensitive.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotLikeCaseInsensitive.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotLikeCaseInsensitiveWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotLikeCaseInsensitiveWhenPresent.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotLikeWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotLikeWhenPresent.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotNull.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotNull.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2018 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNull.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNull.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2018 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/render/CriterionRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/render/CriterionRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/where/render/RenderedCriterion.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/render/RenderedCriterion.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/where/render/WhereClauseProvider.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/render/WhereClauseProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/where/render/WhereConditionVisitor.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/render/WhereConditionVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/org/mybatis/dynamic/sql/where/render/WhereRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/render/WhereRenderer.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/AbstractQueryExpressionDSLExtensions.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/AbstractQueryExpressionDSLExtensions.kt
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/AbstractWhereDSLExtensions.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/AbstractWhereDSLExtensions.kt
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/CriteriaCollector.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/CriteriaCollector.kt
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/FromGathererExtensions.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/FromGathererExtensions.kt
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/JoinCollector.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/JoinCollector.kt
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinBaseBuilders.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinBaseBuilders.kt
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinCountBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinCountBuilder.kt
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinDeleteBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinDeleteBuilder.kt
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinInsertHelpers.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinInsertHelpers.kt
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinQueryBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinQueryBuilder.kt
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinUnionBuilders.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinUnionBuilders.kt
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinUpdateBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinUpdateBuilder.kt
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/mybatis3/MapperSupportFunctions.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/mybatis3/MapperSupportFunctions.kt
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/mybatis3/ProviderBuilderFunctions.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/mybatis3/ProviderBuilderFunctions.kt
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/spring/NamedParameterJdbcTemplateExtensions.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/spring/NamedParameterJdbcTemplateExtensions.kt
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/spring/ProviderBuilderFunctions.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/spring/ProviderBuilderFunctions.kt
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/animal/data/AnimalData.java
+++ b/src/test/java/examples/animal/data/AnimalData.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/animal/data/AnimalDataDynamicSqlSupport.java
+++ b/src/test/java/examples/animal/data/AnimalDataDynamicSqlSupport.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2017 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/animal/data/AnimalDataMapper.java
+++ b/src/test/java/examples/animal/data/AnimalDataMapper.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/animal/data/AnimalDataTest.java
+++ b/src/test/java/examples/animal/data/AnimalDataTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/animal/data/BindingTest.java
+++ b/src/test/java/examples/animal/data/BindingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/animal/data/DeprecatedAdd.java
+++ b/src/test/java/examples/animal/data/DeprecatedAdd.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/animal/data/FetchFirstTest.java
+++ b/src/test/java/examples/animal/data/FetchFirstTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/animal/data/LimitAndOffsetTest.java
+++ b/src/test/java/examples/animal/data/LimitAndOffsetTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/animal/data/MyInCondition.java
+++ b/src/test/java/examples/animal/data/MyInCondition.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2018 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/animal/data/OptionalConditionsAnimalDataTest.java
+++ b/src/test/java/examples/animal/data/OptionalConditionsAnimalDataTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/animal/data/OptionalConditionsWithPredicatesAnimalDataTest.java
+++ b/src/test/java/examples/animal/data/OptionalConditionsWithPredicatesAnimalDataTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/column/comparison/ColumnComparisonDynamicSqlSupport.java
+++ b/src/test/java/examples/column/comparison/ColumnComparisonDynamicSqlSupport.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2018 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/column/comparison/ColumnComparisonMapper.java
+++ b/src/test/java/examples/column/comparison/ColumnComparisonMapper.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2018 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/column/comparison/ColumnComparisonRecord.java
+++ b/src/test/java/examples/column/comparison/ColumnComparisonRecord.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2018 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/column/comparison/ColumnComparisonTest.java
+++ b/src/test/java/examples/column/comparison/ColumnComparisonTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/complexquery/ComplexQueryTest.java
+++ b/src/test/java/examples/complexquery/ComplexQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/complexquery/PersonDynamicSqlSupport.java
+++ b/src/test/java/examples/complexquery/PersonDynamicSqlSupport.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/complexquery/SearchUtils.java
+++ b/src/test/java/examples/complexquery/SearchUtils.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/custom_render/CustomRenderingTest.java
+++ b/src/test/java/examples/custom_render/CustomRenderingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/custom_render/JsonRenderingStrategy.java
+++ b/src/test/java/examples/custom_render/JsonRenderingStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/custom_render/JsonTestDynamicSqlSupport.java
+++ b/src/test/java/examples/custom_render/JsonTestDynamicSqlSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/custom_render/JsonTestMapper.java
+++ b/src/test/java/examples/custom_render/JsonTestMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/custom_render/JsonTestRecord.java
+++ b/src/test/java/examples/custom_render/JsonTestRecord.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/custom_render/PgContainer.java
+++ b/src/test/java/examples/custom_render/PgContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/emptywhere/EmptyWhereTest.java
+++ b/src/test/java/examples/emptywhere/EmptyWhereTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/emptywhere/OrderDynamicSqlSupport.java
+++ b/src/test/java/examples/emptywhere/OrderDynamicSqlSupport.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/emptywhere/PersonDynamicSqlSupport.java
+++ b/src/test/java/examples/emptywhere/PersonDynamicSqlSupport.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/generated/always/GeneratedAlwaysRecord.java
+++ b/src/test/java/examples/generated/always/GeneratedAlwaysRecord.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2017 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/generated/always/PersonRecord.java
+++ b/src/test/java/examples/generated/always/PersonRecord.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/generated/always/mybatis/GeneratedAlwaysAnnotatedMapper.java
+++ b/src/test/java/examples/generated/always/mybatis/GeneratedAlwaysAnnotatedMapper.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/generated/always/mybatis/GeneratedAlwaysAnnotatedMapperTest.java
+++ b/src/test/java/examples/generated/always/mybatis/GeneratedAlwaysAnnotatedMapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/generated/always/mybatis/GeneratedAlwaysDynamicSqlSupport.java
+++ b/src/test/java/examples/generated/always/mybatis/GeneratedAlwaysDynamicSqlSupport.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/generated/always/mybatis/GeneratedKey.java
+++ b/src/test/java/examples/generated/always/mybatis/GeneratedKey.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/generated/always/mybatis/GeneratedKeyList.java
+++ b/src/test/java/examples/generated/always/mybatis/GeneratedKeyList.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/generated/always/mybatis/PersonDynamicSqlSupport.java
+++ b/src/test/java/examples/generated/always/mybatis/PersonDynamicSqlSupport.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/generated/always/mybatis/PersonMapper.java
+++ b/src/test/java/examples/generated/always/mybatis/PersonMapper.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/generated/always/mybatis/PersonMapperTest.java
+++ b/src/test/java/examples/generated/always/mybatis/PersonMapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/generated/always/spring/GeneratedAlwaysDynamicSqlSupport.java
+++ b/src/test/java/examples/generated/always/spring/GeneratedAlwaysDynamicSqlSupport.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2018 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/generated/always/spring/SpringTest.java
+++ b/src/test/java/examples/generated/always/spring/SpringTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/groupby/AddressDynamicSqlSupport.java
+++ b/src/test/java/examples/groupby/AddressDynamicSqlSupport.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/groupby/GroupByMapper.java
+++ b/src/test/java/examples/groupby/GroupByMapper.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2017 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/groupby/GroupByTest.java
+++ b/src/test/java/examples/groupby/GroupByTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/groupby/Person2DynamicSqlSupport.java
+++ b/src/test/java/examples/groupby/Person2DynamicSqlSupport.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/groupby/PersonDynamicSqlSupport.java
+++ b/src/test/java/examples/groupby/PersonDynamicSqlSupport.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/joins/ItemMasterDynamicSQLSupport.java
+++ b/src/test/java/examples/joins/ItemMasterDynamicSQLSupport.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2017 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/joins/JoinMapper.java
+++ b/src/test/java/examples/joins/JoinMapper.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2018 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/joins/JoinMapperTest.java
+++ b/src/test/java/examples/joins/JoinMapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/joins/OrderDetail.java
+++ b/src/test/java/examples/joins/OrderDetail.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2017 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/joins/OrderDetailDynamicSQLSupport.java
+++ b/src/test/java/examples/joins/OrderDetailDynamicSQLSupport.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2017 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/joins/OrderLineDynamicSQLSupport.java
+++ b/src/test/java/examples/joins/OrderLineDynamicSQLSupport.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2017 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/joins/OrderMaster.java
+++ b/src/test/java/examples/joins/OrderMaster.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2017 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/joins/OrderMasterDynamicSQLSupport.java
+++ b/src/test/java/examples/joins/OrderMasterDynamicSQLSupport.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2017 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/joins/User.java
+++ b/src/test/java/examples/joins/User.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2018 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/joins/UserDynamicSQLSupport.java
+++ b/src/test/java/examples/joins/UserDynamicSQLSupport.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2018 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/paging/LimitAndOffsetAdapter.java
+++ b/src/test/java/examples/paging/LimitAndOffsetAdapter.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/paging/LimitAndOffsetMapper.java
+++ b/src/test/java/examples/paging/LimitAndOffsetMapper.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2018 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/paging/LimitAndOffsetTest.java
+++ b/src/test/java/examples/paging/LimitAndOffsetTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/schema_supplier/SchemaSupplier.java
+++ b/src/test/java/examples/schema_supplier/SchemaSupplier.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/schema_supplier/SchemaSupplierTest.java
+++ b/src/test/java/examples/schema_supplier/SchemaSupplierTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/schema_supplier/User.java
+++ b/src/test/java/examples/schema_supplier/User.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/schema_supplier/UserDynamicSqlSupport.java
+++ b/src/test/java/examples/schema_supplier/UserDynamicSqlSupport.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/schema_supplier/UserMapper.java
+++ b/src/test/java/examples/schema_supplier/UserMapper.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/simple/AddressDynamicSqlSupport.java
+++ b/src/test/java/examples/simple/AddressDynamicSqlSupport.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/simple/AddressRecord.java
+++ b/src/test/java/examples/simple/AddressRecord.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/simple/LastName.java
+++ b/src/test/java/examples/simple/LastName.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/simple/LastNameTypeHandler.java
+++ b/src/test/java/examples/simple/LastNameTypeHandler.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/simple/PersonDynamicSqlSupport.java
+++ b/src/test/java/examples/simple/PersonDynamicSqlSupport.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/simple/PersonMapper.java
+++ b/src/test/java/examples/simple/PersonMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/simple/PersonMapperTest.java
+++ b/src/test/java/examples/simple/PersonMapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/simple/PersonRecord.java
+++ b/src/test/java/examples/simple/PersonRecord.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/simple/PersonWithAddress.java
+++ b/src/test/java/examples/simple/PersonWithAddress.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/simple/PersonWithAddressMapper.java
+++ b/src/test/java/examples/simple/PersonWithAddressMapper.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/simple/ReusableWhereTest.java
+++ b/src/test/java/examples/simple/ReusableWhereTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/simple/YesNoTypeHandler.java
+++ b/src/test/java/examples/simple/YesNoTypeHandler.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/simple/legacy/LegacyPersonMapper.java
+++ b/src/test/java/examples/simple/legacy/LegacyPersonMapper.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/simple/legacy/LegacyPersonMapperTest.java
+++ b/src/test/java/examples/simple/legacy/LegacyPersonMapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/simple/legacy/SampleWhereClausesTest.java
+++ b/src/test/java/examples/simple/legacy/SampleWhereClausesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/spring/AddressDynamicSqlSupport.java
+++ b/src/test/java/examples/spring/AddressDynamicSqlSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/spring/AddressRecord.java
+++ b/src/test/java/examples/spring/AddressRecord.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/spring/LastName.java
+++ b/src/test/java/examples/spring/LastName.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/spring/LastNameParameterConverter.java
+++ b/src/test/java/examples/spring/LastNameParameterConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/spring/PersonDynamicSqlSupport.java
+++ b/src/test/java/examples/spring/PersonDynamicSqlSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/spring/PersonRecord.java
+++ b/src/test/java/examples/spring/PersonRecord.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/spring/PersonTemplateTest.java
+++ b/src/test/java/examples/spring/PersonTemplateTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/spring/PersonWithAddress.java
+++ b/src/test/java/examples/spring/PersonWithAddress.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/spring/ReusableWhereTest.java
+++ b/src/test/java/examples/spring/ReusableWhereTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/spring/YesNoParameterConverter.java
+++ b/src/test/java/examples/spring/YesNoParameterConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/springbatch/bulkinsert/BulkInsertConfiguration.java
+++ b/src/test/java/examples/springbatch/bulkinsert/BulkInsertConfiguration.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/springbatch/bulkinsert/SpringBatchBulkInsertTest.java
+++ b/src/test/java/examples/springbatch/bulkinsert/SpringBatchBulkInsertTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/springbatch/bulkinsert/TestRecordGenerator.java
+++ b/src/test/java/examples/springbatch/bulkinsert/TestRecordGenerator.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/springbatch/common/PersonProcessor.java
+++ b/src/test/java/examples/springbatch/common/PersonProcessor.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/springbatch/common/PersonRecord.java
+++ b/src/test/java/examples/springbatch/common/PersonRecord.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/springbatch/common/UpdateStatementConvertor.java
+++ b/src/test/java/examples/springbatch/common/UpdateStatementConvertor.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/springbatch/cursor/CursorReaderBatchConfiguration.java
+++ b/src/test/java/examples/springbatch/cursor/CursorReaderBatchConfiguration.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/springbatch/cursor/SpringBatchCursorTest.java
+++ b/src/test/java/examples/springbatch/cursor/SpringBatchCursorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/springbatch/mapper/PersonDynamicSqlSupport.java
+++ b/src/test/java/examples/springbatch/mapper/PersonDynamicSqlSupport.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/springbatch/mapper/PersonMapper.java
+++ b/src/test/java/examples/springbatch/mapper/PersonMapper.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/springbatch/paging/PagingReaderBatchConfiguration.java
+++ b/src/test/java/examples/springbatch/paging/PagingReaderBatchConfiguration.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/springbatch/paging/SpringBatchPagingTest.java
+++ b/src/test/java/examples/springbatch/paging/SpringBatchPagingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/type_conversion/MyFilesDynamicSqlSupport.java
+++ b/src/test/java/examples/type_conversion/MyFilesDynamicSqlSupport.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/type_conversion/MyFilesMapper.java
+++ b/src/test/java/examples/type_conversion/MyFilesMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/type_conversion/ToBase64.java
+++ b/src/test/java/examples/type_conversion/ToBase64.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/examples/type_conversion/TypeConversionTest.java
+++ b/src/test/java/examples/type_conversion/TypeConversionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/issues/gh100/FromGroupByTest.java
+++ b/src/test/java/issues/gh100/FromGroupByTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/issues/gh100/FromJoinWhereTest.java
+++ b/src/test/java/issues/gh100/FromJoinWhereTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/issues/gh100/Issue100StartAfterJoinTest.java
+++ b/src/test/java/issues/gh100/Issue100StartAfterJoinTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/issues/gh100/Issue100Test.java
+++ b/src/test/java/issues/gh100/Issue100Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/issues/gh100/StudentDynamicSqlSupport.java
+++ b/src/test/java/issues/gh100/StudentDynamicSqlSupport.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/issues/gh100/StudentRegDynamicSqlSupport.java
+++ b/src/test/java/issues/gh100/StudentRegDynamicSqlSupport.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/issues/gh105/Issue105Test.java
+++ b/src/test/java/issues/gh105/Issue105Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/issues/gh105/PersonDynamicSqlSupport.java
+++ b/src/test/java/issues/gh105/PersonDynamicSqlSupport.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/issues/gh105/SearchUtils.java
+++ b/src/test/java/issues/gh105/SearchUtils.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/issues/lhg142/Issue142Test.java
+++ b/src/test/java/issues/lhg142/Issue142Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/issues/lhg142/MyMarkDynamicSqlSupport.java
+++ b/src/test/java/issues/lhg142/MyMarkDynamicSqlSupport.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/issues/lhg142/Page.java
+++ b/src/test/java/issues/lhg142/Page.java
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/mybatis/dynamic/sql/BindableColumnTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/BindableColumnTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/org/mybatis/dynamic/sql/SqlTableTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/SqlTableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/org/mybatis/dynamic/sql/delete/DeleteStatementTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/delete/DeleteStatementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/org/mybatis/dynamic/sql/insert/GeneralInsertStatementTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/insert/GeneralInsertStatementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/org/mybatis/dynamic/sql/insert/InsertStatementTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/insert/InsertStatementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/org/mybatis/dynamic/sql/mybatis3/CriterionRendererTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/mybatis3/CriterionRendererTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/org/mybatis/dynamic/sql/mybatis3/InsertStatementTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/mybatis3/InsertStatementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/org/mybatis/dynamic/sql/mybatis3/SelectStatementTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/mybatis3/SelectStatementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/org/mybatis/dynamic/sql/mybatis3/UpdateStatementTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/mybatis3/UpdateStatementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/org/mybatis/dynamic/sql/select/SelectStatementTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/select/SelectStatementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/org/mybatis/dynamic/sql/subselect/SubSelectTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/subselect/SubSelectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/org/mybatis/dynamic/sql/update/UpdateStatementTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/update/UpdateStatementTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/org/mybatis/dynamic/sql/util/ColumnMappingVisitorTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/util/ColumnMappingVisitorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/org/mybatis/dynamic/sql/util/FragmentCollectorTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/util/FragmentCollectorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/org/mybatis/dynamic/sql/where/WhereModelTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/where/WhereModelTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/org/mybatis/dynamic/sql/where/render/CriterionRendererTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/where/render/CriterionRendererTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/org/mybatis/dynamic/sql/where/render/OptionalCriterionRenderTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/where/render/OptionalCriterionRenderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/org/mybatis/dynamic/sql/where/render/RenderedCriterionTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/where/render/RenderedCriterionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/kotlin/examples/kotlin/mybatis3/canonical/AddressDynamicSqlSupport.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/canonical/AddressDynamicSqlSupport.kt
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/kotlin/examples/kotlin/mybatis3/canonical/AddressRecord.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/canonical/AddressRecord.kt
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/kotlin/examples/kotlin/mybatis3/canonical/LastName.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/canonical/LastName.kt
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/kotlin/examples/kotlin/mybatis3/canonical/LastNameTypeHandler.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/canonical/LastNameTypeHandler.kt
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonDynamicSqlSupport.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonDynamicSqlSupport.kt
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonMapper.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonMapper.kt
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonMapperExtensions.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonMapperExtensions.kt
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonMapperTest.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonMapperTest.kt
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonRecord.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonRecord.kt
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonWithAddress.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonWithAddress.kt
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonWithAddressMapper.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonWithAddressMapper.kt
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonWithAddressMapperExtensions.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonWithAddressMapperExtensions.kt
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/kotlin/examples/kotlin/mybatis3/canonical/ReusableWhereTest.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/canonical/ReusableWhereTest.kt
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/kotlin/examples/kotlin/mybatis3/canonical/YesNoTypeHandler.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/canonical/YesNoTypeHandler.kt
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/kotlin/examples/kotlin/mybatis3/general/GeneralKotlinTest.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/general/GeneralKotlinTest.kt
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/kotlin/examples/kotlin/mybatis3/joins/Domain.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/joins/Domain.kt
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/kotlin/examples/kotlin/mybatis3/joins/ItemMasterDynamicSQLSupport.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/joins/ItemMasterDynamicSQLSupport.kt
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/kotlin/examples/kotlin/mybatis3/joins/JoinMapper.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/joins/JoinMapper.kt
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/kotlin/examples/kotlin/mybatis3/joins/JoinMapperTest.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/joins/JoinMapperTest.kt
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/kotlin/examples/kotlin/mybatis3/joins/OrderDetailDynamicSQLSupport.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/joins/OrderDetailDynamicSQLSupport.kt
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/kotlin/examples/kotlin/mybatis3/joins/OrderLineDynamicSQLSupport.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/joins/OrderLineDynamicSQLSupport.kt
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/kotlin/examples/kotlin/mybatis3/joins/OrderMasterDynamicSQLSupport.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/joins/OrderMasterDynamicSQLSupport.kt
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/kotlin/examples/kotlin/mybatis3/joins/UserDynamicSQLSupport.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/joins/UserDynamicSQLSupport.kt
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/kotlin/examples/kotlin/spring/canonical/AddressDynamicSqlSupport.kt
+++ b/src/test/kotlin/examples/kotlin/spring/canonical/AddressDynamicSqlSupport.kt
@@ -1,5 +1,5 @@
-/**
- *    Copyright 2016-2019 the original author or authors.
+/*
+ *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/kotlin/examples/kotlin/spring/canonical/CanonicalSpringKotlinTemplateDirectTest.kt
+++ b/src/test/kotlin/examples/kotlin/spring/canonical/CanonicalSpringKotlinTemplateDirectTest.kt
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/kotlin/examples/kotlin/spring/canonical/CanonicalSpringKotlinTest.kt
+++ b/src/test/kotlin/examples/kotlin/spring/canonical/CanonicalSpringKotlinTest.kt
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/kotlin/examples/kotlin/spring/canonical/DomainAndConverters.kt
+++ b/src/test/kotlin/examples/kotlin/spring/canonical/DomainAndConverters.kt
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/kotlin/examples/kotlin/spring/canonical/GeneratedAlwaysDynamicSqlSupport.kt
+++ b/src/test/kotlin/examples/kotlin/spring/canonical/GeneratedAlwaysDynamicSqlSupport.kt
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/kotlin/examples/kotlin/spring/canonical/PersonDynamicSqlSupport.kt
+++ b/src/test/kotlin/examples/kotlin/spring/canonical/PersonDynamicSqlSupport.kt
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/kotlin/examples/kotlin/spring/canonical/RowMappers.kt
+++ b/src/test/kotlin/examples/kotlin/spring/canonical/RowMappers.kt
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2016-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
The JavaDoc style comment is incorrect for Java and Kotlin.
IntelliJ is constantly complaining (rightly so) about the generated
license headers. This will be resolved in the next release of the license plugin
by default.