### PR TITLE
Add a SortSpecification for Columns in Joins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@ This log will detail notable changes to MyBatis Dynamic SQL. Full details are av
 
 ### Added
 
-- Added a new sort specification that is useful in selects with joins
-
+- Added a new sort specification that is useful in selects with joins ([#269](https://github.com/mybatis/mybatis-dynamic-sql/pull/269))
 
 ## Release 1.2.1 - September 29, 2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This log will detail notable changes to MyBatis Dynamic SQL. Full details are available on the GitHub milestone pages.
 
+## Release 1.3.0 - Unreleased
+
+### Added
+
+- Added a new sort specification that is useful in selects with joins
+
+
 ## Release 1.2.1 - September 29, 2020
 
 GitHub milestone: [https://github.com/mybatis/mybatis-dynamic-sql/issues?q=milestone%3A1.2.1+](https://github.com/mybatis/mybatis-dynamic-sql/issues?q=milestone%3A1.2.1+)

--- a/src/main/java/org/mybatis/dynamic/sql/SortSpecification.java
+++ b/src/main/java/org/mybatis/dynamic/sql/SortSpecification.java
@@ -31,11 +31,12 @@ public interface SortSpecification {
     SortSpecification descending();
 
     /**
-     * Return the column alias or column name.
+     * Return the phrase that should be written into a rendered order by clause. This should
+     * NOT include the "DESC" word for descending sort specifications.
      *
-     * @return the column alias if one has been specified by the user, or else the column name
+     * @return the order by phrase
      */
-    String aliasOrName();
+    String orderByName();
 
     /**
      * Return true if the sort order is descending.

--- a/src/main/java/org/mybatis/dynamic/sql/SqlBuilder.java
+++ b/src/main/java/org/mybatis/dynamic/sql/SqlBuilder.java
@@ -27,6 +27,7 @@ import org.mybatis.dynamic.sql.insert.GeneralInsertDSL;
 import org.mybatis.dynamic.sql.insert.InsertDSL;
 import org.mybatis.dynamic.sql.insert.InsertSelectDSL;
 import org.mybatis.dynamic.sql.insert.MultiRowInsertDSL;
+import org.mybatis.dynamic.sql.select.ColumnSortSpecification;
 import org.mybatis.dynamic.sql.select.CountDSL;
 import org.mybatis.dynamic.sql.select.QueryExpressionDSL.FromGatherer;
 import org.mybatis.dynamic.sql.select.SelectDSL;
@@ -737,8 +738,35 @@ public interface SqlBuilder {
     }
 
     // order by support
+
+    /**
+     * Creates a sort specification based on a String. This is useful when a column has been
+     * aliased in the select list. For example:
+     *
+     * <pre>
+     *     select(foo.as("bar"))
+     *     .from(baz)
+     *     .orderBy(sortColumn("bar"))
+     * </pre>
+     *
+     * @param name the string to use as a sort specification
+     * @return a sort specification
+     */
     static SortSpecification sortColumn(String name) {
         return SimpleSortSpecification.of(name);
+    }
+
+    /**
+     * Creates a sort specification based on a column and a table alias. This can be useful in a join
+     * where the desired sort order is based on a column not in the select list. This will likely
+     * fail in union queries depending on database support.
+     *
+     * @param tableAlias the table alias
+     * @param column the column
+     * @return a sort specification
+     */
+    static SortSpecification sortColumn(String tableAlias, SqlColumn<?> column) {
+        return new ColumnSortSpecification(tableAlias, column);
     }
 
     class InsertIntoNextStep {

--- a/src/main/java/org/mybatis/dynamic/sql/SqlColumn.java
+++ b/src/main/java/org/mybatis/dynamic/sql/SqlColumn.java
@@ -91,7 +91,7 @@ public class SqlColumn<T> implements BindableColumn<T>, SortSpecification {
     }
 
     @Override
-    public String aliasOrName() {
+    public String orderByName() {
         return alias().orElse(name);
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/select/ColumnSortSpecification.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/ColumnSortSpecification.java
@@ -15,10 +15,10 @@
  */
 package org.mybatis.dynamic.sql.select;
 
+import java.util.Objects;
+
 import org.mybatis.dynamic.sql.SortSpecification;
 import org.mybatis.dynamic.sql.SqlColumn;
-
-import java.util.Objects;
 
 public class ColumnSortSpecification implements SortSpecification {
     private final String tableAlias;

--- a/src/main/java/org/mybatis/dynamic/sql/select/ColumnSortSpecification.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/ColumnSortSpecification.java
@@ -1,0 +1,52 @@
+/*
+ *    Copyright 2016-2020 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.dynamic.sql.select;
+
+import org.mybatis.dynamic.sql.SortSpecification;
+import org.mybatis.dynamic.sql.SqlColumn;
+
+import java.util.Objects;
+
+public class ColumnSortSpecification implements SortSpecification {
+    private final String tableAlias;
+    private final SqlColumn<?> column;
+    private final boolean isDescending;
+
+    public ColumnSortSpecification(String tableAlias, SqlColumn<?> column) {
+        this(tableAlias, column, false);
+    }
+
+    private ColumnSortSpecification(String tableAlias, SqlColumn<?> column, boolean isDescending) {
+        this.tableAlias = Objects.requireNonNull(tableAlias);
+        this.column = Objects.requireNonNull(column);
+        this.isDescending = isDescending;
+    }
+
+    @Override
+    public SortSpecification descending() {
+        return new ColumnSortSpecification(tableAlias, column, true);
+    }
+
+    @Override
+    public String orderByName() {
+        return tableAlias + "." + column.name(); //$NON-NLS-1$
+    }
+
+    @Override
+    public boolean isDescending() {
+        return isDescending;
+    }
+}

--- a/src/main/java/org/mybatis/dynamic/sql/select/SimpleSortSpecification.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/SimpleSortSpecification.java
@@ -31,8 +31,7 @@ public class SimpleSortSpecification implements SortSpecification {
     private final boolean isDescending;
 
     private SimpleSortSpecification(String name) {
-        this.name = Objects.requireNonNull(name);
-        this.isDescending = false;
+        this(name, false);
     }
 
     private SimpleSortSpecification(String name, boolean isDescending) {
@@ -46,7 +45,7 @@ public class SimpleSortSpecification implements SortSpecification {
     }
 
     @Override
-    public String aliasOrName() {
+    public String orderByName() {
         return name;
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/select/render/SelectRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/render/SelectRenderer.java
@@ -74,7 +74,7 @@ public class SelectRenderer {
     }
 
     private String calculateOrderByPhrase(SortSpecification column) {
-        String phrase = column.aliasOrName();
+        String phrase = column.orderByName();
         if (column.isDescending()) {
             phrase = phrase + " DESC"; //$NON-NLS-1$
         }

--- a/src/site/markdown/docs/select.md
+++ b/src/site/markdown/docs/select.md
@@ -176,13 +176,22 @@ The XML element should look like this:
 ## Notes on Order By
 
 Order by phrases can be difficult to calculate when there are aliased columns, aliased tables, unions, and joins.
-This library has taken a simple approach - the library will either write the column alias or the column
-name into the order by phrase.  For the order by phrase, the table alias (if there is one) will be ignored.
+This library has taken a relatively simple approach:
+
+1. When specifying an SqlColumn in an ORDER BY phrase the library will either write the column alias or the column
+name into the ORDER BY phrase.  For the ORDER BY phrase, the table alias (if there is one) will be ignored. Use this pattern
+when the ORDER BY column is a member of the select list. For example `orderBy(foo)`. If the column has an alias, then
+it is easist to use the "arbitrary string" method with the column alias as shown below.
+1. It is also possible to explicitly specify a table alias for a column in an ORDER BY phrase. Use this pattern when
+there is a join, and the ORDER BY column is in two or more tables, and the ORDER BY column is not in the select
+list. For example `orderBy(sortColumn("t1", foo))`.
+1. If none of the above use cases meet your needs, then you can specify an arbitrary String to write into the rendered ORDER BY
+phrase (see below for an example).  
 
 In our testing, this caused an issue in only one case.  When there is an outer join and the select list contains
 both the left and right join column.  In that case, the workaround is to supply a column alias for both columns.
 
-When using a column function (lower, upper, etc.), then is is customary to give the calculated column an alias so you will have a predictable result set.  In cases like this there will not be a column to use for an alias.  The library supports arbitrary values in an ORDER BY expression like this:
+When using a column function (lower, upper, etc.), then it is customary to give the calculated column an alias so you will have a predictable result set.  In cases like this there will not be a column to use for an alias.  The library supports arbitrary values in an ORDER BY expression like this:
 
 ```java
     SelectStatementProvider selectStatement = select(substring(gender, 1, 1).as("ShortGender"), avg(age).as("AverageAge"))


### PR DESCRIPTION
If an order by column is not in the select list, and there is a join, then specifying the proper join clause can be a bit difficult. This PR adds a new SortSpecification implementation designed for this purpose, and a utility method in the SqlBuilder to create it.

Resolves #268