### PR TITLE
Remove deprecated "when" and "then" methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ GitHub milestone: [https://github.com/mybatis/mybatis-dynamic-sql/issues?q=miles
    we did not support the grouping of criteria at the beginning of a where clause or the beginning of an and/or
    condition. Adding this support required significant refactoring, but that should be transparent to most users.
    ([#434](https://github.com/mybatis/mybatis-dynamic-sql/pull/434))
+2. Remove deprecated "when" and "then" methods on all conditions. The methods have been replaced by more appropriately
+   named "filter" and "map" methods that function as expected for method chaining.
+   ([#435](https://github.com/mybatis/mybatis-dynamic-sql/pull/435))
 
 ## Release 1.3.1 - December 18, 2021
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-       Copyright 2016-2021 the original author or authors.
+       Copyright 2016-2022 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsBetween.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsBetween.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ import java.util.Objects;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.function.UnaryOperator;
 
 import org.mybatis.dynamic.sql.AbstractTwoValueCondition;
 
@@ -44,35 +43,6 @@ public class IsBetween<T> extends AbstractTwoValueCondition<T> {
     @Override
     public String renderCondition(String columnName, String placeholder1, String placeholder2) {
         return columnName + " between " + placeholder1 + " and " + placeholder2; //$NON-NLS-1$ //$NON-NLS-2$
-    }
-
-    /**
-     * If renderable and the values match the predicate, returns this condition. Else returns a condition
-     *     that will not render.
-     *
-     * @deprecated replaced by {@link IsBetween#filter(BiPredicate)}
-     * @param predicate predicate applied to the values, if renderable
-     * @return this condition if renderable and the values match the predicate, otherwise a condition
-     *     that will not render.
-     */
-    @Deprecated
-    public IsBetween<T> when(BiPredicate<T, T> predicate) {
-        return filter(predicate);
-    }
-
-    /**
-     * If renderable, apply the mappings to the values and return a new condition with the new values. Else return a
-     *     condition that will not render (this).
-     *
-     * @deprecated replaced by {@link IsBetween#map(Function, Function)}
-     * @param mapper1 a mapping function to apply to the first value, if renderable
-     * @param mapper2 a mapping function to apply to the second value, if renderable
-     * @return a new condition with the result of applying the mappers to the values of this condition,
-     *     if renderable, otherwise a condition that will not render.
-     */
-    @Deprecated
-    public IsBetween<T> then(UnaryOperator<T> mapper1, UnaryOperator<T> mapper2) {
-        return map(mapper1, mapper2);
     }
 
     @Override

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsEqualTo.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsEqualTo.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package org.mybatis.dynamic.sql.where.condition;
 
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.function.UnaryOperator;
 
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 
@@ -47,34 +46,6 @@ public class IsEqualTo<T> extends AbstractSingleValueCondition<T> {
 
     public static <T> IsEqualTo<T> of(T value) {
         return new IsEqualTo<>(value);
-    }
-
-    /**
-     * If renderable and the value matches the predicate, returns this condition. Else returns a condition
-     *     that will not render.
-     *
-     * @deprecated replaced by {@link IsEqualTo#filter(Predicate)}
-     * @param predicate predicate applied to the value, if renderable
-     * @return this condition if renderable and the value matches the predicate, otherwise a condition
-     *     that will not render.
-     */
-    @Deprecated
-    public IsEqualTo<T> when(Predicate<T> predicate) {
-        return filter(predicate);
-    }
-
-    /**
-     * If renderable, apply the mapping to the value and return a new condition with the new value. Else return a
-     *     condition that will not render (this).
-     *
-     * @deprecated replaced by {@link IsEqualTo#map(Function)}
-     * @param mapper a mapping function to apply to the value, if renderable
-     * @return a new condition with the result of applying the mapper to the value of this condition,
-     *     if renderable, otherwise a condition that will not render.
-     */
-    @Deprecated
-    public IsEqualTo<T> then(UnaryOperator<T> mapper) {
-        return map(mapper);
     }
 
     @Override

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThan.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThan.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package org.mybatis.dynamic.sql.where.condition;
 
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.function.UnaryOperator;
 
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 
@@ -46,34 +45,6 @@ public class IsGreaterThan<T> extends AbstractSingleValueCondition<T> {
 
     public static <T> IsGreaterThan<T> of(T value) {
         return new IsGreaterThan<>(value);
-    }
-
-    /**
-     * If renderable and the value matches the predicate, returns this condition. Else returns a condition
-     *     that will not render.
-     *
-     * @deprecated replaced by {@link IsGreaterThan#filter(Predicate)}
-     * @param predicate predicate applied to the value, if renderable
-     * @return this condition if renderable and the value matches the predicate, otherwise a condition
-     *     that will not render.
-     */
-    @Deprecated
-    public IsGreaterThan<T> when(Predicate<T> predicate) {
-        return filter(predicate);
-    }
-
-    /**
-     * If renderable, apply the mapping to the value and return a new condition with the new value. Else return a
-     *     condition that will not render (this).
-     *
-     * @deprecated replaced by {@link IsGreaterThan#map(Function)}
-     * @param mapper a mapping function to apply to the value, if renderable
-     * @return a new condition with the result of applying the mapper to the value of this condition,
-     *     if renderable, otherwise a condition that will not render.
-     */
-    @Deprecated
-    public IsGreaterThan<T> then(UnaryOperator<T> mapper) {
-        return map(mapper);
     }
 
     @Override

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThanOrEqualTo.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThanOrEqualTo.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package org.mybatis.dynamic.sql.where.condition;
 
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.function.UnaryOperator;
 
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 
@@ -46,34 +45,6 @@ public class IsGreaterThanOrEqualTo<T> extends AbstractSingleValueCondition<T> {
 
     public static <T> IsGreaterThanOrEqualTo<T> of(T value) {
         return new IsGreaterThanOrEqualTo<>(value);
-    }
-
-    /**
-     * If renderable and the value matches the predicate, returns this condition. Else returns a condition
-     *     that will not render.
-     *
-     * @deprecated replaced by {@link IsGreaterThanOrEqualTo#filter(Predicate)}
-     * @param predicate predicate applied to the value, if renderable
-     * @return this condition if renderable and the value matches the predicate, otherwise a condition
-     *     that will not render.
-     */
-    @Deprecated
-    public IsGreaterThanOrEqualTo<T> when(Predicate<T> predicate) {
-        return filter(predicate);
-    }
-
-    /**
-     * If renderable, apply the mapping to the value and return a new condition with the new value. Else return a
-     *     condition that will not render (this).
-     *
-     * @deprecated replaced by {@link IsGreaterThanOrEqualTo#map(Function)}
-     * @param mapper a mapping function to apply to the value, if renderable
-     * @return a new condition with the result of applying the mapper to the value of this condition,
-     *     if renderable, otherwise a condition that will not render.
-     */
-    @Deprecated
-    public IsGreaterThanOrEqualTo<T> then(UnaryOperator<T> mapper) {
-        return map(mapper);
     }
 
     @Override

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsIn.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsIn.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,11 +20,9 @@ import static org.mybatis.dynamic.sql.util.StringUtilities.spaceAfter;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -38,6 +36,10 @@ public class IsIn<T> extends AbstractListValueCondition<T> {
         @SuppressWarnings("unchecked")
         IsIn<T> t = (IsIn<T>) EMPTY;
         return t;
+    }
+
+    private <S> IsIn<S> emptyWithCallBack() {
+        return new IsIn<>(Collections.emptyList(), emptyCallback);
     }
 
     protected IsIn(Collection<T> values) {
@@ -59,27 +61,9 @@ public class IsIn<T> extends AbstractListValueCondition<T> {
         return new IsIn<>(values, callback);
     }
 
-    /**
-     * This method allows you to modify the condition's values before they are placed into the parameter map.
-     * For example, you could filter nulls, or trim strings, etc. This process will run before final rendering of SQL.
-     * If you filter values out of the stream, then final condition will not reference those values. If you filter all
-     * values out of the stream, then the condition will not render.
-     *
-     * @deprecated replaced by {@link IsIn#map(Function)} and {@link IsIn#filter(Predicate)}
-     * @param valueStreamTransformer a UnaryOperator that will transform the value stream before
-     *     the values are placed in the parameter map
-     * @return new condition with the specified transformer
-     */
-    @Deprecated
-    public IsIn<T> then(UnaryOperator<Stream<T>> valueStreamTransformer) {
-        List<T> mapped = valueStreamTransformer.apply(values.stream())
-                .collect(Collectors.toList());
-        return new IsIn<>(mapped, emptyCallback);
-    }
-
     @Override
     public IsIn<T> filter(Predicate<? super T> predicate) {
-        return filterSupport(predicate, IsIn::new, this, IsIn::empty);
+        return filterSupport(predicate, IsIn::new, this, this::emptyWithCallBack);
     }
 
     /**
@@ -93,7 +77,7 @@ public class IsIn<T> extends AbstractListValueCondition<T> {
      */
     public <R> IsIn<R> map(Function<? super T, ? extends R> mapper) {
         BiFunction<Collection<R>, Callback, IsIn<R>> constructor = IsIn::new;
-        return mapSupport(mapper, constructor, IsIn::empty);
+        return mapSupport(mapper, constructor, this::emptyWithCallBack);
     }
 
     @SafeVarargs

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInCaseInsensitive.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInCaseInsensitive.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -34,6 +34,10 @@ public class IsInCaseInsensitive extends AbstractListValueCondition<String> {
         return EMPTY;
     }
 
+    private IsInCaseInsensitive emptyWithCallback() {
+        return new IsInCaseInsensitive(Collections.emptyList(), emptyCallback);
+    }
+
     protected  IsInCaseInsensitive(Collection<String> values) {
         super(values);
     }
@@ -56,7 +60,7 @@ public class IsInCaseInsensitive extends AbstractListValueCondition<String> {
 
     @Override
     public IsInCaseInsensitive filter(Predicate<? super String> predicate) {
-        return filterSupport(predicate, IsInCaseInsensitive::new, this, IsInCaseInsensitive::empty);
+        return filterSupport(predicate, IsInCaseInsensitive::new, this, this::emptyWithCallback);
     }
 
     /**
@@ -68,7 +72,7 @@ public class IsInCaseInsensitive extends AbstractListValueCondition<String> {
      *     that will not render.
      */
     public IsInCaseInsensitive map(UnaryOperator<String> mapper) {
-        return mapSupport(mapper, IsInCaseInsensitive::new, IsInCaseInsensitive::empty);
+        return mapSupport(mapper, IsInCaseInsensitive::new, this::emptyWithCallback);
     }
 
     public static IsInCaseInsensitive of(String... values) {

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThan.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThan.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package org.mybatis.dynamic.sql.where.condition;
 
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.function.UnaryOperator;
 
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 
@@ -46,34 +45,6 @@ public class IsLessThan<T> extends AbstractSingleValueCondition<T> {
 
     public static <T> IsLessThan<T> of(T value) {
         return new IsLessThan<>(value);
-    }
-
-    /**
-     * If renderable and the value matches the predicate, returns this condition. Else returns a condition
-     *     that will not render.
-     *
-     * @deprecated replaced by {@link IsLessThan#filter(Predicate)}
-     * @param predicate predicate applied to the value, if renderable
-     * @return this condition if renderable and the value matches the predicate, otherwise a condition
-     *     that will not render.
-     */
-    @Deprecated
-    public IsLessThan<T> when(Predicate<T> predicate) {
-        return filter(predicate);
-    }
-
-    /**
-     * If renderable, apply the mapping to the value and return a new condition with the new value. Else return a
-     *     condition that will not render (this).
-     *
-     * @deprecated replaced by {@link IsLessThan#map(Function)}
-     * @param mapper a mapping function to apply to the value, if renderable
-     * @return a new condition with the result of applying the mapper to the value of this condition,
-     *     if renderable, otherwise a condition that will not render.
-     */
-    @Deprecated
-    public IsLessThan<T> then(UnaryOperator<T> mapper) {
-        return map(mapper);
     }
 
     @Override

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThanOrEqualTo.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThanOrEqualTo.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package org.mybatis.dynamic.sql.where.condition;
 
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.function.UnaryOperator;
 
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 
@@ -46,34 +45,6 @@ public class IsLessThanOrEqualTo<T> extends AbstractSingleValueCondition<T> {
 
     public static <T> IsLessThanOrEqualTo<T> of(T value) {
         return new IsLessThanOrEqualTo<>(value);
-    }
-
-    /**
-     * If renderable and the value matches the predicate, returns this condition. Else returns a condition
-     *     that will not render.
-     *
-     * @deprecated replaced by {@link IsLessThanOrEqualTo#filter(Predicate)}
-     * @param predicate predicate applied to the value, if renderable
-     * @return this condition if renderable and the value matches the predicate, otherwise a condition
-     *     that will not render.
-     */
-    @Deprecated
-    public IsLessThanOrEqualTo<T> when(Predicate<T> predicate) {
-        return filter(predicate);
-    }
-
-    /**
-     * If renderable, apply the mapping to the value and return a new condition with the new value. Else return a
-     *     condition that will not render (this).
-     *
-     * @deprecated replaced by {@link IsLessThanOrEqualTo#map(Function)}
-     * @param mapper a mapping function to apply to the value, if renderable
-     * @return a new condition with the result of applying the mapper to the value of this condition,
-     *     if renderable, otherwise a condition that will not render.
-     */
-    @Deprecated
-    public IsLessThanOrEqualTo<T> then(UnaryOperator<T> mapper) {
-        return map(mapper);
     }
 
     @Override

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLike.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLike.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package org.mybatis.dynamic.sql.where.condition;
 
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.function.UnaryOperator;
 
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 
@@ -46,34 +45,6 @@ public class IsLike<T> extends AbstractSingleValueCondition<T> {
 
     public static <T> IsLike<T> of(T value) {
         return new IsLike<>(value);
-    }
-
-    /**
-     * If renderable and the value matches the predicate, returns this condition. Else returns a condition
-     *     that will not render.
-     *
-     * @deprecated replaced by {@link IsLike#filter(Predicate)}
-     * @param predicate predicate applied to the value, if renderable
-     * @return this condition if renderable and the value matches the predicate, otherwise a condition
-     *     that will not render.
-     */
-    @Deprecated
-    public IsLike<T> when(Predicate<T> predicate) {
-        return filter(predicate);
-    }
-
-    /**
-     * If renderable, apply the mapping to the value and return a new condition with the new value. Else return a
-     *     condition that will not render (this).
-     *
-     * @deprecated replaced by {@link IsLike#map(Function)}
-     * @param mapper a mapping function to apply to the value, if renderable
-     * @return a new condition with the result of applying the mapper to the value of this condition,
-     *     if renderable, otherwise a condition that will not render.
-     */
-    @Deprecated
-    public IsLike<T> then(UnaryOperator<T> mapper) {
-        return map(mapper);
     }
 
     @Override

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLikeCaseInsensitive.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLikeCaseInsensitive.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -49,34 +49,6 @@ public class IsLikeCaseInsensitive extends AbstractSingleValueCondition<String> 
 
     public static IsLikeCaseInsensitive of(String value) {
         return new IsLikeCaseInsensitive(value);
-    }
-
-    /**
-     * If renderable and the value matches the predicate, returns this condition. Else returns a condition
-     *     that will not render.
-     *
-     * @deprecated replaced by {@link IsLikeCaseInsensitive#filter(Predicate)}
-     * @param predicate predicate applied to the value, if renderable
-     * @return this condition if renderable and the value matches the predicate, otherwise a condition
-     *     that will not render.
-     */
-    @Deprecated
-    public IsLikeCaseInsensitive when(Predicate<String> predicate) {
-        return filter(predicate);
-    }
-
-    /**
-     * If renderable, apply the mapping to the value and return a new condition with the new value. Else return a
-     *     condition that will not render (this).
-     *
-     * @deprecated replaced by {@link IsLikeCaseInsensitive#map(UnaryOperator)}
-     * @param mapper a mapping function to apply to the value, if renderable
-     * @return a new condition with the result of applying the mapper to the value of this condition,
-     *     if renderable, otherwise a condition that will not render.
-     */
-    @Deprecated
-    public IsLikeCaseInsensitive then(UnaryOperator<String> mapper) {
-        return map(mapper);
     }
 
     @Override

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotBetween.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotBetween.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ import java.util.Objects;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.function.UnaryOperator;
 
 import org.mybatis.dynamic.sql.AbstractTwoValueCondition;
 
@@ -44,35 +43,6 @@ public class IsNotBetween<T> extends AbstractTwoValueCondition<T> {
     @Override
     public String renderCondition(String columnName, String placeholder1, String placeholder2) {
         return columnName + " not between " + placeholder1 + " and " + placeholder2; //$NON-NLS-1$ //$NON-NLS-2$
-    }
-
-    /**
-     * If renderable and the values match the predicate, returns this condition. Else returns a condition
-     *     that will not render.
-     *
-     * @deprecated replaced by {@link IsNotBetween#filter(BiPredicate)}
-     * @param predicate predicate applied to the values, if renderable
-     * @return this condition if renderable and the values match the predicate, otherwise a condition
-     *     that will not render.
-     */
-    @Deprecated
-    public IsNotBetween<T> when(BiPredicate<T, T> predicate) {
-        return filter(predicate);
-    }
-
-    /**
-     * If renderable, apply the mappings to the values and return a new condition with the new values. Else return a
-     *     condition that will not render (this).
-     *
-     * @deprecated replaced by {@link IsNotBetween#map(Function, Function)}
-     * @param mapper1 a mapping function to apply to the first value, if renderable
-     * @param mapper2 a mapping function to apply to the second value, if renderable
-     * @return a new condition with the result of applying the mappers to the values of this condition,
-     *     if renderable, otherwise a condition that will not render.
-     */
-    @Deprecated
-    public IsNotBetween<T> then(UnaryOperator<T> mapper1, UnaryOperator<T> mapper2) {
-        return map(mapper1, mapper2);
     }
 
     @Override

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotEqualTo.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotEqualTo.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package org.mybatis.dynamic.sql.where.condition;
 
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.function.UnaryOperator;
 
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 
@@ -46,34 +45,6 @@ public class IsNotEqualTo<T> extends AbstractSingleValueCondition<T> {
 
     public static <T> IsNotEqualTo<T> of(T value) {
         return new IsNotEqualTo<>(value);
-    }
-
-    /**
-     * If renderable and the value matches the predicate, returns this condition. Else returns a condition
-     *     that will not render.
-     *
-     * @deprecated replaced by {@link IsNotEqualTo#filter(Predicate)}
-     * @param predicate predicate applied to the value, if renderable
-     * @return this condition if renderable and the value matches the predicate, otherwise a condition
-     *     that will not render.
-     */
-    @Deprecated
-    public IsNotEqualTo<T> when(Predicate<T> predicate) {
-        return filter(predicate);
-    }
-
-    /**
-     * If renderable, apply the mapping to the value and return a new condition with the new value. Else return a
-     *     condition that will not render (this).
-     *
-     * @deprecated replaced by {@link IsNotEqualTo#map(Function)}
-     * @param mapper a mapping function to apply to the value, if renderable
-     * @return a new condition with the result of applying the mapper to the value of this condition,
-     *     if renderable, otherwise a condition that will not render.
-     */
-    @Deprecated
-    public IsNotEqualTo<T> then(UnaryOperator<T> mapper) {
-        return map(mapper);
     }
 
     @Override

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotIn.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotIn.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,11 +20,9 @@ import static org.mybatis.dynamic.sql.util.StringUtilities.spaceAfter;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -38,6 +36,10 @@ public class IsNotIn<T> extends AbstractListValueCondition<T> {
         @SuppressWarnings("unchecked")
         IsNotIn<T> t = (IsNotIn<T>) EMPTY;
         return t;
+    }
+
+    private <S> IsNotIn<S> emptyWithCallback() {
+        return new IsNotIn<>(Collections.emptyList(), emptyCallback);
     }
 
     protected IsNotIn(Collection<T> values) {
@@ -60,28 +62,9 @@ public class IsNotIn<T> extends AbstractListValueCondition<T> {
         return new IsNotIn<>(values, callback);
     }
 
-    /**
-     * This method allows you to modify the condition's values before they are placed into the parameter map.
-     * For example, you could filter nulls, or trim strings, etc. This process will run before final rendering of SQL.
-     * If you filter values out of the stream, then final condition will not reference those values. If you filter all
-     * values out of the stream, then the condition will not render.
-     *
-     * @deprecated replaced by {@link IsNotIn#map(Function)} and {@link IsNotIn#filter(Predicate)}
-     * @param valueStreamTransformer a UnaryOperator that will transform the value stream before
-     *     the values are placed in the parameter map
-     * @return new condition with the specified transformer
-     */
-    @Deprecated
-    public IsNotIn<T> then(UnaryOperator<Stream<T>> valueStreamTransformer) {
-        List<T> mapped = valueStreamTransformer.apply(values.stream())
-                .collect(Collectors.toList());
-
-        return new IsNotIn<>(mapped, emptyCallback);
-    }
-
     @Override
     public IsNotIn<T> filter(Predicate<? super T> predicate) {
-        return filterSupport(predicate, IsNotIn::new, this, IsNotIn::empty);
+        return filterSupport(predicate, IsNotIn::new, this, this::emptyWithCallback);
     }
 
     /**
@@ -95,7 +78,7 @@ public class IsNotIn<T> extends AbstractListValueCondition<T> {
      */
     public <R> IsNotIn<R> map(Function<? super T, ? extends R> mapper) {
         BiFunction<Collection<R>, Callback, IsNotIn<R>> constructor = IsNotIn::new;
-        return mapSupport(mapper, constructor, IsNotIn::empty);
+        return mapSupport(mapper, constructor, this::emptyWithCallback);
     }
 
     @SafeVarargs

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInCaseInsensitive.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInCaseInsensitive.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -34,6 +34,10 @@ public class IsNotInCaseInsensitive extends AbstractListValueCondition<String> {
         return EMPTY;
     }
 
+    private IsNotInCaseInsensitive emptyWithCallback() {
+        return new IsNotInCaseInsensitive(Collections.emptyList(), emptyCallback);
+    }
+
     protected IsNotInCaseInsensitive(Collection<String> values) {
         super(values);
     }
@@ -56,7 +60,7 @@ public class IsNotInCaseInsensitive extends AbstractListValueCondition<String> {
 
     @Override
     public IsNotInCaseInsensitive filter(Predicate<? super String> predicate) {
-        return filterSupport(predicate, IsNotInCaseInsensitive::new, this, IsNotInCaseInsensitive::empty);
+        return filterSupport(predicate, IsNotInCaseInsensitive::new, this, this::emptyWithCallback);
     }
 
     /**
@@ -68,7 +72,7 @@ public class IsNotInCaseInsensitive extends AbstractListValueCondition<String> {
      *     that will not render.
      */
     public IsNotInCaseInsensitive map(UnaryOperator<String> mapper) {
-        return mapSupport(mapper, IsNotInCaseInsensitive::new, IsNotInCaseInsensitive::empty);
+        return mapSupport(mapper, IsNotInCaseInsensitive::new, this::emptyWithCallback);
     }
 
     public static IsNotInCaseInsensitive of(String... values) {

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotLike.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotLike.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package org.mybatis.dynamic.sql.where.condition;
 
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.function.UnaryOperator;
 
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 
@@ -46,34 +45,6 @@ public class IsNotLike<T> extends AbstractSingleValueCondition<T> {
 
     public static <T> IsNotLike<T> of(T value) {
         return new IsNotLike<>(value);
-    }
-
-    /**
-     * If renderable and the value matches the predicate, returns this condition. Else returns a condition
-     *     that will not render.
-     *
-     * @deprecated replaced by {@link IsNotLike#filter(Predicate)}
-     * @param predicate predicate applied to the value, if renderable
-     * @return this condition if renderable and the value matches the predicate, otherwise a condition
-     *     that will not render.
-     */
-    @Deprecated
-    public IsNotLike<T> when(Predicate<T> predicate) {
-        return filter(predicate);
-    }
-
-    /**
-     * If renderable, apply the mapping to the value and return a new condition with the new value. Else return a
-     *     condition that will not render (this).
-     *
-     * @deprecated replaced by {@link IsNotLike#map(Function)}
-     * @param mapper a mapping function to apply to the value, if renderable
-     * @return a new condition with the result of applying the mapper to the value of this condition,
-     *     if renderable, otherwise a condition that will not render.
-     */
-    @Deprecated
-    public IsNotLike<T> then(UnaryOperator<T> mapper) {
-        return map(mapper);
     }
 
     @Override

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotLikeCaseInsensitive.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotLikeCaseInsensitive.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -49,34 +49,6 @@ public class IsNotLikeCaseInsensitive extends AbstractSingleValueCondition<Strin
 
     public static IsNotLikeCaseInsensitive of(String value) {
         return new IsNotLikeCaseInsensitive(value);
-    }
-
-    /**
-     * If renderable and the value matches the predicate, returns this condition. Else returns a condition
-     *     that will not render.
-     *
-     * @deprecated replaced by {@link IsNotLikeCaseInsensitive#filter(Predicate)}
-     * @param predicate predicate applied to the value, if renderable
-     * @return this condition if renderable and the value matches the predicate, otherwise a condition
-     *     that will not render.
-     */
-    @Deprecated
-    public IsNotLikeCaseInsensitive when(Predicate<String> predicate) {
-        return filter(predicate);
-    }
-
-    /**
-     * If renderable, apply the mapping to the value and return a new condition with the new value. Else return a
-     *     condition that will not render (this).
-     *
-     * @deprecated replaced by {@link IsNotLikeCaseInsensitive#map(UnaryOperator)}
-     * @param mapper a mapping function to apply to the value, if renderable
-     * @return a new condition with the result of applying the mapper to the value of this condition,
-     *     if renderable, otherwise a condition that will not render.
-     */
-    @Deprecated
-    public IsNotLikeCaseInsensitive then(UnaryOperator<String> mapper) {
-        return map(mapper);
     }
 
     @Override

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotNull.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotNull.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -40,21 +40,6 @@ public class IsNotNull<T> extends AbstractNoValueCondition<T> {
     @Override
     public String renderCondition(String columnName) {
         return columnName + " is not null"; //$NON-NLS-1$
-    }
-
-    /**
-     * If renderable and the supplier returns true, returns this condition. Else returns a condition
-     *     that will not render.
-     *
-     * @deprecated replaced by {@link IsNotNull#filter(BooleanSupplier)}
-     * @param booleanSupplier function that specifies whether the condition should render
-     * @param <S> condition type - not used except for compilation compliance
-     * @return this condition if renderable and the supplier returns true, otherwise a condition
-     *     that will not render.
-     */
-    @Deprecated
-    public <S> IsNotNull<S> when(BooleanSupplier booleanSupplier) {
-        return filter(booleanSupplier);
     }
 
     /**

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNull.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNull.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -40,21 +40,6 @@ public class IsNull<T> extends AbstractNoValueCondition<T> {
     @Override
     public String renderCondition(String columnName) {
         return columnName + " is null"; //$NON-NLS-1$
-    }
-
-    /**
-     * If renderable and the supplier returns true, returns this condition. Else returns a condition
-     *     that will not render.
-     *
-     * @deprecated replaced by {@link IsNull#filter(BooleanSupplier)}
-     * @param booleanSupplier function that specifies whether the condition should render
-     * @param <S> condition type - not used except for compilation compliance
-     * @return this condition if renderable and the supplier returns true, otherwise a condition
-     *     that will not render.
-     */
-    @Deprecated
-    public <S> IsNull<S> when(BooleanSupplier booleanSupplier) {
-        return filter(booleanSupplier);
     }
 
     /**

--- a/src/test/java/examples/animal/data/AnimalDataTest.java
+++ b/src/test/java/examples/animal/data/AnimalDataTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -582,7 +582,7 @@ class AnimalDataTest {
 
             SelectStatementProvider selectStatement = select(id, animalName, bodyWeight, brainWeight)
                     .from(animalData)
-                    .where(id, isIn(null, 22, null).then(s -> s.filter(Objects::nonNull).filter(i -> i != 22)))
+                    .where(id, isIn(null, 22, null).filter(Objects::nonNull).filter(i -> i != 22))
                     .build()
                     .render(RenderingStrategies.MYBATIS3);
 
@@ -602,7 +602,7 @@ class AnimalDataTest {
 
         SelectModel selectModel = select(id, animalName, bodyWeight, brainWeight)
                 .from(animalData)
-                .where(id, isInRequired(inValues).then(s -> s.filter(Objects::nonNull).filter(i -> i != 22)))
+                .where(id, isInRequired(inValues).filter(Objects::nonNull).filter(i -> i != 22))
                 .build();
 
         assertThatExceptionOfType(RuntimeException.class).isThrownBy(() ->
@@ -697,7 +697,7 @@ class AnimalDataTest {
 
             SelectStatementProvider selectStatement = select(id, animalName, bodyWeight, brainWeight)
                     .from(animalData)
-                    .where(id, isNotIn(null, 22, null).then(s -> s.filter(Objects::nonNull).filter(i -> i != 22)))
+                    .where(id, isNotIn(null, 22, null).filter(Objects::nonNull).filter(i -> i != 22))
                     .build()
                     .render(RenderingStrategies.MYBATIS3);
 
@@ -713,7 +713,7 @@ class AnimalDataTest {
         SelectModel selectModel = select(id, animalName, bodyWeight, brainWeight)
                 .from(animalData)
                 .where(id, isNotInRequired(null, 22, null)
-                        .then(s -> s.filter(Objects::nonNull).filter(i -> i != 22)))
+                        .filter(Objects::nonNull).filter(i -> i != 22))
                 .build();
 
         assertThatExceptionOfType(RuntimeException.class).isThrownBy(() ->

--- a/src/test/java/examples/animal/data/MyInCondition.java
+++ b/src/test/java/examples/animal/data/MyInCondition.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -23,15 +23,8 @@ import org.mybatis.dynamic.sql.where.condition.IsIn;
 public class MyInCondition {
     public static IsIn<String> isIn(String...values) {
         return SqlBuilder.isIn(values)
-                .then(s -> s.filter(Objects::nonNull)
-                        .map((String::trim))
-                        .filter(st -> !st.isEmpty()));
-    }
-
-    public static IsIn<String> isInNewPattern(String...values) {
-        return SqlBuilder.isIn(values)
                 .filter(Objects::nonNull)
-                .map(String::trim)
+                .map((String::trim))
                 .filter(st -> !st.isEmpty());
     }
 }

--- a/src/test/java/examples/animal/data/OptionalConditionsWithPredicatesAnimalDataTest.java
+++ b/src/test/java/examples/animal/data/OptionalConditionsWithPredicatesAnimalDataTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2020 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -76,7 +76,7 @@ class OptionalConditionsWithPredicatesAnimalDataTest {
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             SelectStatementProvider selectStatement = select(id, animalName, bodyWeight, brainWeight)
                     .from(animalData)
-                    .where(id, isGreaterThan(NULL_INTEGER).when(Objects::nonNull))  // the where clause should not render
+                    .where(id, isGreaterThan(NULL_INTEGER).filter(Objects::nonNull))  // the where clause should not render
                     .orderBy(id)
                     .build()
                     .render(RenderingStrategies.MYBATIS3);
@@ -97,8 +97,8 @@ class OptionalConditionsWithPredicatesAnimalDataTest {
             SelectStatementProvider selectStatement = select(id, animalName, bodyWeight, brainWeight)
                     .from(animalData)
                     .where(id, isEqualTo(3))
-                    .and(id, isNotEqualTo(NULL_INTEGER).when(Objects::nonNull))
-                    .or(id, isEqualTo(4).when(Objects::nonNull))
+                    .and(id, isNotEqualTo(NULL_INTEGER).filter(Objects::nonNull))
+                    .or(id, isEqualTo(4).filter(Objects::nonNull))
                     .orderBy(id)
                     .build()
                     .render(RenderingStrategies.MYBATIS3);
@@ -118,9 +118,9 @@ class OptionalConditionsWithPredicatesAnimalDataTest {
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             SelectStatementProvider selectStatement = select(id, animalName, bodyWeight, brainWeight)
                     .from(animalData)
-                    .where(id, isLessThan(NULL_INTEGER).when(Objects::nonNull))
-                    .and(id, isEqualTo(3).when(Objects::nonNull))
-                    .or(id, isEqualTo(4).when(Objects::nonNull))
+                    .where(id, isLessThan(NULL_INTEGER).filter(Objects::nonNull))
+                    .and(id, isEqualTo(3).filter(Objects::nonNull))
+                    .or(id, isEqualTo(4).filter(Objects::nonNull))
                     .orderBy(id)
                     .build()
                     .render(RenderingStrategies.MYBATIS3);
@@ -140,10 +140,10 @@ class OptionalConditionsWithPredicatesAnimalDataTest {
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             SelectStatementProvider selectStatement = select(id, animalName, bodyWeight, brainWeight)
                     .from(animalData)
-                    .where(id, isLessThan(NULL_INTEGER).when(Objects::nonNull), and(id, isGreaterThanOrEqualTo(NULL_INTEGER).when(Objects::nonNull)))
-                    .and(id, isEqualTo(NULL_INTEGER).when(Objects::nonNull), or(id, isEqualTo(3), and(id, isLessThan(NULL_INTEGER).when(Objects::nonNull))))
-                    .or(id, isEqualTo(4).when(Objects::nonNull), and(id, isGreaterThanOrEqualTo(NULL_INTEGER).when(Objects::nonNull)))
-                    .and(id, isNotEqualTo(NULL_INTEGER).when(Objects::nonNull))
+                    .where(id, isLessThan(NULL_INTEGER).filter(Objects::nonNull), and(id, isGreaterThanOrEqualTo(NULL_INTEGER).filter(Objects::nonNull)))
+                    .and(id, isEqualTo(NULL_INTEGER).filter(Objects::nonNull), or(id, isEqualTo(3), and(id, isLessThan(NULL_INTEGER).filter(Objects::nonNull))))
+                    .or(id, isEqualTo(4).filter(Objects::nonNull), and(id, isGreaterThanOrEqualTo(NULL_INTEGER).filter(Objects::nonNull)))
+                    .and(id, isNotEqualTo(NULL_INTEGER).filter(Objects::nonNull))
                     .orderBy(id)
                     .build()
                     .render(RenderingStrategies.MYBATIS3);
@@ -163,8 +163,8 @@ class OptionalConditionsWithPredicatesAnimalDataTest {
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             SelectStatementProvider selectStatement = select(id, animalName, bodyWeight, brainWeight)
                     .from(animalData)
-                    .where(id, isLessThan(NULL_INTEGER).when(Objects::nonNull), and(id, isEqualTo(3).when(Objects::nonNull)))
-                    .or(id, isEqualTo(4).when(Objects::nonNull))
+                    .where(id, isLessThan(NULL_INTEGER).filter(Objects::nonNull), and(id, isEqualTo(3).filter(Objects::nonNull)))
+                    .or(id, isEqualTo(4).filter(Objects::nonNull))
                     .orderBy(id)
                     .build()
                     .render(RenderingStrategies.MYBATIS3);
@@ -184,7 +184,7 @@ class OptionalConditionsWithPredicatesAnimalDataTest {
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             SelectStatementProvider selectStatement = select(id, animalName, bodyWeight, brainWeight)
                     .from(animalData)
-                    .where(id, isEqualTo(4).when(Objects::nonNull))
+                    .where(id, isEqualTo(4).filter(Objects::nonNull))
                     .orderBy(id)
                     .build()
                     .render(RenderingStrategies.MYBATIS3);
@@ -203,7 +203,7 @@ class OptionalConditionsWithPredicatesAnimalDataTest {
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             SelectStatementProvider selectStatement = select(id, animalName, bodyWeight, brainWeight)
                     .from(animalData)
-                    .where(id, isEqualTo(NULL_INTEGER).when(Objects::nonNull))
+                    .where(id, isEqualTo(NULL_INTEGER).filter(Objects::nonNull))
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
@@ -223,7 +223,7 @@ class OptionalConditionsWithPredicatesAnimalDataTest {
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             SelectStatementProvider selectStatement = select(id, animalName, bodyWeight, brainWeight)
                     .from(animalData)
-                    .where(id, isNotEqualTo(4).when(Objects::nonNull))
+                    .where(id, isNotEqualTo(4).filter(Objects::nonNull))
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
@@ -243,7 +243,7 @@ class OptionalConditionsWithPredicatesAnimalDataTest {
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             SelectStatementProvider selectStatement = select(id, animalName, bodyWeight, brainWeight)
                     .from(animalData)
-                    .where(id, isNotEqualTo(NULL_INTEGER).when(Objects::nonNull))
+                    .where(id, isNotEqualTo(NULL_INTEGER).filter(Objects::nonNull))
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
@@ -263,7 +263,7 @@ class OptionalConditionsWithPredicatesAnimalDataTest {
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             SelectStatementProvider selectStatement = select(id, animalName, bodyWeight, brainWeight)
                     .from(animalData)
-                    .where(id, isGreaterThan(4).when(Objects::nonNull))
+                    .where(id, isGreaterThan(4).filter(Objects::nonNull))
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
@@ -283,7 +283,7 @@ class OptionalConditionsWithPredicatesAnimalDataTest {
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             SelectStatementProvider selectStatement = select(id, animalName, bodyWeight, brainWeight)
                     .from(animalData)
-                    .where(id, isGreaterThan(NULL_INTEGER).when(Objects::nonNull))
+                    .where(id, isGreaterThan(NULL_INTEGER).filter(Objects::nonNull))
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
@@ -303,7 +303,7 @@ class OptionalConditionsWithPredicatesAnimalDataTest {
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             SelectStatementProvider selectStatement = select(id, animalName, bodyWeight, brainWeight)
                     .from(animalData)
-                    .where(id, isGreaterThanOrEqualTo(4).when(Objects::nonNull))
+                    .where(id, isGreaterThanOrEqualTo(4).filter(Objects::nonNull))
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
@@ -323,7 +323,7 @@ class OptionalConditionsWithPredicatesAnimalDataTest {
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             SelectStatementProvider selectStatement = select(id, animalName, bodyWeight, brainWeight)
                     .from(animalData)
-                    .where(id, isGreaterThanOrEqualTo(NULL_INTEGER).when(Objects::nonNull))
+                    .where(id, isGreaterThanOrEqualTo(NULL_INTEGER).filter(Objects::nonNull))
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
@@ -343,7 +343,7 @@ class OptionalConditionsWithPredicatesAnimalDataTest {
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             SelectStatementProvider selectStatement = select(id, animalName, bodyWeight, brainWeight)
                     .from(animalData)
-                    .where(id, isLessThan(4).when(Objects::nonNull))
+                    .where(id, isLessThan(4).filter(Objects::nonNull))
                     .orderBy(id)
                     .build()
                     .render(RenderingStrategies.MYBATIS3);
@@ -362,7 +362,7 @@ class OptionalConditionsWithPredicatesAnimalDataTest {
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             SelectStatementProvider selectStatement = select(id, animalName, bodyWeight, brainWeight)
                     .from(animalData)
-                    .where(id, isLessThan(NULL_INTEGER).when(Objects::nonNull))
+                    .where(id, isLessThan(NULL_INTEGER).filter(Objects::nonNull))
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
@@ -382,7 +382,7 @@ class OptionalConditionsWithPredicatesAnimalDataTest {
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             SelectStatementProvider selectStatement = select(id, animalName, bodyWeight, brainWeight)
                     .from(animalData)
-                    .where(id, isLessThanOrEqualTo(4).when(Objects::nonNull))
+                    .where(id, isLessThanOrEqualTo(4).filter(Objects::nonNull))
                     .orderBy(id)
                     .build()
                     .render(RenderingStrategies.MYBATIS3);
@@ -401,7 +401,7 @@ class OptionalConditionsWithPredicatesAnimalDataTest {
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             SelectStatementProvider selectStatement = select(id, animalName, bodyWeight, brainWeight)
                     .from(animalData)
-                    .where(id, isLessThanOrEqualTo(NULL_INTEGER).when(Objects::nonNull))
+                    .where(id, isLessThanOrEqualTo(NULL_INTEGER).filter(Objects::nonNull))
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
@@ -440,7 +440,7 @@ class OptionalConditionsWithPredicatesAnimalDataTest {
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             SelectStatementProvider selectStatement = select(id, animalName, bodyWeight, brainWeight)
                     .from(animalData)
-                    .where(id, isIn(3, NULL_INTEGER, 5).then(s -> s.filter(Objects::nonNull).map(i -> i + 3)))
+                    .where(id, isIn(3, NULL_INTEGER, 5).filter(Objects::nonNull).map(i -> i + 3))
                     .orderBy(id)
                     .build()
                     .render(RenderingStrategies.MYBATIS3);
@@ -480,9 +480,9 @@ class OptionalConditionsWithPredicatesAnimalDataTest {
             SelectStatementProvider selectStatement = select(id, animalName, bodyWeight, brainWeight)
                     .from(animalData)
                     .where(animalName, isIn("  Mouse", "  ", null, "", "Musk shrew  ")
-                            .then(s -> s.filter(Objects::nonNull)
+                            .filter(Objects::nonNull)
                                     .map(String::trim)
-                                    .filter(st -> !st.isEmpty())))
+                                    .filter(st -> !st.isEmpty()))
                     .orderBy(id)
                     .build()
                     .render(RenderingStrategies.MYBATIS3);
@@ -560,7 +560,7 @@ class OptionalConditionsWithPredicatesAnimalDataTest {
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             SelectStatementProvider selectStatement = select(id, animalName, bodyWeight, brainWeight)
                     .from(animalData)
-                    .where(id, isNotIn(3, NULL_INTEGER, 5).then(s -> s.filter(Objects::nonNull)))
+                    .where(id, isNotIn(3, NULL_INTEGER, 5).filter(Objects::nonNull))
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
@@ -620,7 +620,7 @@ class OptionalConditionsWithPredicatesAnimalDataTest {
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             SelectStatementProvider selectStatement = select(id, animalName, bodyWeight, brainWeight)
                     .from(animalData)
-                    .where(id, isBetween(3).and(6).when(Predicates.bothPresent()))
+                    .where(id, isBetween(3).and(6).filter(Predicates.bothPresent()))
                     .orderBy(id)
                     .build()
                     .render(RenderingStrategies.MYBATIS3);
@@ -639,7 +639,7 @@ class OptionalConditionsWithPredicatesAnimalDataTest {
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             SelectStatementProvider selectStatement = select(id, animalName, bodyWeight, brainWeight)
                     .from(animalData)
-                    .where(id, isBetween(NULL_INTEGER).and(6).when(Predicates.bothPresent()))
+                    .where(id, isBetween(NULL_INTEGER).and(6).filter(Predicates.bothPresent()))
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
@@ -659,7 +659,7 @@ class OptionalConditionsWithPredicatesAnimalDataTest {
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             SelectStatementProvider selectStatement = select(id, animalName, bodyWeight, brainWeight)
                     .from(animalData)
-                    .where(id, isBetween(3).and(NULL_INTEGER).when(Predicates.bothPresent()))
+                    .where(id, isBetween(3).and(NULL_INTEGER).filter(Predicates.bothPresent()))
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
@@ -679,7 +679,7 @@ class OptionalConditionsWithPredicatesAnimalDataTest {
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             SelectStatementProvider selectStatement = select(id, animalName, bodyWeight, brainWeight)
                     .from(animalData)
-                    .where(id, isBetween(NULL_INTEGER).and(NULL_INTEGER).when(Predicates.bothPresent()))
+                    .where(id, isBetween(NULL_INTEGER).and(NULL_INTEGER).filter(Predicates.bothPresent()))
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
@@ -699,7 +699,7 @@ class OptionalConditionsWithPredicatesAnimalDataTest {
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             SelectStatementProvider selectStatement = select(id, animalName, bodyWeight, brainWeight)
                     .from(animalData)
-                    .where(id, isNotBetween(3).and(6).when(Predicates.bothPresent()))
+                    .where(id, isNotBetween(3).and(6).filter(Predicates.bothPresent()))
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
@@ -719,7 +719,7 @@ class OptionalConditionsWithPredicatesAnimalDataTest {
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             SelectStatementProvider selectStatement = select(id, animalName, bodyWeight, brainWeight)
                     .from(animalData)
-                    .where(id, isNotBetween(NULL_INTEGER).and(6).when(Predicates.bothPresent()))
+                    .where(id, isNotBetween(NULL_INTEGER).and(6).filter(Predicates.bothPresent()))
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
@@ -739,7 +739,7 @@ class OptionalConditionsWithPredicatesAnimalDataTest {
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             SelectStatementProvider selectStatement = select(id, animalName, bodyWeight, brainWeight)
                     .from(animalData)
-                    .where(id, isNotBetween(3).and(NULL_INTEGER).when(Predicates.bothPresent()))
+                    .where(id, isNotBetween(3).and(NULL_INTEGER).filter(Predicates.bothPresent()))
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
@@ -759,7 +759,7 @@ class OptionalConditionsWithPredicatesAnimalDataTest {
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             SelectStatementProvider selectStatement = select(id, animalName, bodyWeight, brainWeight)
                     .from(animalData)
-                    .where(id, isNotBetween(NULL_INTEGER).and(NULL_INTEGER).when(Predicates.bothPresent()))
+                    .where(id, isNotBetween(NULL_INTEGER).and(NULL_INTEGER).filter(Predicates.bothPresent()))
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
@@ -779,7 +779,7 @@ class OptionalConditionsWithPredicatesAnimalDataTest {
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             SelectStatementProvider selectStatement = select(id, animalName, bodyWeight, brainWeight)
                     .from(animalData)
-                    .where(animalName, isLike("%mole").when(Objects::nonNull))
+                    .where(animalName, isLike("%mole").filter(Objects::nonNull))
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
@@ -799,7 +799,7 @@ class OptionalConditionsWithPredicatesAnimalDataTest {
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             SelectStatementProvider selectStatement = select(id, animalName, bodyWeight, brainWeight)
                     .from(animalData)
-                    .where(animalName, isLike((String) null).when(Objects::nonNull))
+                    .where(animalName, isLike((String) null).filter(Objects::nonNull))
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
@@ -819,7 +819,7 @@ class OptionalConditionsWithPredicatesAnimalDataTest {
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             SelectStatementProvider selectStatement = select(id, animalName, bodyWeight, brainWeight)
                     .from(animalData)
-                    .where(animalName, isLikeCaseInsensitive("%MoLe").when(Objects::nonNull))
+                    .where(animalName, isLikeCaseInsensitive("%MoLe").filter(Objects::nonNull))
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
@@ -839,7 +839,7 @@ class OptionalConditionsWithPredicatesAnimalDataTest {
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             SelectStatementProvider selectStatement = select(id, animalName, bodyWeight, brainWeight)
                     .from(animalData)
-                    .where(animalName, isLikeCaseInsensitive((String) null).when(Objects::nonNull))
+                    .where(animalName, isLikeCaseInsensitive((String) null).filter(Objects::nonNull))
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
@@ -859,7 +859,7 @@ class OptionalConditionsWithPredicatesAnimalDataTest {
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             SelectStatementProvider selectStatement = select(id, animalName, bodyWeight, brainWeight)
                     .from(animalData)
-                    .where(animalName, isNotLike("%mole").when(Objects::nonNull))
+                    .where(animalName, isNotLike("%mole").filter(Objects::nonNull))
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
@@ -879,7 +879,7 @@ class OptionalConditionsWithPredicatesAnimalDataTest {
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             SelectStatementProvider selectStatement = select(id, animalName, bodyWeight, brainWeight)
                     .from(animalData)
-                    .where(animalName, isNotLike((String) null).when(Objects::nonNull))
+                    .where(animalName, isNotLike((String) null).filter(Objects::nonNull))
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
@@ -899,7 +899,7 @@ class OptionalConditionsWithPredicatesAnimalDataTest {
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             SelectStatementProvider selectStatement = select(id, animalName, bodyWeight, brainWeight)
                     .from(animalData)
-                    .where(animalName, isNotLikeCaseInsensitive("%MoLe").when(Objects::nonNull))
+                    .where(animalName, isNotLikeCaseInsensitive("%MoLe").filter(Objects::nonNull))
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()
@@ -919,7 +919,7 @@ class OptionalConditionsWithPredicatesAnimalDataTest {
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
             SelectStatementProvider selectStatement = select(id, animalName, bodyWeight, brainWeight)
                     .from(animalData)
-                    .where(animalName, isNotLikeCaseInsensitive((String) null).when(Objects::nonNull))
+                    .where(animalName, isNotLikeCaseInsensitive((String) null).filter(Objects::nonNull))
                     .and(id, isLessThanOrEqualTo(10))
                     .orderBy(id)
                     .build()

--- a/src/test/java/examples/complexquery/ComplexQueryTest.java
+++ b/src/test/java/examples/complexquery/ComplexQueryTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2020 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -117,8 +117,8 @@ class ComplexQueryTest {
                 .and(id, isEqualTo(targetId));
         } else {
             builder
-                .and(firstName, isLike(fName).when(Objects::nonNull).then(s -> "%" + s + "%"))
-                .and(lastName, isLikeWhenPresent(lName).then(this::addWildcards));
+                .and(firstName, isLike(fName).filter(Objects::nonNull).map(s -> "%" + s + "%"))
+                .and(lastName, isLikeWhenPresent(lName).map(this::addWildcards));
         }
 
         builder

--- a/src/test/java/examples/emptywhere/EmptyWhereTest.java
+++ b/src/test/java/examples/emptywhere/EmptyWhereTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2020 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -98,8 +98,8 @@ class EmptyWhereTest {
         DeleteDSL<DeleteModel>.DeleteWhereBuilder builder = deleteFrom(person)
                 .where(id, isEqualTo(3));
 
-        builder.and(firstName, isEqualTo(fName).when(Objects::nonNull));
-        builder.and(PersonDynamicSqlSupport.lastName, isEqualTo(lName).when(Objects::nonNull));
+        builder.and(firstName, isEqualTo(fName).filter(Objects::nonNull));
+        builder.and(PersonDynamicSqlSupport.lastName, isEqualTo(lName).filter(Objects::nonNull));
 
         DeleteStatementProvider deleteStatement = builder.build().render(RenderingStrategies.MYBATIS3);
 
@@ -117,8 +117,8 @@ class EmptyWhereTest {
         DeleteDSL<DeleteModel>.DeleteWhereBuilder builder = deleteFrom(person)
                 .where();
 
-        builder.and(firstName, isEqualTo(variation.firstName).when(Objects::nonNull));
-        builder.or(PersonDynamicSqlSupport.lastName, isEqualTo(variation.lastName).when(Objects::nonNull));
+        builder.and(firstName, isEqualTo(variation.firstName).filter(Objects::nonNull));
+        builder.or(PersonDynamicSqlSupport.lastName, isEqualTo(variation.lastName).filter(Objects::nonNull));
 
         DeleteStatementProvider deleteStatement = builder.build().render(RenderingStrategies.MYBATIS3);
 
@@ -136,8 +136,8 @@ class EmptyWhereTest {
                 .from(person)
                 .where(id, isEqualTo(3));
 
-        builder.and(firstName, isEqualTo(fName).when(Objects::nonNull));
-        builder.and(PersonDynamicSqlSupport.lastName, isEqualTo(lName).when(Objects::nonNull));
+        builder.and(firstName, isEqualTo(fName).filter(Objects::nonNull));
+        builder.and(PersonDynamicSqlSupport.lastName, isEqualTo(lName).filter(Objects::nonNull));
 
         SelectStatementProvider selectStatement = builder.build().render(RenderingStrategies.MYBATIS3);
 
@@ -157,8 +157,8 @@ class EmptyWhereTest {
                 .from(person)
                 .where();
 
-        builder.and(firstName, isEqualTo(variation.firstName).when(Objects::nonNull));
-        builder.or(PersonDynamicSqlSupport.lastName, isEqualTo(variation.lastName).when(Objects::nonNull));
+        builder.and(firstName, isEqualTo(variation.firstName).filter(Objects::nonNull));
+        builder.or(PersonDynamicSqlSupport.lastName, isEqualTo(variation.lastName).filter(Objects::nonNull));
 
         SelectStatementProvider selectStatement = builder.build().render(RenderingStrategies.MYBATIS3);
 
@@ -176,8 +176,8 @@ class EmptyWhereTest {
                 .from(person).join(order).on(person.id, equalTo(order.personId))
                 .where(id, isEqualTo(3));
 
-        builder.and(firstName, isEqualTo(fName).when(Objects::nonNull));
-        builder.and(PersonDynamicSqlSupport.lastName, isEqualTo(lName).when(Objects::nonNull));
+        builder.and(firstName, isEqualTo(fName).filter(Objects::nonNull));
+        builder.and(PersonDynamicSqlSupport.lastName, isEqualTo(lName).filter(Objects::nonNull));
 
         SelectStatementProvider selectStatement = builder.build().render(RenderingStrategies.MYBATIS3);
 
@@ -198,8 +198,8 @@ class EmptyWhereTest {
                 .from(person).join(order).on(person.id, equalTo(order.personId))
                 .where();
 
-        builder.and(firstName, isEqualTo(variation.firstName).when(Objects::nonNull));
-        builder.or(PersonDynamicSqlSupport.lastName, isEqualTo(variation.lastName).when(Objects::nonNull));
+        builder.and(firstName, isEqualTo(variation.firstName).filter(Objects::nonNull));
+        builder.or(PersonDynamicSqlSupport.lastName, isEqualTo(variation.lastName).filter(Objects::nonNull));
 
         SelectStatementProvider selectStatement = builder.build().render(RenderingStrategies.MYBATIS3);
 
@@ -220,8 +220,8 @@ class EmptyWhereTest {
                 .set(id).equalTo(3)
                 .where(id, isEqualTo(3));
 
-        builder.and(firstName, isEqualTo(fName).when(Objects::nonNull));
-        builder.and(PersonDynamicSqlSupport.lastName, isEqualTo(lName).when(Objects::nonNull));
+        builder.and(firstName, isEqualTo(fName).filter(Objects::nonNull));
+        builder.and(PersonDynamicSqlSupport.lastName, isEqualTo(lName).filter(Objects::nonNull));
 
         UpdateStatementProvider updateStatement = builder.build().render(RenderingStrategies.MYBATIS3);
 
@@ -241,8 +241,8 @@ class EmptyWhereTest {
                 .set(id).equalTo(3)
                 .where();
 
-        builder.and(firstName, isEqualTo(variation.firstName).when(Objects::nonNull));
-        builder.or(PersonDynamicSqlSupport.lastName, isEqualTo(variation.lastName).when(Objects::nonNull));
+        builder.and(firstName, isEqualTo(variation.firstName).filter(Objects::nonNull));
+        builder.or(PersonDynamicSqlSupport.lastName, isEqualTo(variation.lastName).filter(Objects::nonNull));
 
         UpdateStatementProvider updateStatement = builder.build().render(RenderingStrategies.MYBATIS3);
 
@@ -260,8 +260,8 @@ class EmptyWhereTest {
 
         WhereDSL builder = where(id, isEqualTo(3));
 
-        builder.and(firstName, isEqualTo(fName).when(Objects::nonNull));
-        builder.and(PersonDynamicSqlSupport.lastName, isEqualTo(lName).when(Objects::nonNull));
+        builder.and(firstName, isEqualTo(fName).filter(Objects::nonNull));
+        builder.and(PersonDynamicSqlSupport.lastName, isEqualTo(lName).filter(Objects::nonNull));
 
         WhereClauseProvider whereClause = builder.build().render(RenderingStrategies.MYBATIS3);
 
@@ -277,8 +277,8 @@ class EmptyWhereTest {
     void testWhereVariations(Variation variation) {
         WhereDSL builder = where();
 
-        builder.and(firstName, isEqualTo(variation.firstName).when(Objects::nonNull));
-        builder.or(PersonDynamicSqlSupport.lastName, isEqualTo(variation.lastName).when(Objects::nonNull));
+        builder.and(firstName, isEqualTo(variation.firstName).filter(Objects::nonNull));
+        builder.or(PersonDynamicSqlSupport.lastName, isEqualTo(variation.lastName).filter(Objects::nonNull));
 
         WhereClauseProvider whereClause = builder.build().render(RenderingStrategies.MYBATIS3);
 

--- a/src/test/java/examples/generated/always/spring/SpringTest.java
+++ b/src/test/java/examples/generated/always/spring/SpringTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2020 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -142,7 +142,7 @@ class SpringTest {
                 .build()
                 .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
 
-        SqlParameterSource parameterSource = new BeanPropertySqlParameterSource(insertStatement.getRecord());
+        SqlParameterSource parameterSource = new BeanPropertySqlParameterSource(insertStatement.getRow());
         KeyHolder keyHolder = new GeneratedKeyHolder();
 
         int rows = template.update(insertStatement.getInsertStatement(), parameterSource, keyHolder);

--- a/src/test/java/issues/gh105/Issue105Test.java
+++ b/src/test/java/issues/gh105/Issue105Test.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2020 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -35,8 +35,8 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(firstName, isLike(fName).when(Objects::nonNull).then(s -> "%" + s + "%"))
-                .and(lastName, isLike(lName).when(Objects::nonNull).then(s -> "%" + s + "%"))
+                .where(firstName, isLike(fName).filter(Objects::nonNull).map(s -> "%" + s + "%"))
+                .and(lastName, isLike(lName).filter(Objects::nonNull).map(s -> "%" + s + "%"))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -57,8 +57,8 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(firstName, isLike(fName).when(Objects::nonNull).then(SearchUtils::addWildcards))
-                .and(lastName, isLike(lName).when(Objects::nonNull).then(SearchUtils::addWildcards))
+                .where(firstName, isLike(fName).filter(Objects::nonNull).map(SearchUtils::addWildcards))
+                .and(lastName, isLike(lName).filter(Objects::nonNull).map(SearchUtils::addWildcards))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -77,8 +77,8 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(firstName, isLike(fName).when(Objects::nonNull).then(SearchUtils::addWildcards))
-                .and(lastName, isLike(lName).when(Objects::nonNull).then(SearchUtils::addWildcards))
+                .where(firstName, isLike(fName).filter(Objects::nonNull).map(SearchUtils::addWildcards))
+                .and(lastName, isLike(lName).filter(Objects::nonNull).map(SearchUtils::addWildcards))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -97,8 +97,8 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(firstName, isLike(fName).when(Objects::nonNull).then(SearchUtils::addWildcards))
-                .and(lastName, isLike(lName).when(Objects::nonNull).then(SearchUtils::addWildcards))
+                .where(firstName, isLike(fName).filter(Objects::nonNull).map(SearchUtils::addWildcards))
+                .and(lastName, isLike(lName).filter(Objects::nonNull).map(SearchUtils::addWildcards))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -114,7 +114,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(age, isBetween(1).and(10).then(i1 -> i1 + 1,  i2 -> i2 + 2))
+                .where(age, isBetween(1).and(10).map(i1 -> i1 + 1,  i2 -> i2 + 2))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -132,7 +132,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(age, isBetweenWhenPresent(1).and(10).then(i1 -> i1 + 1,  i2 -> i2 + 2))
+                .where(age, isBetweenWhenPresent(1).and(10).map(i1 -> i1 + 1,  i2 -> i2 + 2))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -150,7 +150,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(age, isEqualTo(1).then(i -> i + 1))
+                .where(age, isEqualTo(1).map(i -> i + 1))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -167,7 +167,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(age, isEqualToWhenPresent(1).then(i -> i + 1))
+                .where(age, isEqualToWhenPresent(1).map(i -> i + 1))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -184,7 +184,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(age, isGreaterThan(1).then(i -> i + 1))
+                .where(age, isGreaterThan(1).map(i -> i + 1))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -201,7 +201,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(age, isGreaterThanOrEqualTo(1).then(i -> i + 1))
+                .where(age, isGreaterThanOrEqualTo(1).map(i -> i + 1))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -218,7 +218,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(age, isGreaterThanOrEqualToWhenPresent(1).then(i -> i + 1))
+                .where(age, isGreaterThanOrEqualToWhenPresent(1).map(i -> i + 1))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -235,7 +235,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(age, isGreaterThanWhenPresent(1).then(i -> i + 1))
+                .where(age, isGreaterThanWhenPresent(1).map(i -> i + 1))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -252,7 +252,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(age, isLessThan(1).then(i -> i + 1))
+                .where(age, isLessThan(1).map(i -> i + 1))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -269,7 +269,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(age, isLessThanOrEqualTo(1).then(i -> i + 1))
+                .where(age, isLessThanOrEqualTo(1).map(i -> i + 1))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -286,7 +286,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(age, isLessThanOrEqualToWhenPresent(1).then(i -> i + 1))
+                .where(age, isLessThanOrEqualToWhenPresent(1).map(i -> i + 1))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -303,7 +303,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(age, isLessThanWhenPresent(1).then(i -> i + 1))
+                .where(age, isLessThanWhenPresent(1).map(i -> i + 1))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -320,7 +320,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(firstName, isLike("fred").then(SearchUtils::addWildcards))
+                .where(firstName, isLike("fred").map(SearchUtils::addWildcards))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -337,7 +337,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(firstName, isLikeCaseInsensitive("fred").then(SearchUtils::addWildcards))
+                .where(firstName, isLikeCaseInsensitive("fred").map(SearchUtils::addWildcards))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -354,7 +354,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(firstName, isLikeCaseInsensitiveWhenPresent("fred").then(SearchUtils::addWildcards))
+                .where(firstName, isLikeCaseInsensitiveWhenPresent("fred").map(SearchUtils::addWildcards))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -371,7 +371,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(firstName, isLikeWhenPresent("fred").then(SearchUtils::addWildcards))
+                .where(firstName, isLikeWhenPresent("fred").map(SearchUtils::addWildcards))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -388,7 +388,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(age, isNotBetween(1).and(10).then(i1 -> i1 + 1,  i2 -> i2 + 2))
+                .where(age, isNotBetween(1).and(10).map(i1 -> i1 + 1,  i2 -> i2 + 2))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -406,7 +406,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(age, isNotBetweenWhenPresent(1).and(10).then(i1 -> i1 + 1,  i2 -> i2 + 2))
+                .where(age, isNotBetweenWhenPresent(1).and(10).map(i1 -> i1 + 1,  i2 -> i2 + 2))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -424,7 +424,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(age, isNotEqualTo(1).then(i -> i + 1))
+                .where(age, isNotEqualTo(1).map(i -> i + 1))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -441,7 +441,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(age, isNotEqualToWhenPresent(1).then(i -> i + 1))
+                .where(age, isNotEqualToWhenPresent(1).map(i -> i + 1))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -458,7 +458,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(firstName, isNotLike("fred").then(SearchUtils::addWildcards))
+                .where(firstName, isNotLike("fred").map(SearchUtils::addWildcards))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -475,7 +475,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(firstName, isNotLikeCaseInsensitive("fred").then(SearchUtils::addWildcards))
+                .where(firstName, isNotLikeCaseInsensitive("fred").map(SearchUtils::addWildcards))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -492,7 +492,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(firstName, isNotLikeCaseInsensitiveWhenPresent("fred").then(SearchUtils::addWildcards))
+                .where(firstName, isNotLikeCaseInsensitiveWhenPresent("fred").map(SearchUtils::addWildcards))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -509,7 +509,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(firstName, isNotLikeWhenPresent("fred").then(SearchUtils::addWildcards))
+                .where(firstName, isNotLikeWhenPresent("fred").map(SearchUtils::addWildcards))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -526,7 +526,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(age, isBetween(1).and((Integer) null).when(Predicates.bothPresent()).then(i1 -> i1 + 1,  i2 -> i2 + 2))
+                .where(age, isBetween(1).and((Integer) null).filter(Predicates.bothPresent()).map(i1 -> i1 + 1,  i2 -> i2 + 2))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -541,7 +541,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(age, isBetweenWhenPresent(1).and((Integer) null).then(i1 -> i1 + 1,  i2 -> i2 + 2))
+                .where(age, isBetweenWhenPresent(1).and((Integer) null).map(i1 -> i1 + 1,  i2 -> i2 + 2))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -556,7 +556,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(age, isEqualTo((Integer) null).when(Objects::nonNull).then(i -> i + 1))
+                .where(age, isEqualTo((Integer) null).filter(Objects::nonNull).map(i -> i + 1))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -571,7 +571,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(age, isEqualToWhenPresent((Integer) null).then(i -> i + 1))
+                .where(age, isEqualToWhenPresent((Integer) null).map(i -> i + 1))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -586,7 +586,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(age, isGreaterThan((Integer) null).when(Objects::nonNull).then(i -> i + 1))
+                .where(age, isGreaterThan((Integer) null).filter(Objects::nonNull).map(i -> i + 1))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -601,7 +601,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(age, isGreaterThanOrEqualTo((Integer) null).when(Objects::nonNull).then(i -> i + 1))
+                .where(age, isGreaterThanOrEqualTo((Integer) null).filter(Objects::nonNull).map(i -> i + 1))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -616,7 +616,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(age, isGreaterThanOrEqualToWhenPresent((Integer) null).then(i -> i + 1))
+                .where(age, isGreaterThanOrEqualToWhenPresent((Integer) null).map(i -> i + 1))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -631,7 +631,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(age, isGreaterThanWhenPresent((Integer) null).then(i -> i + 1))
+                .where(age, isGreaterThanWhenPresent((Integer) null).map(i -> i + 1))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -646,7 +646,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(age, isLessThan((Integer) null).when(Objects::nonNull).then(i -> i + 1))
+                .where(age, isLessThan((Integer) null).filter(Objects::nonNull).map(i -> i + 1))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -661,7 +661,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(age, isLessThanOrEqualTo((Integer) null).when(Objects::nonNull).then(i -> i + 1))
+                .where(age, isLessThanOrEqualTo((Integer) null).filter(Objects::nonNull).map(i -> i + 1))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -676,7 +676,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(age, isLessThanOrEqualToWhenPresent((Integer) null).then(i -> i + 1))
+                .where(age, isLessThanOrEqualToWhenPresent((Integer) null).map(i -> i + 1))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -691,7 +691,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(age, isLessThanWhenPresent((Integer) null).then(i -> i + 1))
+                .where(age, isLessThanWhenPresent((Integer) null).map(i -> i + 1))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -706,7 +706,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(firstName, isLike((String) null).when(Objects::nonNull).then(SearchUtils::addWildcards))
+                .where(firstName, isLike((String) null).filter(Objects::nonNull).map(SearchUtils::addWildcards))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -721,7 +721,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(firstName, isLikeCaseInsensitive((String) null).when(Objects::nonNull).then(SearchUtils::addWildcards))
+                .where(firstName, isLikeCaseInsensitive((String) null).filter(Objects::nonNull).map(SearchUtils::addWildcards))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -736,7 +736,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(firstName, isLikeCaseInsensitiveWhenPresent((String) null).then(SearchUtils::addWildcards))
+                .where(firstName, isLikeCaseInsensitiveWhenPresent((String) null).map(SearchUtils::addWildcards))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -751,7 +751,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(firstName, isLikeWhenPresent((String) null).then(SearchUtils::addWildcards))
+                .where(firstName, isLikeWhenPresent((String) null).map(SearchUtils::addWildcards))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -766,7 +766,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(age, isNotBetween((Integer) null).and(10).when(Predicates.bothPresent()).then(i1 -> i1 + 1,  i2 -> i2 + 2))
+                .where(age, isNotBetween((Integer) null).and(10).filter(Predicates.bothPresent()).map(i1 -> i1 + 1,  i2 -> i2 + 2))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -781,7 +781,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(age, isNotBetweenWhenPresent(1).and((Integer) null).then(i1 -> i1 + 1,  i2 -> i2 + 2))
+                .where(age, isNotBetweenWhenPresent(1).and((Integer) null).map(i1 -> i1 + 1,  i2 -> i2 + 2))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -796,7 +796,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(age, isNotEqualTo((Integer) null).when(Objects::nonNull).then(i -> i + 1))
+                .where(age, isNotEqualTo((Integer) null).filter(Objects::nonNull).map(i -> i + 1))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -811,7 +811,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(age, isNotEqualToWhenPresent((Integer) null).then(i -> i + 1))
+                .where(age, isNotEqualToWhenPresent((Integer) null).map(i -> i + 1))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -826,7 +826,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(firstName, isNotLike((String) null).when(Objects::nonNull).then(SearchUtils::addWildcards))
+                .where(firstName, isNotLike((String) null).filter(Objects::nonNull).map(SearchUtils::addWildcards))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -841,7 +841,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(firstName, isNotLikeCaseInsensitive((String) null).when(Objects::nonNull).then(SearchUtils::addWildcards))
+                .where(firstName, isNotLikeCaseInsensitive((String) null).filter(Objects::nonNull).map(SearchUtils::addWildcards))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -856,7 +856,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(firstName, isNotLikeCaseInsensitiveWhenPresent((String) null).then(SearchUtils::addWildcards))
+                .where(firstName, isNotLikeCaseInsensitiveWhenPresent((String) null).map(SearchUtils::addWildcards))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -871,7 +871,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(firstName, isNotLikeWhenPresent((String) null).then(SearchUtils::addWildcards))
+                .where(firstName, isNotLikeWhenPresent((String) null).map(SearchUtils::addWildcards))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 

--- a/src/test/java/org/mybatis/dynamic/sql/where/condition/FilterAndMapTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/where/condition/FilterAndMapTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -429,28 +429,12 @@ class FilterAndMapTest {
     }
 
     @Test
-    void testIsInUnRenderableMapShouldReturnSameObject() {
-        IsIn<String> cond = SqlBuilder.isIn("Fred", "Wilma").filter(v -> false);
-        assertThat(cond.shouldRender()).isFalse();
-        IsIn<String> mapped = cond.map(String::toUpperCase);
-        assertThat(cond).isSameAs(mapped);
-    }
-
-    @Test
     void testIsInRenderableMapShouldReturnMappedObject() {
         IsIn<String> cond = SqlBuilder.isIn("Fred", "Wilma");
         assertThat(cond.shouldRender()).isTrue();
         IsIn<String> mapped = cond.map(String::toUpperCase);
         List<String> mappedValues = mapped.mapValues(Function.identity()).collect(Collectors.toList());
         assertThat(mappedValues).containsExactly("FRED", "WILMA");
-    }
-
-    @Test
-    void testIsNotInUnRenderableMapShouldReturnSameObject() {
-        IsNotIn<String> cond = SqlBuilder.isNotIn("Fred", "Wilma").filter(v -> false);
-        assertThat(cond.shouldRender()).isFalse();
-        IsNotIn<String> mapped = cond.map(String::toUpperCase);
-        assertThat(cond).isSameAs(mapped);
     }
 
     @Test
@@ -463,14 +447,6 @@ class FilterAndMapTest {
     }
 
     @Test
-    void testIsNotInCaseInsensitiveUnRenderableMapShouldReturnSameObject() {
-        IsNotInCaseInsensitive cond = SqlBuilder.isNotInCaseInsensitive("Fred", "Wilma").filter(v -> false);
-        assertThat(cond.shouldRender()).isFalse();
-        IsNotInCaseInsensitive mapped = cond.map(String::toUpperCase);
-        assertThat(cond).isSameAs(mapped);
-    }
-
-    @Test
     void testIsNotInCaseInsensitiveRenderableMapShouldReturnMappedObject() {
         IsNotInCaseInsensitive cond = SqlBuilder.isNotInCaseInsensitive("Fred  ", "Wilma  ");
         List<String> values = cond.mapValues(Function.identity()).collect(Collectors.toList());
@@ -480,14 +456,6 @@ class FilterAndMapTest {
         IsNotInCaseInsensitive mapped = cond.map(String::trim);
         List<String> mappedValues = mapped.mapValues(Function.identity()).collect(Collectors.toList());
         assertThat(mappedValues).containsExactly("FRED", "WILMA");
-    }
-
-    @Test
-    void testIsInCaseInsensitiveUnRenderableMapShouldReturnSameObject() {
-        IsInCaseInsensitive cond = SqlBuilder.isInCaseInsensitive("Fred", "Wilma").filter(v -> false);
-        assertThat(cond.shouldRender()).isFalse();
-        IsInCaseInsensitive mapped = cond.map(String::toUpperCase);
-        assertThat(cond).isSameAs(mapped);
     }
 
     @Test

--- a/src/test/java/org/mybatis/dynamic/sql/where/render/OptionalCriterionRenderTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/where/render/OptionalCriterionRenderTest.java
@@ -28,10 +28,10 @@ import org.mybatis.dynamic.sql.SqlTable;
 import org.mybatis.dynamic.sql.render.RenderingStrategies;
 
 class OptionalCriterionRenderTest {
-    private static SqlTable person = SqlTable.of("person");
-    private static SqlColumn<Integer> id = person.column("id");
-    private static SqlColumn<String> firstName = person.column("first_name");
-    private static SqlColumn<String> lastName = person.column("last_name");
+    private static final SqlTable person = SqlTable.of("person");
+    private static final SqlColumn<Integer> id = person.column("id");
+    private static final SqlColumn<String> firstName = person.column("first_name");
+    private static final SqlColumn<String> lastName = person.column("last_name");
 
     @Test
     void testNoRenderableCriteria() {
@@ -51,7 +51,7 @@ class OptionalCriterionRenderTest {
     void testNoRenderableCriteriaWithIf() {
         Integer nullId = null;
 
-        WhereClauseProvider whereClause = where(id, isEqualTo(nullId).when(Objects::nonNull))
+        WhereClauseProvider whereClause = where(id, isEqualTo(nullId).filter(Objects::nonNull))
                 .build()
                 .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
 
@@ -63,7 +63,7 @@ class OptionalCriterionRenderTest {
 
     @Test
     void testDisabledIsNull() {
-        WhereClauseProvider whereClause = where(id, isNull().when(() -> false))
+        WhereClauseProvider whereClause = where(id, isNull().filter(() -> false))
                 .build()
                 .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
 
@@ -75,7 +75,7 @@ class OptionalCriterionRenderTest {
 
     @Test
     void testEnabledIsNull() {
-        WhereClauseProvider whereClause = where(id, isNull().when(() -> true))
+        WhereClauseProvider whereClause = where(id, isNull().filter(() -> true))
                 .build()
                 .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
 
@@ -87,7 +87,7 @@ class OptionalCriterionRenderTest {
 
     @Test
     void testDisabledIsNotNull() {
-        WhereClauseProvider whereClause = where(id, isNotNull().when(() -> false))
+        WhereClauseProvider whereClause = where(id, isNotNull().filter(() -> false))
                 .build()
                 .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
 
@@ -99,7 +99,7 @@ class OptionalCriterionRenderTest {
 
     @Test
     void testEnabledIsNotNull() {
-        WhereClauseProvider whereClause = where(id, isNotNull().when(() -> true))
+        WhereClauseProvider whereClause = where(id, isNotNull().filter(() -> true))
                 .build()
                 .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
 


### PR DESCRIPTION
The methods have been replaced by more appropriately named "filter" and "map" methods that function as expected for method chaining.
