### PR TITLE
Support Specifying javaType on SqlColumn, and Render Properly for MyBatis

### DIFF
--- a/src/main/java/org/mybatis/dynamic/sql/BindableColumn.java
+++ b/src/main/java/org/mybatis/dynamic/sql/BindableColumn.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2020 the original author or authors.
+ *    Copyright 2016-2021 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/BindableColumn.java
+++ b/src/main/java/org/mybatis/dynamic/sql/BindableColumn.java
@@ -51,4 +51,8 @@ public interface BindableColumn<T> extends BasicColumn {
     default Object convertParameterType(T value) {
         return value;
     }
+
+    default Optional<Class<T>> javaType() {
+        return Optional.empty();
+    }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/SqlColumn.java
+++ b/src/main/java/org/mybatis/dynamic/sql/SqlColumn.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2020 the original author or authors.
+ *    Copyright 2016-2021 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/SqlColumn.java
+++ b/src/main/java/org/mybatis/dynamic/sql/SqlColumn.java
@@ -36,6 +36,7 @@ public class SqlColumn<T> implements BindableColumn<T>, SortSpecification {
     protected final RenderingStrategy renderingStrategy;
     protected final ParameterTypeConverter<T, ?> parameterTypeConverter;
     protected final BiFunction<TableAliasCalculator, SqlTable, Optional<String>> tableQualifierFunction;
+    protected final Class<T> javaType;
 
     private SqlColumn(Builder<T> builder) {
         name = Objects.requireNonNull(builder.name);
@@ -47,6 +48,7 @@ public class SqlColumn<T> implements BindableColumn<T>, SortSpecification {
         renderingStrategy = builder.renderingStrategy;
         parameterTypeConverter = builder.parameterTypeConverter;
         tableQualifierFunction = Objects.requireNonNull(builder.tableQualifierFunction);
+        javaType = builder.javaType;
     }
 
     public String name() {
@@ -70,6 +72,11 @@ public class SqlColumn<T> implements BindableColumn<T>, SortSpecification {
     @Override
     public Optional<String> typeHandler() {
         return Optional.ofNullable(typeHandler);
+    }
+
+    @Override
+    public Optional<Class<T>> javaType() {
+        return Optional.ofNullable(javaType);
     }
 
     @Override
@@ -158,6 +165,12 @@ public class SqlColumn<T> implements BindableColumn<T>, SortSpecification {
         return b.withParameterTypeConverter(parameterTypeConverter).build();
     }
 
+    @NotNull
+    public <S> SqlColumn<S> withJavaType(Class<S> javaType) {
+        Builder<S> b = copy();
+        return b.withJavaType(javaType).build();
+    }
+
     /**
      * This method helps us tell a bit of fiction to the Java compiler. Java, for better or worse,
      * does not carry generic type information through chained methods. We want to enable method
@@ -178,7 +191,8 @@ public class SqlColumn<T> implements BindableColumn<T>, SortSpecification {
                 .withTypeHandler(this.typeHandler)
                 .withRenderingStrategy(this.renderingStrategy)
                 .withParameterTypeConverter((ParameterTypeConverter<S, ?>) this.parameterTypeConverter)
-                .withTableQualifierFunction(this.tableQualifierFunction);
+                .withTableQualifierFunction(this.tableQualifierFunction)
+                .withJavaType((Class<S>) this.javaType);
     }
 
     private String applyTableAlias(String tableAlias) {
@@ -209,6 +223,7 @@ public class SqlColumn<T> implements BindableColumn<T>, SortSpecification {
         protected ParameterTypeConverter<T, ?> parameterTypeConverter;
         protected BiFunction<TableAliasCalculator, SqlTable, Optional<String>> tableQualifierFunction =
                 TableAliasCalculator::aliasForColumn;
+        protected Class<T> javaType;
 
         public Builder<T> withName(String name) {
             this.name = name;
@@ -253,6 +268,11 @@ public class SqlColumn<T> implements BindableColumn<T>, SortSpecification {
         private Builder<T> withTableQualifierFunction(
                 BiFunction<TableAliasCalculator, SqlTable, Optional<String>> tableQualifierFunction) {
             this.tableQualifierFunction = tableQualifierFunction;
+            return this;
+        }
+
+        public Builder<T> withJavaType(Class<T> javaType) {
+            this.javaType = javaType;
             return this;
         }
 

--- a/src/main/java/org/mybatis/dynamic/sql/render/MyBatis3RenderingStrategy.java
+++ b/src/main/java/org/mybatis/dynamic/sql/render/MyBatis3RenderingStrategy.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2020 the original author or authors.
+ *    Copyright 2016-2021 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/render/MyBatis3RenderingStrategy.java
+++ b/src/main/java/org/mybatis/dynamic/sql/render/MyBatis3RenderingStrategy.java
@@ -34,6 +34,7 @@ public class MyBatis3RenderingStrategy extends RenderingStrategy {
                 + "." //$NON-NLS-1$
                 + parameterName
                 + renderJdbcType(column)
+                + renderJavaType(column)
                 + renderTypeHandler(column)
                 + "}"; //$NON-NLS-1$
     }
@@ -47,6 +48,12 @@ public class MyBatis3RenderingStrategy extends RenderingStrategy {
     private String renderJdbcType(BindableColumn<?> column) {
         return column.jdbcType()
                 .map(jt -> ",jdbcType=" + jt.getName()) //$NON-NLS-1$
+                .orElse(""); //$NON-NLS-1$
+    }
+
+    private String renderJavaType(BindableColumn<?> column) {
+        return column.javaType()
+                .map(jt -> ",javaType=" + jt.getName()) //$NON-NLS-1$
                 .orElse(""); //$NON-NLS-1$
     }
 }

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/elements/SqlTableExtensions.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/elements/SqlTableExtensions.kt
@@ -19,6 +19,7 @@ import org.mybatis.dynamic.sql.SqlColumn
 import org.mybatis.dynamic.sql.SqlTable
 import org.mybatis.dynamic.sql.render.RenderingStrategy
 import java.sql.JDBCType
+import kotlin.reflect.KClass
 
 /**
  * This function replaces the native functions in [@see SqlColumn} such as
@@ -31,7 +32,8 @@ fun <T : Any> SqlTable.column(
     jdbcType: JDBCType? = null,
     typeHandler: String? = null,
     renderingStrategy: RenderingStrategy? = null,
-    parameterTypeConverter: ((T?) -> Any?)? = null
+    parameterTypeConverter: ((T?) -> Any?)? = null,
+    javaType: KClass<T>? = null
 ): SqlColumn<T> {
     var column: SqlColumn<T> = if (jdbcType == null) {
         column(name)
@@ -49,6 +51,10 @@ fun <T : Any> SqlTable.column(
 
     if (parameterTypeConverter != null) {
         column = column.withParameterTypeConverter(parameterTypeConverter)
+    }
+
+    if (javaType != null) {
+        column = column.withJavaType(javaType.java)
     }
 
     return column

--- a/src/test/java/examples/simple/AddressDynamicSqlSupport.java
+++ b/src/test/java/examples/simple/AddressDynamicSqlSupport.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2020 the original author or authors.
+ *    Copyright 2016-2021 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/simple/AddressDynamicSqlSupport.java
+++ b/src/test/java/examples/simple/AddressDynamicSqlSupport.java
@@ -26,12 +26,16 @@ public final class AddressDynamicSqlSupport {
     public static final SqlColumn<String> streetAddress = address.streetAddress;
     public static final SqlColumn<String> city = address.city;
     public static final SqlColumn<String> state = address.state;
+    public static final SqlColumn<AddressRecord.AddressType> addressType = address.addressType;
 
     public static final class Address extends SqlTable {
         public final SqlColumn<Integer> id = column("address_id", JDBCType.INTEGER);
         public final SqlColumn<String> streetAddress = column("street_address", JDBCType.VARCHAR);
         public final SqlColumn<String> city = column("city", JDBCType.VARCHAR);
         public final SqlColumn<String> state = column("state", JDBCType.VARCHAR);
+        public final SqlColumn<AddressRecord.AddressType> addressType = column("address_type", JDBCType.INTEGER)
+                .withTypeHandler("org.apache.ibatis.type.EnumOrdinalTypeHandler")
+                .withJavaType(AddressRecord.AddressType.class);
 
         public Address() {
             super("Address");

--- a/src/test/java/examples/simple/AddressMapper.java
+++ b/src/test/java/examples/simple/AddressMapper.java
@@ -1,0 +1,7 @@
+package examples.simple;
+
+import org.mybatis.dynamic.sql.util.mybatis3.CommonInsertMapper;
+import org.mybatis.dynamic.sql.util.mybatis3.CommonSelectMapper;
+
+public interface AddressMapper extends CommonInsertMapper<AddressRecord>, CommonSelectMapper {
+}

--- a/src/test/java/examples/simple/AddressMapper.java
+++ b/src/test/java/examples/simple/AddressMapper.java
@@ -1,3 +1,18 @@
+/*
+ *    Copyright 2016-2021 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package examples.simple;
 
 import org.mybatis.dynamic.sql.util.mybatis3.CommonInsertMapper;

--- a/src/test/java/examples/simple/AddressRecord.java
+++ b/src/test/java/examples/simple/AddressRecord.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2020 the original author or authors.
+ *    Copyright 2016-2021 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/simple/AddressRecord.java
+++ b/src/test/java/examples/simple/AddressRecord.java
@@ -20,6 +20,7 @@ public class AddressRecord {
     private String streetAddress;
     private String city;
     private String state;
+    private AddressType addressType;
 
     public Integer getId() {
         return id;
@@ -51,5 +52,18 @@ public class AddressRecord {
 
     public void setState(String state) {
         this.state = state;
+    }
+
+    public AddressType getAddressType() {
+        return addressType;
+    }
+
+    public void setAddressType(AddressType addressType) {
+        this.addressType = addressType;
+    }
+
+    public enum AddressType {
+        HOME,
+        BUSINESS
     }
 }

--- a/src/test/java/examples/simple/PersonWithAddressMapper.java
+++ b/src/test/java/examples/simple/PersonWithAddressMapper.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2020 the original author or authors.
+ *    Copyright 2016-2021 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/examples/simple/PersonWithAddressMapper.java
+++ b/src/test/java/examples/simple/PersonWithAddressMapper.java
@@ -33,6 +33,7 @@ import org.apache.ibatis.annotations.Result;
 import org.apache.ibatis.annotations.ResultMap;
 import org.apache.ibatis.annotations.Results;
 import org.apache.ibatis.annotations.SelectProvider;
+import org.apache.ibatis.type.EnumOrdinalTypeHandler;
 import org.apache.ibatis.type.JdbcType;
 import org.mybatis.dynamic.sql.BasicColumn;
 import org.mybatis.dynamic.sql.SqlBuilder;
@@ -64,7 +65,9 @@ public interface PersonWithAddressMapper {
             @Result(column="address_id", property="address.id", jdbcType=JdbcType.INTEGER),
             @Result(column="street_address", property="address.streetAddress", jdbcType=JdbcType.VARCHAR),
             @Result(column="city", property="address.city", jdbcType=JdbcType.VARCHAR),
-            @Result(column="state", property="address.state", jdbcType=JdbcType.CHAR)
+            @Result(column="state", property="address.state", jdbcType=JdbcType.CHAR),
+            @Result(column="address_type", property="address.addressType", jdbcType=JdbcType.INTEGER,
+                    typeHandler = EnumOrdinalTypeHandler.class)
     })
     List<PersonWithAddress> selectMany(SelectStatementProvider selectStatement);
 
@@ -77,7 +80,7 @@ public interface PersonWithAddressMapper {
 
     BasicColumn[] selectList =
             BasicColumn.columnList(id.as("A_ID"), firstName, lastName, birthDate, employed, occupation, address.id,
-                    address.streetAddress, address.city, address.state);
+                    address.streetAddress, address.city, address.state, address.addressType);
 
     default Optional<PersonWithAddress> selectOne(SelectDSLCompleter completer) {
         QueryExpressionDSL<SelectModel> start = SqlBuilder.select(selectList).from(person)

--- a/src/test/kotlin/examples/kotlin/mybatis3/canonical/AddressDynamicSqlSupport.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/canonical/AddressDynamicSqlSupport.kt
@@ -25,11 +25,18 @@ object AddressDynamicSqlSupport {
     val streetAddress = address.streetAddress
     val city = address.city
     val state = address.state
+    val addressType = address.addressType
 
     class Address : SqlTable("Address") {
         val id = column<Int>(name = "address_id", jdbcType = JDBCType.INTEGER)
         val streetAddress = column<String>(name = "street_address", jdbcType = JDBCType.VARCHAR)
         val city = column<String>(name = "city", jdbcType = JDBCType.VARCHAR)
         val state = column<String>(name = "state", jdbcType = JDBCType.VARCHAR)
+        val addressType = column(
+            name = "address_type",
+            jdbcType = JDBCType.INTEGER,
+            javaType = AddressType::class,
+            typeHandler = "org.apache.ibatis.type.EnumOrdinalTypeHandler"
+        )
     }
 }

--- a/src/test/kotlin/examples/kotlin/mybatis3/canonical/AddressMapper.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/canonical/AddressMapper.kt
@@ -15,14 +15,7 @@
  */
 package examples.kotlin.mybatis3.canonical
 
-data class AddressRecord(
-    var id: Int? = null,
-    var streetAddress: String? = null,
-    var city: String? = null,
-    var state: String? = null,
-    var addressType: AddressType? = null
-)
+import org.mybatis.dynamic.sql.util.mybatis3.CommonInsertMapper
+import org.mybatis.dynamic.sql.util.mybatis3.CommonSelectMapper
 
-enum class AddressType {
-    HOME, BUSINESS
-}
+interface AddressMapper: CommonInsertMapper<AddressRecord>, CommonSelectMapper

--- a/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonWithAddressMapper.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonWithAddressMapper.kt
@@ -20,6 +20,7 @@ import org.apache.ibatis.annotations.Result
 import org.apache.ibatis.annotations.ResultMap
 import org.apache.ibatis.annotations.Results
 import org.apache.ibatis.annotations.SelectProvider
+import org.apache.ibatis.type.EnumOrdinalTypeHandler
 import org.apache.ibatis.type.JdbcType
 import org.mybatis.dynamic.sql.select.render.SelectStatementProvider
 import org.mybatis.dynamic.sql.util.SqlProviderAdapter
@@ -55,7 +56,13 @@ interface PersonWithAddressMapper {
             Result(column = "address_id", property = "address.id", jdbcType = JdbcType.INTEGER),
             Result(column = "street_address", property = "address.streetAddress", jdbcType = JdbcType.VARCHAR),
             Result(column = "city", property = "address.city", jdbcType = JdbcType.VARCHAR),
-            Result(column = "state", property = "address.state", jdbcType = JdbcType.CHAR)
+            Result(column = "state", property = "address.state", jdbcType = JdbcType.CHAR),
+            Result(
+                column = "address_type",
+                property = "address.addressType",
+                jdbcType = JdbcType.INTEGER,
+                typeHandler = EnumOrdinalTypeHandler::class
+            )
         ]
     )
     fun selectMany(selectStatement: SelectStatementProvider): List<PersonWithAddress>

--- a/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonWithAddressMapperExtensions.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonWithAddressMapperExtensions.kt
@@ -29,11 +29,12 @@ import org.mybatis.dynamic.sql.util.kotlin.elements.isEqualTo
 import org.mybatis.dynamic.sql.util.kotlin.mybatis3.select
 import org.mybatis.dynamic.sql.util.kotlin.mybatis3.selectDistinct
 
+private val columnList = listOf(id.`as`("A_ID"), firstName, lastName, birthDate,
+    employed, occupation, address.id, address.streetAddress, address.city, address.state, address.addressType
+)
+
 fun PersonWithAddressMapper.selectOne(completer: SelectCompleter): PersonWithAddress? =
-    select(
-        id.`as`("A_ID"), firstName, lastName, birthDate,
-        employed, occupation, address.id, address.streetAddress, address.city, address.state
-    ) {
+    select(columnList) {
         from(person)
         fullJoin(address) {
             on(person.addressId, equalTo(address.id))
@@ -42,10 +43,7 @@ fun PersonWithAddressMapper.selectOne(completer: SelectCompleter): PersonWithAdd
     }.run(this::selectOne)
 
 fun PersonWithAddressMapper.select(completer: SelectCompleter): List<PersonWithAddress> =
-    select(
-        id.`as`("A_ID"), firstName, lastName, birthDate,
-        employed, occupation, address.id, address.streetAddress, address.city, address.state
-    ) {
+    select(columnList) {
         from(person, "p")
         fullJoin(address) {
             on(person.addressId, equalTo(address.id))
@@ -54,10 +52,7 @@ fun PersonWithAddressMapper.select(completer: SelectCompleter): List<PersonWithA
     }.run(this::selectMany)
 
 fun PersonWithAddressMapper.selectDistinct(completer: SelectCompleter): List<PersonWithAddress> =
-    selectDistinct(
-        id.`as`("A_ID"), firstName, lastName,
-        birthDate, employed, occupation, address.id, address.streetAddress, address.city, address.state
-    ) {
+    selectDistinct(columnList) {
         from(person)
         fullJoin(address) {
             on(person.addressId, equalTo(address.id))

--- a/src/test/resources/examples/kotlin/mybatis3/CreateSimpleDB.sql
+++ b/src/test/resources/examples/kotlin/mybatis3/CreateSimpleDB.sql
@@ -1,5 +1,5 @@
 --
---    Copyright 2016-2019 the original author or authors.
+--    Copyright 2016-2021 the original author or authors.
 --
 --    Licensed under the Apache License, Version 2.0 (the "License");
 --    you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ create table Address (
    street_address varchar(50) not null,
    city varchar(20) not null,
    state varchar(2) not null,
+   address_type int not null,
    primary key(address_id)
 );
 
@@ -36,11 +37,11 @@ create table Person (
    primary key(id)
 );
 
-insert into Address (address_id, street_address, city, state)
-values(1, '123 Main Street', 'Bedrock', 'IN');
+insert into Address (address_id, street_address, city, state, address_type)
+values(1, '123 Main Street', 'Bedrock', 'IN', 0);
 
-insert into Address (address_id, street_address, city, state)
-values(2, '456 Main Street', 'Bedrock', 'IN');
+insert into Address (address_id, street_address, city, state, address_type)
+values(2, '456 Main Street', 'Bedrock', 'IN', 1);
 
 insert into Person values(1, 'Fred', 'Flintstone', '1935-02-01', 'Yes', 'Brontosaurus Operator', 1);
 

--- a/src/test/resources/examples/simple/CreateSimpleDB.sql
+++ b/src/test/resources/examples/simple/CreateSimpleDB.sql
@@ -1,5 +1,5 @@
 --
---    Copyright 2016-2019 the original author or authors.
+--    Copyright 2016-2021 the original author or authors.
 --
 --    Licensed under the Apache License, Version 2.0 (the "License");
 --    you may not use this file except in compliance with the License.

--- a/src/test/resources/examples/simple/CreateSimpleDB.sql
+++ b/src/test/resources/examples/simple/CreateSimpleDB.sql
@@ -22,6 +22,7 @@ create table Address (
    street_address varchar(50) not null,
    city varchar(20) not null,
    state varchar(2) not null,
+   address_type int not null,
    primary key(address_id)
 );
 
@@ -36,11 +37,11 @@ create table Person (
    primary key(id)
 );
 
-insert into Address (address_id, street_address, city, state)
-values(1, '123 Main Street', 'Bedrock', 'IN');
+insert into Address (address_id, street_address, city, state, address_type)
+values(1, '123 Main Street', 'Bedrock', 'IN', 0);
 
-insert into Address (address_id, street_address, city, state)
-values(2, '456 Main Street', 'Bedrock', 'IN');
+insert into Address (address_id, street_address, city, state, address_type)
+values(2, '456 Main Street', 'Bedrock', 'IN', 1);
 
 insert into Person values(1, 'Fred', 'Flintstone', '1935-02-01', 'Yes', 'Brontosaurus Operator', 1);
 


### PR DESCRIPTION
MyBatis' EnumOrdinalTypeHandler requires that javaType be specified on the parameter marker. This PR adds that capability.

Resolves #385 
