### PR TITLE
Allow the "in when present" conditions to accept a null Collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ Kotlin DSL.
 - Refactored the built-in conditions ([#331](https://github.com/mybatis/mybatis-dynamic-sql/pull/331)) ([#336](https://github.com/mybatis/mybatis-dynamic-sql/pull/336))
 - Added composition functions for WhereApplier ([#335](https://github.com/mybatis/mybatis-dynamic-sql/pull/335))
 - Added a mapping for general insert and update statements that will render null values as "null" in the SQL ([#343](https://github.com/mybatis/mybatis-dynamic-sql/pull/343))
+- Allow the "in when present" conditions to accept a null Collection as a parameter ([#346](https://github.com/mybatis/mybatis-dynamic-sql/pull/346))
 
 ## Release 1.2.1 - September 29, 2020
 

--- a/src/main/java/org/mybatis/dynamic/sql/SqlBuilder.java
+++ b/src/main/java/org/mybatis/dynamic/sql/SqlBuilder.java
@@ -577,7 +577,7 @@ public interface SqlBuilder {
     }
 
     static <T> IsIn<T> isInWhenPresent(Collection<T> values) {
-        return IsIn.of(values).filter(Objects::nonNull);
+        return values == null ? IsIn.empty() : IsIn.of(values).filter(Objects::nonNull);
     }
 
     @SafeVarargs
@@ -599,7 +599,7 @@ public interface SqlBuilder {
     }
 
     static <T> IsNotIn<T> isNotInWhenPresent(Collection<T> values) {
-        return IsNotIn.of(values).filter(Objects::nonNull);
+        return values == null ? IsNotIn.empty() : IsNotIn.of(values).filter(Objects::nonNull);
     }
 
     static <T> IsBetween.Builder<T> isBetween(T value1) {
@@ -722,7 +722,7 @@ public interface SqlBuilder {
     }
 
     static IsInCaseInsensitive isInCaseInsensitiveWhenPresent(Collection<String> values) {
-        return IsInCaseInsensitive.of(values).filter(Objects::nonNull);
+        return values == null ? IsInCaseInsensitive.empty() : IsInCaseInsensitive.of(values).filter(Objects::nonNull);
     }
 
     static IsNotInCaseInsensitive isNotInCaseInsensitive(String...values) {
@@ -738,7 +738,8 @@ public interface SqlBuilder {
     }
 
     static IsNotInCaseInsensitive isNotInCaseInsensitiveWhenPresent(Collection<String> values) {
-        return IsNotInCaseInsensitive.of(values).filter(Objects::nonNull);
+        return values == null ? IsNotInCaseInsensitive.empty() :
+                IsNotInCaseInsensitive.of(values).filter(Objects::nonNull);
     }
 
     // order by support

--- a/src/test/java/org/mybatis/dynamic/sql/select/SelectStatementTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/select/SelectStatementTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2020 the original author or authors.
+ *    Copyright 2016-2021 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mybatis.dynamic.sql.SqlBuilder.*;
 
 import java.sql.JDBCType;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -369,5 +370,49 @@ class SelectStatementTest {
         assertThatExceptionOfType(RuntimeException.class).isThrownBy(() ->
                 selectModel.render(RenderingStrategies.MYBATIS3)
         ).withMessage("Fred");
+    }
+
+    @Test
+    void testInWhenPresentNullList() {
+        SelectStatementProvider selectStatement = select(column1, column3)
+                .from(table)
+                .where(column3, isInWhenPresent((Collection<String>) null))
+                .build()
+                .render(RenderingStrategies.MYBATIS3);
+
+        assertThat(selectStatement.getSelectStatement()).isEqualTo("select column1, column3 from foo");
+    }
+
+    @Test
+    void testInCaseInsensitiveWhenPresentNullList() {
+        SelectStatementProvider selectStatement = select(column1, column3)
+                .from(table)
+                .where(column3, isInCaseInsensitiveWhenPresent((Collection<String>) null))
+                .build()
+                .render(RenderingStrategies.MYBATIS3);
+
+        assertThat(selectStatement.getSelectStatement()).isEqualTo("select column1, column3 from foo");
+    }
+
+    @Test
+    void testNotInWhenPresentNullList() {
+        SelectStatementProvider selectStatement = select(column1, column3)
+                .from(table)
+                .where(column3, isNotInWhenPresent((Collection<String>) null))
+                .build()
+                .render(RenderingStrategies.MYBATIS3);
+
+        assertThat(selectStatement.getSelectStatement()).isEqualTo("select column1, column3 from foo");
+    }
+
+    @Test
+    void testNotInCaseInsensitiveWhenPresentNullList() {
+        SelectStatementProvider selectStatement = select(column1, column3)
+                .from(table)
+                .where(column3, isNotInCaseInsensitiveWhenPresent((Collection<String>) null))
+                .build()
+                .render(RenderingStrategies.MYBATIS3);
+
+        assertThat(selectStatement.getSelectStatement()).isEqualTo("select column1, column3 from foo");
     }
 }


### PR DESCRIPTION
A null Collection is interpreted as an empty list - the condition will not render.