### PR TITLE
Refactor Where support

### DIFF
--- a/src/main/java/org/mybatis/dynamic/sql/delete/DeleteDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/delete/DeleteDSL.java
@@ -83,7 +83,7 @@ public class DeleteDSL<R> extends AbstractWhereSupportingDSL<DeleteDSL<R>.Delete
 
         @Override
         protected WhereModel buildWhereModel() {
-            return super.internalBuild();
+            return super.buildWhereModel();
         }
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/delete/DeleteDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/delete/DeleteDSL.java
@@ -22,10 +22,10 @@ import org.jetbrains.annotations.NotNull;
 import org.mybatis.dynamic.sql.SqlTable;
 import org.mybatis.dynamic.sql.util.Buildable;
 import org.mybatis.dynamic.sql.where.AbstractWhereDSL;
-import org.mybatis.dynamic.sql.where.AbstractWhereSupportingDSL;
+import org.mybatis.dynamic.sql.where.AbstractWhereSupport;
 import org.mybatis.dynamic.sql.where.WhereModel;
 
-public class DeleteDSL<R> extends AbstractWhereSupportingDSL<DeleteDSL<R>.DeleteWhereBuilder> implements Buildable<R> {
+public class DeleteDSL<R> extends AbstractWhereSupport<DeleteDSL<R>.DeleteWhereBuilder> implements Buildable<R> {
 
     private final Function<DeleteModel, R> adapterFunction;
     private final SqlTable table;

--- a/src/main/java/org/mybatis/dynamic/sql/delete/DeleteDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/delete/DeleteDSL.java
@@ -19,16 +19,13 @@ import java.util.Objects;
 import java.util.function.Function;
 
 import org.jetbrains.annotations.NotNull;
-import org.mybatis.dynamic.sql.BindableColumn;
-import org.mybatis.dynamic.sql.SqlCriterion;
 import org.mybatis.dynamic.sql.SqlTable;
-import org.mybatis.dynamic.sql.VisitableCondition;
 import org.mybatis.dynamic.sql.util.Buildable;
 import org.mybatis.dynamic.sql.where.AbstractWhereDSL;
-import org.mybatis.dynamic.sql.where.WhereApplier;
+import org.mybatis.dynamic.sql.where.AbstractWhereSupportingDSL;
 import org.mybatis.dynamic.sql.where.WhereModel;
 
-public class DeleteDSL<R> implements Buildable<R> {
+public class DeleteDSL<R> extends AbstractWhereSupportingDSL<DeleteDSL<R>.DeleteWhereBuilder> implements Buildable<R> {
 
     private final Function<DeleteModel, R> adapterFunction;
     private final SqlTable table;
@@ -39,18 +36,9 @@ public class DeleteDSL<R> implements Buildable<R> {
         this.adapterFunction = Objects.requireNonNull(adapterFunction);
     }
 
-    public DeleteWhereBuilder where() {
+    @Override
+    protected DeleteWhereBuilder whereDsl() {
         return whereBuilder;
-    }
-
-    public <T> DeleteWhereBuilder where(BindableColumn<T> column, VisitableCondition<T> condition,
-            SqlCriterion<?>...subCriteria) {
-        whereBuilder.where(column, condition, subCriteria);
-        return whereBuilder;
-    }
-
-    public DeleteWhereBuilder applyWhere(WhereApplier whereApplier) {
-        return whereBuilder.applyWhere(whereApplier);
     }
 
     /**

--- a/src/main/java/org/mybatis/dynamic/sql/delete/DeleteDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/delete/DeleteDSL.java
@@ -37,7 +37,7 @@ public class DeleteDSL<R> extends AbstractWhereSupportingDSL<DeleteDSL<R>.Delete
     }
 
     @Override
-    protected DeleteWhereBuilder whereDsl() {
+    public DeleteWhereBuilder where() {
         return whereBuilder;
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/delete/DeleteDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/delete/DeleteDSL.java
@@ -81,9 +81,8 @@ public class DeleteDSL<R> extends AbstractWhereSupportingDSL<DeleteDSL<R>.Delete
             return this;
         }
 
-        @Override
         protected WhereModel buildWhereModel() {
-            return super.buildWhereModel();
+            return internalBuild();
         }
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/select/AbstractQueryExpressionDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/AbstractQueryExpressionDSL.java
@@ -31,8 +31,11 @@ import org.mybatis.dynamic.sql.select.join.JoinModel;
 import org.mybatis.dynamic.sql.select.join.JoinSpecification;
 import org.mybatis.dynamic.sql.select.join.JoinType;
 import org.mybatis.dynamic.sql.util.Buildable;
+import org.mybatis.dynamic.sql.where.AbstractWhereDSL;
+import org.mybatis.dynamic.sql.where.AbstractWhereSupportingDSL;
 
-public abstract class AbstractQueryExpressionDSL<T extends AbstractQueryExpressionDSL<T, R>, R>
+public abstract class AbstractQueryExpressionDSL<W extends AbstractWhereDSL<?>, T extends AbstractQueryExpressionDSL<W, T, R>, R>
+        extends AbstractWhereSupportingDSL<W>
         implements Buildable<R> {
 
     private final List<JoinSpecification.Builder> joinSpecificationBuilders = new ArrayList<>();

--- a/src/main/java/org/mybatis/dynamic/sql/select/AbstractQueryExpressionDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/AbstractQueryExpressionDSL.java
@@ -34,7 +34,11 @@ import org.mybatis.dynamic.sql.util.Buildable;
 import org.mybatis.dynamic.sql.where.AbstractWhereDSL;
 import org.mybatis.dynamic.sql.where.AbstractWhereSupportingDSL;
 
-public abstract class AbstractQueryExpressionDSL<W extends AbstractWhereDSL<?>, T extends AbstractQueryExpressionDSL<W, T, R>, R>
+public abstract class AbstractQueryExpressionDSL<
+            W extends AbstractWhereDSL<?>,
+            T extends AbstractQueryExpressionDSL<W, T, R>,
+            R
+        >
         extends AbstractWhereSupportingDSL<W>
         implements Buildable<R> {
 

--- a/src/main/java/org/mybatis/dynamic/sql/select/AbstractQueryExpressionDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/AbstractQueryExpressionDSL.java
@@ -32,14 +32,11 @@ import org.mybatis.dynamic.sql.select.join.JoinSpecification;
 import org.mybatis.dynamic.sql.select.join.JoinType;
 import org.mybatis.dynamic.sql.util.Buildable;
 import org.mybatis.dynamic.sql.where.AbstractWhereDSL;
-import org.mybatis.dynamic.sql.where.AbstractWhereSupportingDSL;
+import org.mybatis.dynamic.sql.where.AbstractWhereSupport;
 
-public abstract class AbstractQueryExpressionDSL<
-            W extends AbstractWhereDSL<?>,
-            T extends AbstractQueryExpressionDSL<W, T, R>,
-            R
-        >
-        extends AbstractWhereSupportingDSL<W>
+public abstract class AbstractQueryExpressionDSL<W extends AbstractWhereDSL<?>,
+            T extends AbstractQueryExpressionDSL<W, T, R>, R>
+        extends AbstractWhereSupport<W>
         implements Buildable<R> {
 
     private final List<JoinSpecification.Builder> joinSpecificationBuilders = new ArrayList<>();

--- a/src/main/java/org/mybatis/dynamic/sql/select/CountDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/CountDSL.java
@@ -132,7 +132,7 @@ public class CountDSL<R> extends AbstractQueryExpressionDSL<CountDSL<R>.CountWhe
 
         @Override
         protected WhereModel buildWhereModel() {
-            return super.internalBuild();
+            return super.buildWhereModel();
         }
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/select/CountDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/CountDSL.java
@@ -20,14 +20,10 @@ import java.util.function.Function;
 
 import org.jetbrains.annotations.NotNull;
 import org.mybatis.dynamic.sql.BasicColumn;
-import org.mybatis.dynamic.sql.BindableColumn;
 import org.mybatis.dynamic.sql.SqlBuilder;
-import org.mybatis.dynamic.sql.SqlCriterion;
 import org.mybatis.dynamic.sql.SqlTable;
-import org.mybatis.dynamic.sql.VisitableCondition;
 import org.mybatis.dynamic.sql.util.Buildable;
 import org.mybatis.dynamic.sql.where.AbstractWhereDSL;
-import org.mybatis.dynamic.sql.where.WhereApplier;
 import org.mybatis.dynamic.sql.where.WhereModel;
 
 /**
@@ -39,7 +35,7 @@ import org.mybatis.dynamic.sql.where.WhereModel;
  *
  * @author Jeff Butler
  */
-public class CountDSL<R> extends AbstractQueryExpressionDSL<CountDSL<R>, R> implements Buildable<R> {
+public class CountDSL<R> extends AbstractQueryExpressionDSL<CountDSL<R>.CountWhereBuilder, CountDSL<R>, R> implements Buildable<R> {
 
     private final Function<SelectModel, R> adapterFunction;
     private final CountWhereBuilder whereBuilder = new CountWhereBuilder();
@@ -51,18 +47,9 @@ public class CountDSL<R> extends AbstractQueryExpressionDSL<CountDSL<R>, R> impl
         this.adapterFunction = Objects.requireNonNull(adapterFunction);
     }
 
-    public CountWhereBuilder where() {
+    @Override
+    protected CountWhereBuilder whereDsl() {
         return whereBuilder;
-    }
-
-    public <T> CountWhereBuilder where(BindableColumn<T> column, VisitableCondition<T> condition,
-            SqlCriterion<?>...subCriteria) {
-        whereBuilder.where(column, condition, subCriteria);
-        return whereBuilder;
-    }
-
-    public CountWhereBuilder applyWhere(WhereApplier whereApplier) {
-        return whereBuilder.applyWhere(whereApplier);
     }
 
     @NotNull

--- a/src/main/java/org/mybatis/dynamic/sql/select/CountDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/CountDSL.java
@@ -35,7 +35,8 @@ import org.mybatis.dynamic.sql.where.WhereModel;
  *
  * @author Jeff Butler
  */
-public class CountDSL<R> extends AbstractQueryExpressionDSL<CountDSL<R>.CountWhereBuilder, CountDSL<R>, R> implements Buildable<R> {
+public class CountDSL<R> extends AbstractQueryExpressionDSL<CountDSL<R>.CountWhereBuilder, CountDSL<R>, R>
+        implements Buildable<R> {
 
     private final Function<SelectModel, R> adapterFunction;
     private final CountWhereBuilder whereBuilder = new CountWhereBuilder();
@@ -130,9 +131,8 @@ public class CountDSL<R> extends AbstractQueryExpressionDSL<CountDSL<R>.CountWhe
             return this;
         }
 
-        @Override
         protected WhereModel buildWhereModel() {
-            return super.buildWhereModel();
+            return internalBuild();
         }
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/select/CountDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/CountDSL.java
@@ -48,7 +48,7 @@ public class CountDSL<R> extends AbstractQueryExpressionDSL<CountDSL<R>.CountWhe
     }
 
     @Override
-    protected CountWhereBuilder whereDsl() {
+    public CountWhereBuilder where() {
         return whereBuilder;
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/select/QueryExpressionDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/QueryExpressionDSL.java
@@ -286,7 +286,7 @@ public class QueryExpressionDSL<R> extends AbstractQueryExpressionDSL<QueryExpre
 
         @Override
         protected WhereModel buildWhereModel() {
-            return super.internalBuild();
+            return super.buildWhereModel();
         }
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/select/QueryExpressionDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/QueryExpressionDSL.java
@@ -23,22 +23,20 @@ import java.util.Objects;
 
 import org.jetbrains.annotations.NotNull;
 import org.mybatis.dynamic.sql.BasicColumn;
-import org.mybatis.dynamic.sql.BindableColumn;
 import org.mybatis.dynamic.sql.SortSpecification;
-import org.mybatis.dynamic.sql.SqlCriterion;
 import org.mybatis.dynamic.sql.SqlTable;
 import org.mybatis.dynamic.sql.TableExpression;
-import org.mybatis.dynamic.sql.VisitableCondition;
 import org.mybatis.dynamic.sql.select.join.JoinCondition;
 import org.mybatis.dynamic.sql.select.join.JoinCriterion;
 import org.mybatis.dynamic.sql.select.join.JoinSpecification;
 import org.mybatis.dynamic.sql.select.join.JoinType;
 import org.mybatis.dynamic.sql.util.Buildable;
 import org.mybatis.dynamic.sql.where.AbstractWhereDSL;
-import org.mybatis.dynamic.sql.where.WhereApplier;
+import org.mybatis.dynamic.sql.where.AbstractWhereSupportingDSL;
 import org.mybatis.dynamic.sql.where.WhereModel;
 
-public class QueryExpressionDSL<R> extends AbstractQueryExpressionDSL<QueryExpressionDSL<R>.QueryExpressionWhereBuilder, QueryExpressionDSL<R>, R>
+public class QueryExpressionDSL<R>
+        extends AbstractQueryExpressionDSL<QueryExpressionDSL<R>.QueryExpressionWhereBuilder, QueryExpressionDSL<R>, R>
         implements Buildable<R> {
 
     private final String connector;
@@ -284,9 +282,8 @@ public class QueryExpressionDSL<R> extends AbstractQueryExpressionDSL<QueryExpre
             return this;
         }
 
-        @Override
         protected WhereModel buildWhereModel() {
-            return super.buildWhereModel();
+            return internalBuild();
         }
     }
 
@@ -309,7 +306,8 @@ public class QueryExpressionDSL<R> extends AbstractQueryExpressionDSL<QueryExpre
         }
     }
 
-    public class JoinSpecificationFinisher implements Buildable<R> {
+    public class JoinSpecificationFinisher extends AbstractWhereSupportingDSL<QueryExpressionWhereBuilder>
+            implements Buildable<R> {
         private final JoinSpecification.Builder joinSpecificationBuilder;
 
         public JoinSpecificationFinisher(TableExpression table, BasicColumn joinColumn,
@@ -349,17 +347,9 @@ public class QueryExpressionDSL<R> extends AbstractQueryExpressionDSL<QueryExpre
             return QueryExpressionDSL.this.build();
         }
 
+        @Override
         public QueryExpressionWhereBuilder where() {
             return QueryExpressionDSL.this.where();
-        }
-
-        public <T> QueryExpressionWhereBuilder where(BindableColumn<T> column, VisitableCondition<T> condition,
-                SqlCriterion<?>...subCriteria) {
-            return QueryExpressionDSL.this.where(column, condition, subCriteria);
-        }
-
-        public QueryExpressionWhereBuilder applyWhere(WhereApplier whereApplier) {
-            return QueryExpressionDSL.this.applyWhere(whereApplier);
         }
 
         public JoinSpecificationFinisher and(BasicColumn joinColumn, JoinCondition joinCondition) {

--- a/src/main/java/org/mybatis/dynamic/sql/select/QueryExpressionDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/QueryExpressionDSL.java
@@ -38,7 +38,7 @@ import org.mybatis.dynamic.sql.where.AbstractWhereDSL;
 import org.mybatis.dynamic.sql.where.WhereApplier;
 import org.mybatis.dynamic.sql.where.WhereModel;
 
-public class QueryExpressionDSL<R> extends AbstractQueryExpressionDSL<QueryExpressionDSL<R>, R>
+public class QueryExpressionDSL<R> extends AbstractQueryExpressionDSL<QueryExpressionDSL<R>.QueryExpressionWhereBuilder, QueryExpressionDSL<R>, R>
         implements Buildable<R> {
 
     private final String connector;
@@ -61,18 +61,9 @@ public class QueryExpressionDSL<R> extends AbstractQueryExpressionDSL<QueryExpre
         tableAliases.put(table, tableAlias);
     }
 
-    public QueryExpressionWhereBuilder where() {
+    @Override
+    protected QueryExpressionWhereBuilder whereDsl() {
         return whereBuilder;
-    }
-
-    public <T> QueryExpressionWhereBuilder where(BindableColumn<T> column, VisitableCondition<T> condition,
-            SqlCriterion<?>...subCriteria) {
-        whereBuilder.where(column, condition, subCriteria);
-        return whereBuilder;
-    }
-
-    public QueryExpressionWhereBuilder applyWhere(WhereApplier whereApplier) {
-        return whereBuilder.applyWhere(whereApplier);
     }
 
     @NotNull

--- a/src/main/java/org/mybatis/dynamic/sql/select/QueryExpressionDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/QueryExpressionDSL.java
@@ -32,7 +32,7 @@ import org.mybatis.dynamic.sql.select.join.JoinSpecification;
 import org.mybatis.dynamic.sql.select.join.JoinType;
 import org.mybatis.dynamic.sql.util.Buildable;
 import org.mybatis.dynamic.sql.where.AbstractWhereDSL;
-import org.mybatis.dynamic.sql.where.AbstractWhereSupportingDSL;
+import org.mybatis.dynamic.sql.where.AbstractWhereSupport;
 import org.mybatis.dynamic.sql.where.WhereModel;
 
 public class QueryExpressionDSL<R>
@@ -306,7 +306,7 @@ public class QueryExpressionDSL<R>
         }
     }
 
-    public class JoinSpecificationFinisher extends AbstractWhereSupportingDSL<QueryExpressionWhereBuilder>
+    public class JoinSpecificationFinisher extends AbstractWhereSupport<QueryExpressionWhereBuilder>
             implements Buildable<R> {
         private final JoinSpecification.Builder joinSpecificationBuilder;
 

--- a/src/main/java/org/mybatis/dynamic/sql/select/QueryExpressionDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/QueryExpressionDSL.java
@@ -62,7 +62,7 @@ public class QueryExpressionDSL<R> extends AbstractQueryExpressionDSL<QueryExpre
     }
 
     @Override
-    protected QueryExpressionWhereBuilder whereDsl() {
+    public QueryExpressionWhereBuilder where() {
         return whereBuilder;
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/update/UpdateDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/update/UpdateDSL.java
@@ -153,9 +153,8 @@ public class UpdateDSL<R> extends AbstractWhereSupportingDSL<UpdateDSL<R>.Update
             return this;
         }
 
-        @Override
         protected WhereModel buildWhereModel() {
-            return super.buildWhereModel();
+            return internalBuild();
         }
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/update/UpdateDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/update/UpdateDSL.java
@@ -155,7 +155,7 @@ public class UpdateDSL<R> extends AbstractWhereSupportingDSL<UpdateDSL<R>.Update
 
         @Override
         protected WhereModel buildWhereModel() {
-            return super.internalBuild();
+            return super.buildWhereModel();
         }
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/update/UpdateDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/update/UpdateDSL.java
@@ -23,11 +23,8 @@ import java.util.function.Supplier;
 
 import org.jetbrains.annotations.NotNull;
 import org.mybatis.dynamic.sql.BasicColumn;
-import org.mybatis.dynamic.sql.BindableColumn;
 import org.mybatis.dynamic.sql.SqlColumn;
-import org.mybatis.dynamic.sql.SqlCriterion;
 import org.mybatis.dynamic.sql.SqlTable;
-import org.mybatis.dynamic.sql.VisitableCondition;
 import org.mybatis.dynamic.sql.select.SelectModel;
 import org.mybatis.dynamic.sql.util.AbstractColumnMapping;
 import org.mybatis.dynamic.sql.util.Buildable;
@@ -39,10 +36,10 @@ import org.mybatis.dynamic.sql.util.StringConstantMapping;
 import org.mybatis.dynamic.sql.util.ValueMapping;
 import org.mybatis.dynamic.sql.util.ValueWhenPresentMapping;
 import org.mybatis.dynamic.sql.where.AbstractWhereDSL;
-import org.mybatis.dynamic.sql.where.WhereApplier;
+import org.mybatis.dynamic.sql.where.AbstractWhereSupportingDSL;
 import org.mybatis.dynamic.sql.where.WhereModel;
 
-public class UpdateDSL<R> implements Buildable<R> {
+public class UpdateDSL<R> extends AbstractWhereSupportingDSL<UpdateDSL<R>.UpdateWhereBuilder> implements Buildable<R> {
 
     private final Function<UpdateModel, R> adapterFunction;
     private final List<AbstractColumnMapping> columnMappings = new ArrayList<>();
@@ -58,18 +55,9 @@ public class UpdateDSL<R> implements Buildable<R> {
         return new SetClauseFinisher<>(column);
     }
 
-    public UpdateWhereBuilder where() {
+    @Override
+    protected UpdateWhereBuilder whereDsl() {
         return whereBuilder;
-    }
-
-    public <T> UpdateWhereBuilder where(BindableColumn<T> column, VisitableCondition<T> condition,
-            SqlCriterion<?>...subCriteria) {
-        whereBuilder.where(column, condition, subCriteria);
-        return whereBuilder;
-    }
-
-    public UpdateWhereBuilder applyWhere(WhereApplier whereApplier) {
-        return whereBuilder.applyWhere(whereApplier);
     }
 
     /**

--- a/src/main/java/org/mybatis/dynamic/sql/update/UpdateDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/update/UpdateDSL.java
@@ -36,10 +36,10 @@ import org.mybatis.dynamic.sql.util.StringConstantMapping;
 import org.mybatis.dynamic.sql.util.ValueMapping;
 import org.mybatis.dynamic.sql.util.ValueWhenPresentMapping;
 import org.mybatis.dynamic.sql.where.AbstractWhereDSL;
-import org.mybatis.dynamic.sql.where.AbstractWhereSupportingDSL;
+import org.mybatis.dynamic.sql.where.AbstractWhereSupport;
 import org.mybatis.dynamic.sql.where.WhereModel;
 
-public class UpdateDSL<R> extends AbstractWhereSupportingDSL<UpdateDSL<R>.UpdateWhereBuilder> implements Buildable<R> {
+public class UpdateDSL<R> extends AbstractWhereSupport<UpdateDSL<R>.UpdateWhereBuilder> implements Buildable<R> {
 
     private final Function<UpdateModel, R> adapterFunction;
     private final List<AbstractColumnMapping> columnMappings = new ArrayList<>();

--- a/src/main/java/org/mybatis/dynamic/sql/update/UpdateDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/update/UpdateDSL.java
@@ -56,7 +56,7 @@ public class UpdateDSL<R> extends AbstractWhereSupportingDSL<UpdateDSL<R>.Update
     }
 
     @Override
-    protected UpdateWhereBuilder whereDsl() {
+    public UpdateWhereBuilder where() {
         return whereBuilder;
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/where/AbstractWhereDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/AbstractWhereDSL.java
@@ -125,11 +125,9 @@ public abstract class AbstractWhereDSL<T extends AbstractWhereDSL<T>> {
         criteria.add(criterion);
     }
 
-    protected WhereModel internalBuild() {
+    protected WhereModel buildWhereModel() {
         return WhereModel.of(criteria);
     }
-
-    protected abstract WhereModel buildWhereModel();
 
     protected abstract T getThis();
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/AbstractWhereDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/AbstractWhereDSL.java
@@ -125,7 +125,7 @@ public abstract class AbstractWhereDSL<T extends AbstractWhereDSL<T>> {
         criteria.add(criterion);
     }
 
-    protected WhereModel buildWhereModel() {
+    protected WhereModel internalBuild() {
         return WhereModel.of(criteria);
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/where/AbstractWhereSupport.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/AbstractWhereSupport.java
@@ -24,11 +24,14 @@ import org.mybatis.dynamic.sql.SqlCriterion;
 import org.mybatis.dynamic.sql.VisitableCondition;
 
 /**
- * Base class for DSLs that support where clauses.
+ * Base class for DSLs that support where clauses - which is every DSL except Insert.
+ * The purpose of the class is to provide an implementation of the {@link AbstractWhereDSL}
+ * that is customized for a particular DSL, and to add the initiating common "where"
+ * methods.
  *
- * @param <W> the implementation of the Where DSL.
+ * @param <W> the implementation of the Where DSL customized for a particular SQL statement.
  */
-public abstract class AbstractWhereSupportingDSL<W extends AbstractWhereDSL<?>> {
+public abstract class AbstractWhereSupport<W extends AbstractWhereDSL<?>> {
 
     public abstract W where();
 

--- a/src/main/java/org/mybatis/dynamic/sql/where/AbstractWhereSupportingDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/AbstractWhereSupportingDSL.java
@@ -1,12 +1,27 @@
+/*
+ *    Copyright 2016-2020 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.mybatis.dynamic.sql.where;
-
-import org.mybatis.dynamic.sql.BindableColumn;
-import org.mybatis.dynamic.sql.SqlCriterion;
-import org.mybatis.dynamic.sql.VisitableCondition;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
+
+import org.mybatis.dynamic.sql.BindableColumn;
+import org.mybatis.dynamic.sql.SqlCriterion;
+import org.mybatis.dynamic.sql.VisitableCondition;
 
 /**
  * Base class for DSLs that support where clauses.
@@ -14,6 +29,8 @@ import java.util.function.Consumer;
  * @param <W> the implementation of the Where DSL.
  */
 public abstract class AbstractWhereSupportingDSL<W extends AbstractWhereDSL<?>> {
+
+    public abstract W where();
 
     public <T> W where(BindableColumn<T> column, VisitableCondition<T> condition, SqlCriterion<?>...subCriteria) {
         return where(column, condition, Arrays.asList(subCriteria));
@@ -32,6 +49,4 @@ public abstract class AbstractWhereSupportingDSL<W extends AbstractWhereDSL<?>> 
         block.accept(dsl);
         return dsl;
     }
-
-    public abstract W where();
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/AbstractWhereSupportingDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/AbstractWhereSupportingDSL.java
@@ -13,10 +13,6 @@ import java.util.function.Consumer;
  */
 public abstract class AbstractWhereSupportingDSL<W extends AbstractWhereDSL<?>> {
 
-    public W where() {
-        return whereDsl();
-    }
-
     public <T> W where(BindableColumn<T> column, VisitableCondition<T> condition, SqlCriterion<?>...subCriteria) {
         return apply(w -> w.where(column, condition, subCriteria));
     }
@@ -26,10 +22,10 @@ public abstract class AbstractWhereSupportingDSL<W extends AbstractWhereDSL<?>> 
     }
 
     private W apply(Consumer<W> block) {
-        W dsl = whereDsl();
+        W dsl = where();
         block.accept(dsl);
         return dsl;
     }
 
-    protected abstract W whereDsl();
+    public abstract W where();
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/AbstractWhereSupportingDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/AbstractWhereSupportingDSL.java
@@ -1,0 +1,35 @@
+package org.mybatis.dynamic.sql.where;
+
+import org.mybatis.dynamic.sql.BindableColumn;
+import org.mybatis.dynamic.sql.SqlCriterion;
+import org.mybatis.dynamic.sql.VisitableCondition;
+
+import java.util.function.Consumer;
+
+/**
+ * Base class for DSLs that support where clauses.
+ *
+ * @param <W> the implementation of the Where DSL.
+ */
+public abstract class AbstractWhereSupportingDSL<W extends AbstractWhereDSL<?>> {
+
+    public W where() {
+        return whereDsl();
+    }
+
+    public <T> W where(BindableColumn<T> column, VisitableCondition<T> condition, SqlCriterion<?>...subCriteria) {
+        return apply(w -> w.where(column, condition, subCriteria));
+    }
+
+    public W applyWhere(WhereApplier whereApplier) {
+        return apply(w -> w.applyWhere(whereApplier));
+    }
+
+    private W apply(Consumer<W> block) {
+        W dsl = whereDsl();
+        block.accept(dsl);
+        return dsl;
+    }
+
+    protected abstract W whereDsl();
+}

--- a/src/main/java/org/mybatis/dynamic/sql/where/AbstractWhereSupportingDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/AbstractWhereSupportingDSL.java
@@ -4,6 +4,8 @@ import org.mybatis.dynamic.sql.BindableColumn;
 import org.mybatis.dynamic.sql.SqlCriterion;
 import org.mybatis.dynamic.sql.VisitableCondition;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.function.Consumer;
 
 /**
@@ -14,6 +16,10 @@ import java.util.function.Consumer;
 public abstract class AbstractWhereSupportingDSL<W extends AbstractWhereDSL<?>> {
 
     public <T> W where(BindableColumn<T> column, VisitableCondition<T> condition, SqlCriterion<?>...subCriteria) {
+        return where(column, condition, Arrays.asList(subCriteria));
+    }
+
+    public <T> W where(BindableColumn<T> column, VisitableCondition<T> condition, List<SqlCriterion<?>> subCriteria) {
         return apply(w -> w.where(column, condition, subCriteria));
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/where/WhereDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/WhereDSL.java
@@ -30,11 +30,6 @@ public class WhereDSL extends AbstractWhereDSL<WhereDSL> {
         return new WhereDSL();
     }
 
-    @Override
-    protected WhereModel buildWhereModel() {
-        return super.internalBuild();
-    }
-
     public WhereModel build() {
         return buildWhereModel();
     }

--- a/src/main/java/org/mybatis/dynamic/sql/where/WhereDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/WhereDSL.java
@@ -31,6 +31,6 @@ public class WhereDSL extends AbstractWhereDSL<WhereDSL> {
     }
 
     public WhereModel build() {
-        return buildWhereModel();
+        return internalBuild();
     }
 }

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinBaseBuilders.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinBaseBuilders.kt
@@ -38,8 +38,8 @@ abstract class KotlinBaseBuilder<D: AbstractWhereSupportingDSL<*>, B: KotlinBase
         }
 
     fun <T> where(column: BindableColumn<T>, condition: VisitableCondition<T>, subCriteria: CriteriaReceiver) =
-        applyToWhere(subCriteria) { sq ->
-            where(column, condition, sq)
+        applyToWhere(subCriteria) { sc ->
+            where(column, condition, sc)
         }
 
     fun applyWhere(whereApplier: WhereApplier) =
@@ -53,8 +53,8 @@ abstract class KotlinBaseBuilder<D: AbstractWhereSupportingDSL<*>, B: KotlinBase
         }
 
     fun <T> and(column: BindableColumn<T>, condition: VisitableCondition<T>, subCriteria: CriteriaReceiver) =
-        applyToWhere(subCriteria) { sq ->
-            and(column, condition, sq)
+        applyToWhere(subCriteria) { sc ->
+            and(column, condition, sc)
         }
 
     fun <T> or(column: BindableColumn<T>, condition: VisitableCondition<T>) =
@@ -63,24 +63,24 @@ abstract class KotlinBaseBuilder<D: AbstractWhereSupportingDSL<*>, B: KotlinBase
         }
 
     fun <T> or(column: BindableColumn<T>, condition: VisitableCondition<T>, subCriteria: CriteriaReceiver) =
-        applyToWhere(subCriteria) { sq ->
-            or(column, condition, sq)
+        applyToWhere(subCriteria) { sc ->
+            or(column, condition, sc)
         }
 
     fun allRows() = self()
 
-    private fun applyToWhere(block: AbstractWhereDSL<*>.() -> Unit): B {
-        getDsl().where().apply(block)
-        return self()
-    }
+    private fun applyToWhere(block: AbstractWhereDSL<*>.() -> Unit) =
+        self().also{
+            getDsl().where().apply(block)
+        }
 
     private fun applyToWhere(
         subCriteria: CriteriaReceiver,
         block: AbstractWhereDSL<*>.(List<SqlCriterion<*>>) -> Unit
-    ): B {
-        getDsl().where().block(CriteriaCollector().apply(subCriteria).criteria)
-        return self()
-    }
+    ) =
+        self().also {
+            getDsl().where().block(CriteriaCollector().apply(subCriteria).criteria)
+        }
 
     protected abstract fun self(): B
 
@@ -163,17 +163,17 @@ abstract class KotlinBaseJoiningBuilder<D: AbstractQueryExpressionDSL<*, *, *>, 
             rightJoin(sq, sq.correlationName, jc.onJoinCriterion, jc.andJoinCriteria)
         }
 
-    private fun applyToDsl(joinCriteria: JoinReceiver, applyJoin: D.(JoinCollector) -> Unit): B {
-        getDsl().applyJoin(JoinCollector().apply(joinCriteria))
-        return self()
-    }
+    private fun applyToDsl(joinCriteria: JoinReceiver, applyJoin: D.(JoinCollector) -> Unit) =
+        self().also {
+            getDsl().applyJoin(JoinCollector().apply(joinCriteria))
+        }
 
     private fun applyToDsl(
         subQuery: KotlinQualifiedSubQueryBuilder.() -> Unit,
         joinCriteria: JoinReceiver,
         applyJoin: D.(KotlinQualifiedSubQueryBuilder, JoinCollector) -> Unit
-    ): B {
-        getDsl().applyJoin(KotlinQualifiedSubQueryBuilder().apply(subQuery), JoinCollector().apply(joinCriteria))
-        return self()
-    }
+    ) =
+        self().also {
+            getDsl().applyJoin(KotlinQualifiedSubQueryBuilder().apply(subQuery), JoinCollector().apply(joinCriteria))
+        }
 }

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinBaseBuilders.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinBaseBuilders.kt
@@ -77,7 +77,7 @@ abstract class KotlinBaseBuilder<W : AbstractWhereDSL<W>, B : KotlinBaseBuilder<
 }
 
 @Suppress("TooManyFunctions")
-abstract class KotlinBaseJoiningBuilder<T : AbstractQueryExpressionDSL<T, SelectModel>, W : AbstractWhereDSL<W>,
+abstract class KotlinBaseJoiningBuilder<T : AbstractQueryExpressionDSL<W, T, SelectModel>, W : AbstractWhereDSL<W>,
         B : KotlinBaseJoiningBuilder<T, W, B>> : KotlinBaseBuilder<W, B>() {
 
     fun join(table: SqlTable, joinCriteria: JoinReceiver) =
@@ -161,5 +161,5 @@ abstract class KotlinBaseJoiningBuilder<T : AbstractQueryExpressionDSL<T, Select
             JoinCollector().apply(joinCriteria).apply(block)
         }
 
-    protected abstract fun getDsl(): AbstractQueryExpressionDSL<T, SelectModel>
+    protected abstract fun getDsl(): AbstractQueryExpressionDSL<W, T, SelectModel>
 }

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinBaseBuilders.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinBaseBuilders.kt
@@ -21,7 +21,7 @@ import org.mybatis.dynamic.sql.SqlTable
 import org.mybatis.dynamic.sql.VisitableCondition
 import org.mybatis.dynamic.sql.select.AbstractQueryExpressionDSL
 import org.mybatis.dynamic.sql.where.AbstractWhereDSL
-import org.mybatis.dynamic.sql.where.AbstractWhereSupportingDSL
+import org.mybatis.dynamic.sql.where.AbstractWhereSupport
 
 @Target(AnnotationTarget.CLASS, AnnotationTarget.TYPE)
 @DslMarker
@@ -31,7 +31,7 @@ typealias WhereApplier = AbstractWhereDSL<*>.() -> Unit
 
 @MyBatisDslMarker
 @Suppress("TooManyFunctions")
-abstract class KotlinBaseBuilder<D: AbstractWhereSupportingDSL<*>, B: KotlinBaseBuilder<D, B>> {
+abstract class KotlinBaseBuilder<D: AbstractWhereSupport<*>, B: KotlinBaseBuilder<D, B>> {
     fun <T> where(column: BindableColumn<T>, condition: VisitableCondition<T>) =
         applyToWhere {
             where(column, condition)

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinCountBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinCountBuilder.kt
@@ -23,8 +23,7 @@ import org.mybatis.dynamic.sql.util.Buildable
 typealias CountCompleter = KotlinCountBuilder.() -> Unit
 
 class KotlinCountBuilder(private val fromGatherer: CountDSL.FromGatherer<SelectModel>) :
-    KotlinBaseJoiningBuilder<CountDSL<SelectModel>,
-            CountDSL<SelectModel>.CountWhereBuilder, KotlinCountBuilder>(),
+    KotlinBaseJoiningBuilder<CountDSL<SelectModel>, KotlinCountBuilder>(),
     Buildable<SelectModel> {
 
     private lateinit var dsl: CountDSL<SelectModel>
@@ -35,8 +34,6 @@ class KotlinCountBuilder(private val fromGatherer: CountDSL.FromGatherer<SelectM
         }
 
     override fun build(): SelectModel = getDsl().build()
-
-    override fun getWhere(): CountDSL<SelectModel>.CountWhereBuilder = getDsl().where()
 
     override fun self() = this
 

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinDeleteBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinDeleteBuilder.kt
@@ -22,11 +22,11 @@ import org.mybatis.dynamic.sql.util.Buildable
 typealias DeleteCompleter = KotlinDeleteBuilder.() -> Unit
 
 class KotlinDeleteBuilder(private val dsl: DeleteDSL<DeleteModel>) :
-        KotlinBaseBuilder<DeleteDSL<DeleteModel>.DeleteWhereBuilder, KotlinDeleteBuilder>(), Buildable<DeleteModel> {
+        KotlinBaseBuilder<DeleteDSL<DeleteModel>, KotlinDeleteBuilder>(), Buildable<DeleteModel> {
 
     override fun build(): DeleteModel = dsl.build()
 
-    override fun getWhere(): DeleteDSL<DeleteModel>.DeleteWhereBuilder = dsl.where()
+    override fun getDsl() = dsl
 
     override fun self() = this
 }

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinSelectBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinSelectBuilder.kt
@@ -26,9 +26,7 @@ typealias SelectCompleter = KotlinSelectBuilder.() -> Unit
 
 @Suppress("TooManyFunctions")
 class KotlinSelectBuilder(private val fromGatherer: QueryExpressionDSL.FromGatherer<SelectModel>) :
-    KotlinBaseJoiningBuilder<QueryExpressionDSL<SelectModel>,
-            QueryExpressionDSL<SelectModel>.QueryExpressionWhereBuilder,
-            KotlinSelectBuilder>(), Buildable<SelectModel> {
+    KotlinBaseJoiningBuilder<QueryExpressionDSL<SelectModel>, KotlinSelectBuilder>(), Buildable<SelectModel> {
 
     private lateinit var dsl: QueryExpressionDSL<SelectModel>
 
@@ -86,8 +84,6 @@ class KotlinSelectBuilder(private val fromGatherer: QueryExpressionDSL.FromGathe
     override fun build() = getDsl().build()
 
     override fun self(): KotlinSelectBuilder = this
-
-    override fun getWhere(): QueryExpressionDSL<SelectModel>.QueryExpressionWhereBuilder = getDsl().where()
 
     override fun getDsl(): QueryExpressionDSL<SelectModel> {
         try {

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinUpdateBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinUpdateBuilder.kt
@@ -24,13 +24,13 @@ import org.mybatis.dynamic.sql.util.Buildable
 typealias UpdateCompleter = KotlinUpdateBuilder.() -> Unit
 
 class KotlinUpdateBuilder(private val dsl: UpdateDSL<UpdateModel>) :
-    KotlinBaseBuilder<UpdateDSL<UpdateModel>.UpdateWhereBuilder, KotlinUpdateBuilder>(), Buildable<UpdateModel> {
+    KotlinBaseBuilder<UpdateDSL<UpdateModel>, KotlinUpdateBuilder>(), Buildable<UpdateModel> {
 
     fun <T> set(column: SqlColumn<T>) = KotlinSetClauseFinisher(column)
 
     override fun build(): UpdateModel = dsl.build()
 
-    override fun getWhere(): UpdateDSL<UpdateModel>.UpdateWhereBuilder = dsl.where()
+    override fun getDsl() = dsl
 
     override fun self() = this
 


### PR DESCRIPTION
Consolidate basic where functionality into an abstract base class for where supporting DSLs. This refactoring will simplify further enhancements to where clauses (like adding support for exists).

Also refactor the Kotlin where support to be a bit more idiomatic.
