### PR TITLE
Relax generic constraints on built-in functions

### DIFF
--- a/src/main/java/org/mybatis/dynamic/sql/SqlBuilder.java
+++ b/src/main/java/org/mybatis/dynamic/sql/SqlBuilder.java
@@ -354,22 +354,22 @@ public interface SqlBuilder {
     }
 
     // functions
-    static <T extends Number> Add<T> add(BindableColumn<T> firstColumn, BasicColumn secondColumn,
+    static <T> Add<T> add(BindableColumn<T> firstColumn, BasicColumn secondColumn,
             BasicColumn... subsequentColumns) {
         return Add.of(firstColumn, secondColumn, subsequentColumns);
     }
 
-    static <T extends Number> Divide<T> divide(BindableColumn<T> firstColumn, BasicColumn secondColumn,
+    static <T> Divide<T> divide(BindableColumn<T> firstColumn, BasicColumn secondColumn,
             BasicColumn... subsequentColumns) {
         return Divide.of(firstColumn, secondColumn, subsequentColumns);
     }
 
-    static <T extends Number> Multiply<T> multiply(BindableColumn<T> firstColumn, BasicColumn secondColumn,
+    static <T> Multiply<T> multiply(BindableColumn<T> firstColumn, BasicColumn secondColumn,
             BasicColumn... subsequentColumns) {
         return Multiply.of(firstColumn, secondColumn, subsequentColumns);
     }
 
-    static <T extends Number> Subtract<T> subtract(BindableColumn<T> firstColumn, BasicColumn secondColumn,
+    static <T> Subtract<T> subtract(BindableColumn<T> firstColumn, BasicColumn secondColumn,
             BasicColumn... subsequentColumns) {
         return Subtract.of(firstColumn, secondColumn, subsequentColumns);
     }
@@ -384,15 +384,15 @@ public interface SqlBuilder {
         return OperatorFunction.of(operator, firstColumn, secondColumn, subsequentColumns);
     }
 
-    static Lower lower(BindableColumn<String> column) {
+    static <T> Lower<T> lower(BindableColumn<T> column) {
         return Lower.of(column);
     }
 
-    static Substring substring(BindableColumn<String> column, int offset, int length) {
+    static <T> Substring<T> substring(BindableColumn<T> column, int offset, int length) {
         return Substring.of(column, offset, length);
     }
 
-    static Upper upper(BindableColumn<String> column) {
+    static <T> Upper<T> upper(BindableColumn<T> column) {
         return Upper.of(column);
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/select/function/Add.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/function/Add.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2020 the original author or authors.
+ *    Copyright 2016-2021 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import java.util.List;
 import org.mybatis.dynamic.sql.BasicColumn;
 import org.mybatis.dynamic.sql.BindableColumn;
 
-public class Add<T extends Number> extends OperatorFunction<T> {
+public class Add<T> extends OperatorFunction<T> {
 
     private Add(BindableColumn<T> firstColumn, BasicColumn secondColumn,
             List<BasicColumn> subsequentColumns) {
@@ -33,12 +33,12 @@ public class Add<T extends Number> extends OperatorFunction<T> {
         return new Add<>(column, secondColumn, subsequentColumns);
     }
 
-    public static <T extends Number> Add<T> of(BindableColumn<T> firstColumn, BasicColumn secondColumn,
-                                               BasicColumn... subsequentColumns) {
+    public static <T> Add<T> of(BindableColumn<T> firstColumn, BasicColumn secondColumn,
+                                BasicColumn... subsequentColumns) {
         return of(firstColumn, secondColumn, Arrays.asList(subsequentColumns));
     }
 
-    public static <T extends Number> Add<T> of(BindableColumn<T> firstColumn, BasicColumn secondColumn,
+    public static <T> Add<T> of(BindableColumn<T> firstColumn, BasicColumn secondColumn,
             List<BasicColumn> subsequentColumns) {
         return new Add<>(firstColumn, secondColumn, subsequentColumns);
     }

--- a/src/main/java/org/mybatis/dynamic/sql/select/function/Divide.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/function/Divide.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2020 the original author or authors.
+ *    Copyright 2016-2021 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import java.util.List;
 import org.mybatis.dynamic.sql.BasicColumn;
 import org.mybatis.dynamic.sql.BindableColumn;
 
-public class Divide<T extends Number> extends OperatorFunction<T> {
+public class Divide<T> extends OperatorFunction<T> {
 
     private Divide(BindableColumn<T> firstColumn, BasicColumn secondColumn,
             List<BasicColumn> subsequentColumns) {
@@ -33,12 +33,12 @@ public class Divide<T extends Number> extends OperatorFunction<T> {
         return new Divide<>(column, secondColumn, subsequentColumns);
     }
 
-    public static <T extends Number> Divide<T> of(BindableColumn<T> firstColumn, BasicColumn secondColumn,
-                                                  BasicColumn... subsequentColumns) {
+    public static <T> Divide<T> of(BindableColumn<T> firstColumn, BasicColumn secondColumn,
+                                   BasicColumn... subsequentColumns) {
         return of(firstColumn, secondColumn, Arrays.asList(subsequentColumns));
     }
 
-    public static <T extends Number> Divide<T> of(BindableColumn<T> firstColumn, BasicColumn secondColumn,
+    public static <T> Divide<T> of(BindableColumn<T> firstColumn, BasicColumn secondColumn,
             List<BasicColumn> subsequentColumns) {
         return new Divide<>(firstColumn, secondColumn, subsequentColumns);
     }

--- a/src/main/java/org/mybatis/dynamic/sql/select/function/Lower.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/function/Lower.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2020 the original author or authors.
+ *    Copyright 2016-2021 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,9 +18,9 @@ package org.mybatis.dynamic.sql.select.function;
 import org.mybatis.dynamic.sql.BindableColumn;
 import org.mybatis.dynamic.sql.render.TableAliasCalculator;
 
-public class Lower extends AbstractUniTypeFunction<String, Lower> {
+public class Lower<T> extends AbstractUniTypeFunction<T, Lower<T>> {
 
-    private Lower(BindableColumn<String> column) {
+    private Lower(BindableColumn<T> column) {
         super(column);
     }
 
@@ -32,11 +32,11 @@ public class Lower extends AbstractUniTypeFunction<String, Lower> {
     }
 
     @Override
-    protected Lower copy() {
-        return new Lower(column);
+    protected Lower<T> copy() {
+        return new Lower<>(column);
     }
 
-    public static Lower of(BindableColumn<String> column) {
-        return new Lower(column);
+    public static <T> Lower<T> of(BindableColumn<T> column) {
+        return new Lower<>(column);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/select/function/Multiply.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/function/Multiply.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2020 the original author or authors.
+ *    Copyright 2016-2021 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import java.util.List;
 import org.mybatis.dynamic.sql.BasicColumn;
 import org.mybatis.dynamic.sql.BindableColumn;
 
-public class Multiply<T extends Number> extends OperatorFunction<T> {
+public class Multiply<T> extends OperatorFunction<T> {
 
     private Multiply(BindableColumn<T> firstColumn, BasicColumn secondColumn,
             List<BasicColumn> subsequentColumns) {
@@ -33,12 +33,12 @@ public class Multiply<T extends Number> extends OperatorFunction<T> {
         return new Multiply<>(column, secondColumn, subsequentColumns);
     }
 
-    public static <T extends Number> Multiply<T> of(BindableColumn<T> firstColumn, BasicColumn secondColumn,
-                                                    BasicColumn... subsequentColumns) {
+    public static <T> Multiply<T> of(BindableColumn<T> firstColumn, BasicColumn secondColumn,
+                                     BasicColumn... subsequentColumns) {
         return of(firstColumn, secondColumn, Arrays.asList(subsequentColumns));
     }
 
-    public static <T extends Number> Multiply<T> of(BindableColumn<T> firstColumn, BasicColumn secondColumn,
+    public static <T> Multiply<T> of(BindableColumn<T> firstColumn, BasicColumn secondColumn,
             List<BasicColumn> subsequentColumns) {
         return new Multiply<>(firstColumn, secondColumn, subsequentColumns);
     }

--- a/src/main/java/org/mybatis/dynamic/sql/select/function/Substring.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/function/Substring.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2020 the original author or authors.
+ *    Copyright 2016-2021 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,12 +18,12 @@ package org.mybatis.dynamic.sql.select.function;
 import org.mybatis.dynamic.sql.BindableColumn;
 import org.mybatis.dynamic.sql.render.TableAliasCalculator;
 
-public class Substring extends AbstractUniTypeFunction<String, Substring> {
+public class Substring<T> extends AbstractUniTypeFunction<T, Substring<T>> {
 
     private final int offset;
     private final int length;
 
-    private Substring(BindableColumn<String> column, int offset, int length) {
+    private Substring(BindableColumn<T> column, int offset, int length) {
         super(column);
         this.offset = offset;
         this.length = length;
@@ -41,11 +41,11 @@ public class Substring extends AbstractUniTypeFunction<String, Substring> {
     }
 
     @Override
-    protected Substring copy() {
-        return new Substring(column, offset, length);
+    protected Substring<T> copy() {
+        return new Substring<>(column, offset, length);
     }
 
-    public static Substring of(BindableColumn<String> column, int offset, int length) {
-        return new Substring(column, offset, length);
+    public static <T> Substring<T> of(BindableColumn<T> column, int offset, int length) {
+        return new Substring<>(column, offset, length);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/select/function/Subtract.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/function/Subtract.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2020 the original author or authors.
+ *    Copyright 2016-2021 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import java.util.List;
 import org.mybatis.dynamic.sql.BasicColumn;
 import org.mybatis.dynamic.sql.BindableColumn;
 
-public class Subtract<T extends Number> extends OperatorFunction<T> {
+public class Subtract<T> extends OperatorFunction<T> {
 
     private Subtract(BindableColumn<T> firstColumn, BasicColumn secondColumn,
             List<BasicColumn> subsequentColumns) {
@@ -33,13 +33,13 @@ public class Subtract<T extends Number> extends OperatorFunction<T> {
         return new Subtract<>(column, secondColumn, subsequentColumns);
     }
 
-    public static <T extends Number> Subtract<T> of(BindableColumn<T> firstColumn, BasicColumn secondColumn,
+    public static <T> Subtract<T> of(BindableColumn<T> firstColumn, BasicColumn secondColumn,
             BasicColumn... subsequentColumns) {
         return of(firstColumn, secondColumn, Arrays.asList(subsequentColumns));
     }
 
-    public static <T extends Number> Subtract<T> of(BindableColumn<T> firstColumn, BasicColumn secondColumn,
-                                                    List<BasicColumn> subsequentColumns) {
+    public static <T> Subtract<T> of(BindableColumn<T> firstColumn, BasicColumn secondColumn,
+                                     List<BasicColumn> subsequentColumns) {
         return new Subtract<>(firstColumn, secondColumn, subsequentColumns);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/select/function/Upper.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/function/Upper.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2020 the original author or authors.
+ *    Copyright 2016-2021 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,9 +18,9 @@ package org.mybatis.dynamic.sql.select.function;
 import org.mybatis.dynamic.sql.BindableColumn;
 import org.mybatis.dynamic.sql.render.TableAliasCalculator;
 
-public class Upper extends AbstractUniTypeFunction<String, Upper> {
+public class Upper<T> extends AbstractUniTypeFunction<T, Upper<T>> {
 
-    private Upper(BindableColumn<String> column) {
+    private Upper(BindableColumn<T> column) {
         super(column);
     }
 
@@ -32,11 +32,11 @@ public class Upper extends AbstractUniTypeFunction<String, Upper> {
     }
 
     @Override
-    protected Upper copy() {
-        return new Upper(column);
+    protected Upper<T> copy() {
+        return new Upper<>(column);
     }
 
-    public static Upper of(BindableColumn<String> column) {
-        return new Upper(column);
+    public static <T> Upper<T> of(BindableColumn<T> column) {
+        return new Upper<>(column);
     }
 }


### PR DESCRIPTION
The constraints aren't very useful and make these functions difficult to use
with columns that have type handlers.