### PR TITLE
Add check for duplicate table aliases

### DIFF
--- a/src/main/java/org/mybatis/dynamic/sql/exception/DuplicateTableAliasException.java
+++ b/src/main/java/org/mybatis/dynamic/sql/exception/DuplicateTableAliasException.java
@@ -1,0 +1,52 @@
+/*
+ *    Copyright 2016-2021 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.dynamic.sql.exception;
+
+import java.util.Objects;
+
+import org.mybatis.dynamic.sql.SqlTable;
+
+/**
+ * This exception is thrown when a query is built that attempts to specify more than one
+ * alias for the same instance of an SqlTable object. That error that would produce a select
+ * statement that doesn't work.
+ *
+ * <p>This error usually occurs when building a self-join query. The workaround is to create
+ * a second instance of the SqlTable object to use in the self-join.
+ *
+ * @since 1.3.1
+ * @author Jeff Butler
+ */
+public class DuplicateTableAliasException extends RuntimeException {
+
+    private final SqlTable table;
+    private final String newAlias;
+    private final String existingAlias;
+
+    public DuplicateTableAliasException(SqlTable table, String newAlias, String existingAlias) {
+        this.table = Objects.requireNonNull(table);
+        this.newAlias = Objects.requireNonNull(newAlias);
+        this.existingAlias = Objects.requireNonNull(existingAlias);
+    }
+
+    @Override
+    public String getMessage() {
+        return "Table \"" + table.tableNameAtRuntime() //$NON-NLS-1$
+                + "\" with requested alias \"" + newAlias //$NON-NLS-1$
+                + "\" is already aliased in this query with alias \"" + existingAlias //$NON-NLS-1$
+                + "\". Attempting to re-alias a table in the same query is not supported."; //$NON-NLS-1$
+    }
+}

--- a/src/main/java/org/mybatis/dynamic/sql/select/CountDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/CountDSL.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2020 the original author or authors.
+ *    Copyright 2016-2021 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -63,7 +63,7 @@ public class CountDSL<R> extends AbstractQueryExpressionDSL<CountDSL<R>.CountWhe
         QueryExpressionModel.Builder b = new QueryExpressionModel.Builder()
                 .withSelectColumn(countColumn)
                 .withTable(table())
-                .withTableAliases(tableAliases)
+                .withTableAliases(tableAliases())
                 .withWhereModel(whereBuilder.buildWhereModel());
 
         buildJoinModel().ifPresent(b::withJoinModel);

--- a/src/main/java/org/mybatis/dynamic/sql/select/QueryExpressionDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/QueryExpressionDSL.java
@@ -56,7 +56,7 @@ public class QueryExpressionDSL<R>
 
     QueryExpressionDSL(FromGatherer<R> fromGatherer, SqlTable table, String tableAlias) {
         this(fromGatherer, table);
-        tableAliases.put(table, tableAlias);
+        addTableAlias(table, tableAlias);
     }
 
     @Override
@@ -75,7 +75,7 @@ public class QueryExpressionDSL<R>
     }
 
     public JoinSpecificationStarter join(SqlTable joinTable, String tableAlias) {
-        tableAliases.put(joinTable, tableAlias);
+        addTableAlias(joinTable, tableAlias);
         return join(joinTable);
     }
 
@@ -88,7 +88,7 @@ public class QueryExpressionDSL<R>
     }
 
     public JoinSpecificationStarter leftJoin(SqlTable joinTable, String tableAlias) {
-        tableAliases.put(joinTable, tableAlias);
+        addTableAlias(joinTable, tableAlias);
         return leftJoin(joinTable);
     }
 
@@ -101,7 +101,7 @@ public class QueryExpressionDSL<R>
     }
 
     public JoinSpecificationStarter rightJoin(SqlTable joinTable, String tableAlias) {
-        tableAliases.put(joinTable, tableAlias);
+        addTableAlias(joinTable, tableAlias);
         return rightJoin(joinTable);
     }
 
@@ -114,7 +114,7 @@ public class QueryExpressionDSL<R>
     }
 
     public JoinSpecificationStarter fullJoin(SqlTable joinTable, String tableAlias) {
-        tableAliases.put(joinTable, tableAlias);
+        addTableAlias(joinTable, tableAlias);
         return fullJoin(joinTable);
     }
 
@@ -153,7 +153,7 @@ public class QueryExpressionDSL<R>
                 .withConnector(connector)
                 .withTable(table())
                 .isDistinct(isDistinct)
-                .withTableAliases(tableAliases)
+                .withTableAliases(tableAliases())
                 .withWhereModel(whereBuilder.buildWhereModel())
                 .withJoinModel(buildJoinModel().orElse(null))
                 .withGroupByModel(groupByModel)


### PR DESCRIPTION
This error is common on self-joins. We can easily detect it.