### PR TITLE
Add Mapping for General Insert and Update that Renders null Values More Simply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ Kotlin DSL.
 - Added support for the "exists" and "not exists" operator in where clauses ([#296](https://github.com/mybatis/mybatis-dynamic-sql/pull/296))
 - Refactored the built-in conditions ([#331](https://github.com/mybatis/mybatis-dynamic-sql/pull/331)) ([#336](https://github.com/mybatis/mybatis-dynamic-sql/pull/336))
 - Added composition functions for WhereApplier ([#335](https://github.com/mybatis/mybatis-dynamic-sql/pull/335))
+- Added a mapping for general insert and update statements that will render null values as "null" in the SQL ([#343](https://github.com/mybatis/mybatis-dynamic-sql/pull/343))
 
 ## Release 1.2.1 - September 29, 2020
 

--- a/src/main/java/org/mybatis/dynamic/sql/insert/GeneralInsertDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/GeneralInsertDSL.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2020 the original author or authors.
+ *    Copyright 2016-2021 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import org.mybatis.dynamic.sql.util.ConstantMapping;
 import org.mybatis.dynamic.sql.util.NullMapping;
 import org.mybatis.dynamic.sql.util.StringConstantMapping;
 import org.mybatis.dynamic.sql.util.ValueMapping;
+import org.mybatis.dynamic.sql.util.ValueOrNullMapping;
 import org.mybatis.dynamic.sql.util.ValueWhenPresentMapping;
 
 public class GeneralInsertDSL implements Buildable<GeneralInsertModel> {
@@ -85,6 +86,15 @@ public class GeneralInsertDSL implements Buildable<GeneralInsertModel> {
 
         public GeneralInsertDSL toValue(Supplier<T> valueSupplier) {
             insertMappings.add(ValueMapping.of(column, valueSupplier));
+            return GeneralInsertDSL.this;
+        }
+
+        public GeneralInsertDSL toValueOrNull(T value) {
+            return toValueOrNull(() -> value);
+        }
+
+        public GeneralInsertDSL toValueOrNull(Supplier<T> valueSupplier) {
+            insertMappings.add(ValueOrNullMapping.of(column, valueSupplier));
             return GeneralInsertDSL.this;
         }
 

--- a/src/main/java/org/mybatis/dynamic/sql/update/UpdateDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/update/UpdateDSL.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2020 the original author or authors.
+ *    Copyright 2016-2021 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import org.mybatis.dynamic.sql.util.NullMapping;
 import org.mybatis.dynamic.sql.util.SelectMapping;
 import org.mybatis.dynamic.sql.util.StringConstantMapping;
 import org.mybatis.dynamic.sql.util.ValueMapping;
+import org.mybatis.dynamic.sql.util.ValueOrNullMapping;
 import org.mybatis.dynamic.sql.util.ValueWhenPresentMapping;
 import org.mybatis.dynamic.sql.where.AbstractWhereDSL;
 import org.mybatis.dynamic.sql.where.AbstractWhereSupport;
@@ -123,6 +124,15 @@ public class UpdateDSL<R> extends AbstractWhereSupport<UpdateDSL<R>.UpdateWhereB
 
         public UpdateDSL<R> equalTo(BasicColumn rightColumn) {
             columnMappings.add(ColumnToColumnMapping.of(column, rightColumn));
+            return UpdateDSL.this;
+        }
+
+        public UpdateDSL<R> equalToOrNull(T value) {
+            return equalToOrNull(() -> value);
+        }
+
+        public UpdateDSL<R> equalToOrNull(Supplier<T> valueSupplier) {
+            columnMappings.add(ValueOrNullMapping.of(column, valueSupplier));
             return UpdateDSL.this;
         }
 

--- a/src/main/java/org/mybatis/dynamic/sql/update/render/SetPhraseVisitor.java
+++ b/src/main/java/org/mybatis/dynamic/sql/update/render/SetPhraseVisitor.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2020 the original author or authors.
+ *    Copyright 2016-2021 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import org.mybatis.dynamic.sql.util.SelectMapping;
 import org.mybatis.dynamic.sql.util.StringConstantMapping;
 import org.mybatis.dynamic.sql.util.UpdateMappingVisitor;
 import org.mybatis.dynamic.sql.util.ValueMapping;
+import org.mybatis.dynamic.sql.util.ValueOrNullMapping;
 import org.mybatis.dynamic.sql.util.ValueWhenPresentMapping;
 
 public class SetPhraseVisitor extends UpdateMappingVisitor<Optional<FragmentAndParameters>> {
@@ -72,6 +73,16 @@ public class SetPhraseVisitor extends UpdateMappingVisitor<Optional<FragmentAndP
     @Override
     public <T> Optional<FragmentAndParameters> visit(ValueMapping<T> mapping) {
         return buildFragment(mapping, mapping.value());
+    }
+
+    @Override
+    public <T> Optional<FragmentAndParameters> visit(ValueOrNullMapping<T> mapping) {
+        return mapping.value()
+                .map(v -> buildFragment(mapping, v))
+                .orElseGet(() -> FragmentAndParameters
+                        .withFragment(mapping.columnName() + " = null") //$NON-NLS-1$
+                        .buildOptional()
+                );
     }
 
     @Override

--- a/src/main/java/org/mybatis/dynamic/sql/util/ColumnMappingVisitor.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/ColumnMappingVisitor.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2020 the original author or authors.
+ *    Copyright 2016-2021 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -37,6 +37,8 @@ public interface ColumnMappingVisitor<R> {
     R visit(StringConstantMapping mapping);
 
     <T> R visit(ValueMapping<T> mapping);
+
+    <T> R visit(ValueOrNullMapping<T> mapping);
 
     <T> R visit(ValueWhenPresentMapping<T> mapping);
 

--- a/src/main/java/org/mybatis/dynamic/sql/util/InsertMappingVisitor.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/InsertMappingVisitor.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2020 the original author or authors.
+ *    Copyright 2016-2021 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,6 +18,11 @@ package org.mybatis.dynamic.sql.util;
 public abstract class InsertMappingVisitor<R> implements ColumnMappingVisitor<R> {
     @Override
     public final <T> R visit(ValueMapping<T> mapping) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public final <T> R visit(ValueOrNullMapping<T> mapping) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/util/ValueOrNullMapping.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/ValueOrNullMapping.java
@@ -15,11 +15,11 @@
  */
 package org.mybatis.dynamic.sql.util;
 
-import org.mybatis.dynamic.sql.SqlColumn;
-
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
+
+import org.mybatis.dynamic.sql.SqlColumn;
 
 public class ValueOrNullMapping<T> extends AbstractColumnMapping {
 

--- a/src/main/java/org/mybatis/dynamic/sql/util/ValueOrNullMapping.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/ValueOrNullMapping.java
@@ -1,0 +1,48 @@
+/*
+ *    Copyright 2016-2021 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.dynamic.sql.util;
+
+import org.mybatis.dynamic.sql.SqlColumn;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+public class ValueOrNullMapping<T> extends AbstractColumnMapping {
+
+    private final Supplier<T> valueSupplier;
+    // keep a reference to the column so we don't lose the type
+    private final SqlColumn<T> localColumn;
+
+    private ValueOrNullMapping(SqlColumn<T> column, Supplier<T> valueSupplier) {
+        super(column);
+        this.valueSupplier = Objects.requireNonNull(valueSupplier);
+        localColumn = Objects.requireNonNull(column);
+    }
+
+    public Optional<Object> value() {
+        return Optional.ofNullable(localColumn.convertParameterType(valueSupplier.get()));
+    }
+
+    @Override
+    public <R> R accept(ColumnMappingVisitor<R> visitor) {
+        return visitor.visit(this);
+    }
+
+    public static <T> ValueOrNullMapping<T> of(SqlColumn<T> column, Supplier<T> valueSupplier) {
+        return new ValueOrNullMapping<>(column, valueSupplier);
+    }
+}

--- a/src/test/java/org/mybatis/dynamic/sql/util/ColumnMappingVisitorTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/util/ColumnMappingVisitorTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2020 the original author or authors.
+ *    Copyright 2016-2021 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -193,6 +193,11 @@ class ColumnMappingVisitorTest {
         }
 
         @Override
+        public <R> String visit(ValueOrNullMapping<R> mapping) {
+            return "Value or Null Mapping";
+        }
+
+        @Override
         public <R> String visit(ValueWhenPresentMapping<R> mapping) {
             return "Value When Present Mapping";
         }
@@ -244,6 +249,11 @@ class ColumnMappingVisitorTest {
         @Override
         public <R> String visit(ValueMapping<R> mapping) {
             return "Value Mapping";
+        }
+
+        @Override
+        public <R> String visit(ValueOrNullMapping<R> mapping) {
+            return "Value or Null Mapping";
         }
 
         @Override

--- a/src/test/java/org/mybatis/dynamic/sql/util/ColumnMappingVisitorTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/util/ColumnMappingVisitorTest.java
@@ -88,6 +88,15 @@ class ColumnMappingVisitorTest {
     }
 
     @Test
+    void testThatInsertVisitorErrorsForValueOrNullMapping() {
+        TestTable table = new TestTable();
+        InsertVisitor tv = new InsertVisitor();
+        ValueOrNullMapping<Integer> mapping = ValueOrNullMapping.of(table.id, () -> 3);
+
+        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> tv.visit(mapping));
+    }
+
+    @Test
     void testThatInsertVisitorErrorsForValueWhenPresentMapping() {
         TestTable table = new TestTable();
         InsertVisitor tv = new InsertVisitor();
@@ -226,7 +235,7 @@ class ColumnMappingVisitorTest {
 
         @Override
         public String visit(PropertyWhenPresentMapping mapping) {
-            return "Property Whn Present Mapping";
+            return "Property When Present Mapping";
         }
     }
 


### PR DESCRIPTION
Rather than rendering null values as a null parameter, the new mapping will simply render null values as "null" in the generated SQL.

This mapping will be important in the updated Kotlin DSL where we more clearly express nullability expectations.
