### PR TITLE
[Kotlin] General DSL Cleanup and Simplification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ GitHub milestone: [https://github.com/mybatis/mybatis-dynamic-sql/issues?q=miles
    but is deprecated. It will be removed in version 1.5.0 of the library. Documentation for the new DSL is here:
    https://github.com/mybatis/mybatis-dynamic-sql/blob/master/src/site/markdown/docs/kotlinWhereClauses.md
    ([#442](https://github.com/mybatis/mybatis-dynamic-sql/pull/442))
+5. General cleanup of the Kotlin DSL. The Kotlin DSL functions are now mostly Unit functions. This should have
+   no impact on most users and is source code compatible with prior versions of the library when the library was used
+   as described in the documentation. This change greatly simplifies the type hierarchy of the Kotlin builders.
+   ([#446](https://github.com/mybatis/mybatis-dynamic-sql/pull/446))
 
 ## Release 1.3.1 - December 18, 2021
 

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/CriteriaCollector.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/CriteriaCollector.kt
@@ -35,20 +35,20 @@ class CriteriaCollector {
         column: BindableColumn<T>,
         condition: VisitableCondition<T>,
         criteriaReceiver: CriteriaReceiver = {}
-    ): CriteriaCollector =
+    ): Unit =
         addCriteriaGroup("and", buildCriterion(column, condition), criteriaReceiver)
 
-    fun and(existsPredicate: ExistsPredicate, criteriaReceiver: CriteriaReceiver = {}): CriteriaCollector =
+    fun and(existsPredicate: ExistsPredicate, criteriaReceiver: CriteriaReceiver = {}): Unit =
         addCriteriaGroup("and", buildCriterion(existsPredicate), criteriaReceiver)
 
     fun <T> or(
         column: BindableColumn<T>,
         condition: VisitableCondition<T>,
         criteriaReceiver: CriteriaReceiver = {}
-    ): CriteriaCollector =
+    ): Unit =
         addCriteriaGroup("or", buildCriterion(column, condition), criteriaReceiver)
 
-    fun or(existsPredicate: ExistsPredicate, criteriaReceiver: CriteriaReceiver = {}): CriteriaCollector =
+    fun or(existsPredicate: ExistsPredicate, criteriaReceiver: CriteriaReceiver = {}): Unit =
         addCriteriaGroup("or", buildCriterion(existsPredicate), criteriaReceiver)
 
     private fun <T> buildCriterion(
@@ -64,14 +64,13 @@ class CriteriaCollector {
         connector: String,
         initialCriterion: SqlCriterion,
         criteriaReceiver: CriteriaReceiver
-    ) =
-        apply {
-            criteria.add(
-                AndOrCriteriaGroup.Builder()
-                    .withInitialCriterion(initialCriterion)
-                    .withSubCriteria(CriteriaCollector().apply(criteriaReceiver).criteria)
-                    .withConnector(connector)
-                    .build()
-            )
-        }
+    ) {
+        criteria.add(
+            AndOrCriteriaGroup.Builder()
+                .withInitialCriterion(initialCriterion)
+                .withSubCriteria(CriteriaCollector().apply(criteriaReceiver).criteria)
+                .withConnector(connector)
+                .build()
+        )
+    }
 }

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/JoinCollector.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/JoinCollector.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -27,23 +27,21 @@ class JoinCollector {
     val andJoinCriteria = mutableListOf<JoinCriterion>()
     private lateinit var internalOnCriterion: JoinCriterion
 
-    fun on(column: BasicColumn, condition: JoinCondition): JoinCollector =
-        apply {
-            internalOnCriterion = JoinCriterion.Builder()
-                .withConnector("on")
+    fun on(column: BasicColumn, condition: JoinCondition) {
+        internalOnCriterion = JoinCriterion.Builder()
+            .withConnector("on")
+            .withJoinColumn(column)
+            .withJoinCondition(condition)
+            .build()
+    }
+
+    fun and(column: BasicColumn, condition: JoinCondition) {
+        andJoinCriteria.add(
+            JoinCriterion.Builder()
+                .withConnector("and")
                 .withJoinColumn(column)
                 .withJoinCondition(condition)
                 .build()
-        }
-
-    fun and(column: BasicColumn, condition: JoinCondition): JoinCollector =
-        apply {
-            andJoinCriteria.add(
-                JoinCriterion.Builder()
-                    .withConnector("and")
-                    .withJoinColumn(column)
-                    .withJoinCondition(condition)
-                    .build()
-            )
-        }
+        )
+    }
 }

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinBaseBuilders.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinBaseBuilders.kt
@@ -28,7 +28,7 @@ import org.mybatis.dynamic.sql.where.AbstractWhereSupport
 @DslMarker
 annotation class MyBatisDslMarker
 
-typealias WhereApplier = KotlinBaseBuilder<*, *>.() -> Unit
+typealias WhereApplier = KotlinBaseBuilder<*>.() -> Unit
 
 fun WhereApplier.andThen(after: WhereApplier): WhereApplier = {
     invoke(this)
@@ -37,7 +37,7 @@ fun WhereApplier.andThen(after: WhereApplier): WhereApplier = {
 
 @MyBatisDslMarker
 @Suppress("TooManyFunctions")
-abstract class KotlinBaseBuilder<D : AbstractWhereSupport<*>, B : KotlinBaseBuilder<D, B>> {
+abstract class KotlinBaseBuilder<D : AbstractWhereSupport<*>> {
     fun where(criteria: GroupingCriteriaReceiver): Unit =
         with(GroupingCriteriaCollector().apply(criteria)) {
             this@KotlinBaseBuilder.getDsl().where(initialCriterion, subCriteria)
@@ -53,21 +53,18 @@ abstract class KotlinBaseBuilder<D : AbstractWhereSupport<*>, B : KotlinBaseBuil
             this@KotlinBaseBuilder.getDsl().where().or(initialCriterion, subCriteria)
         }
 
-    fun applyWhere(whereApplier: WhereApplier): B =
-        self().apply {
-            whereApplier.invoke(this)
-        }
+    fun applyWhere(whereApplier: WhereApplier) = whereApplier.invoke(this)
 
     @Deprecated("Deprecated in favor of the new where clause DSL. Update by moving the column and condition " +
             "into a lambda and rewriting the condition to use an infix function.")
-    fun <T> where(column: BindableColumn<T>, condition: VisitableCondition<T>): B =
+    fun <T> where(column: BindableColumn<T>, condition: VisitableCondition<T>): Unit =
         applyToWhere {
             where(column, condition)
         }
 
     @Deprecated("Deprecated in favor of the new where clause DSL. Update by moving the column and condition " +
             "inside the lambda and rewriting the condition to use an infix function.")
-    fun <T> where(column: BindableColumn<T>, condition: VisitableCondition<T>, subCriteria: CriteriaReceiver): B =
+    fun <T> where(column: BindableColumn<T>, condition: VisitableCondition<T>, subCriteria: CriteriaReceiver): Unit =
         applyToWhere(subCriteria) { sc ->
             where(column, condition, sc)
         }
@@ -76,28 +73,28 @@ abstract class KotlinBaseBuilder<D : AbstractWhereSupport<*>, B : KotlinBaseBuil
         message = "Deprecated in favor of the new where clause DSL.",
         replaceWith = ReplaceWith("where { existsPredicate }")
     )
-    fun where(existsPredicate: ExistsPredicate): B =
+    fun where(existsPredicate: ExistsPredicate): Unit =
         applyToWhere {
             where(existsPredicate)
         }
 
     @Deprecated("Deprecated in favor of the new where clause DSL. Update by moving the exists expression " +
             "into the lambda.")
-    fun where(existsPredicate: ExistsPredicate, subCriteria: CriteriaReceiver): B =
+    fun where(existsPredicate: ExistsPredicate, subCriteria: CriteriaReceiver): Unit =
         applyToWhere(subCriteria) { sc ->
             where(existsPredicate, sc)
         }
 
     @Deprecated("Deprecated in favor of the new where clause DSL. Update by moving the column and condition " +
             "into a lambda and rewriting the condition to use an infix function.")
-    fun <T> and(column: BindableColumn<T>, condition: VisitableCondition<T>): B =
+    fun <T> and(column: BindableColumn<T>, condition: VisitableCondition<T>): Unit =
         applyToWhere {
             and(column, condition)
         }
 
     @Deprecated("Deprecated in favor of the new where clause DSL. Update by moving the column and condition " +
             "inside the lambda and rewriting the condition to use an infix function.")
-    fun <T> and(column: BindableColumn<T>, condition: VisitableCondition<T>, subCriteria: CriteriaReceiver): B =
+    fun <T> and(column: BindableColumn<T>, condition: VisitableCondition<T>, subCriteria: CriteriaReceiver): Unit =
         applyToWhere(subCriteria) { sc ->
             and(column, condition, sc)
         }
@@ -106,28 +103,28 @@ abstract class KotlinBaseBuilder<D : AbstractWhereSupport<*>, B : KotlinBaseBuil
         message = "Deprecated in favor of the new where clause DSL.",
         replaceWith = ReplaceWith("and { existsPredicate }")
     )
-    fun and(existsPredicate: ExistsPredicate): B =
+    fun and(existsPredicate: ExistsPredicate): Unit =
         applyToWhere {
             and(existsPredicate)
         }
 
     @Deprecated("Deprecated in favor of the new where clause DSL. Update by moving the exists expression " +
             "into the lambda.")
-    fun and(existsPredicate: ExistsPredicate, subCriteria: CriteriaReceiver): B =
+    fun and(existsPredicate: ExistsPredicate, subCriteria: CriteriaReceiver): Unit =
         applyToWhere(subCriteria) { sc ->
             and(existsPredicate, sc)
         }
 
     @Deprecated("Deprecated in favor of the new where clause DSL. Update by moving the column and condition " +
             "into a lambda and rewriting the condition to use an infix function.")
-    fun <T> or(column: BindableColumn<T>, condition: VisitableCondition<T>): B =
+    fun <T> or(column: BindableColumn<T>, condition: VisitableCondition<T>): Unit =
         applyToWhere {
             or(column, condition)
         }
 
     @Deprecated("Deprecated in favor of the new where clause DSL. Update by moving the column and condition " +
             "inside the lambda and rewriting the condition to use an infix function.")
-    fun <T> or(column: BindableColumn<T>, condition: VisitableCondition<T>, subCriteria: CriteriaReceiver): B =
+    fun <T> or(column: BindableColumn<T>, condition: VisitableCondition<T>, subCriteria: CriteriaReceiver): Unit =
         applyToWhere(subCriteria) { sc ->
             or(column, condition, sc)
         }
@@ -136,48 +133,43 @@ abstract class KotlinBaseBuilder<D : AbstractWhereSupport<*>, B : KotlinBaseBuil
         message = "Deprecated in favor of the new where clause DSL.",
         replaceWith = ReplaceWith("or { existsPredicate }")
     )
-    fun or(existsPredicate: ExistsPredicate): B =
+    fun or(existsPredicate: ExistsPredicate): Unit =
         applyToWhere {
             or(existsPredicate)
         }
 
     @Deprecated("Deprecated in favor of the new where clause DSL. Update by moving the exists expression " +
             "into the lambda.")
-    fun or(existsPredicate: ExistsPredicate, subCriteria: CriteriaReceiver): B =
+    fun or(existsPredicate: ExistsPredicate, subCriteria: CriteriaReceiver): Unit =
         applyToWhere(subCriteria) { sc ->
             or(existsPredicate, sc)
         }
 
-    fun allRows(): B = self()
+    fun allRows() {}
 
-    private fun applyToWhere(block: AbstractWhereDSL<*>.() -> Unit): B {
+    private fun applyToWhere(block: AbstractWhereDSL<*>.() -> Unit): Unit {
         getDsl().where().apply(block)
-        return self()
     }
 
     private fun applyToWhere(
         subCriteria: CriteriaReceiver,
         block: AbstractWhereDSL<*>.(List<AndOrCriteriaGroup>) -> Unit
-    ): B {
+    ): Unit {
         getDsl().where().block(CriteriaCollector().apply(subCriteria).criteria)
-        return self()
     }
-
-    protected abstract fun self(): B
 
     protected abstract fun getDsl(): D
 }
 
 @Suppress("TooManyFunctions")
-abstract class KotlinBaseJoiningBuilder<D : AbstractQueryExpressionDSL<*, *>, B : KotlinBaseJoiningBuilder<D, B>> :
-    KotlinBaseBuilder<D, B>() {
+abstract class KotlinBaseJoiningBuilder<D : AbstractQueryExpressionDSL<*, *>> : KotlinBaseBuilder<D>() {
 
-    fun join(table: SqlTable, joinCriteria: JoinReceiver): B =
+    fun join(table: SqlTable, joinCriteria: JoinReceiver): Unit =
         applyToDsl(joinCriteria) { jc ->
             join(table, jc.onJoinCriterion, jc.andJoinCriteria)
         }
 
-    fun join(table: SqlTable, alias: String, joinCriteria: JoinReceiver): B =
+    fun join(table: SqlTable, alias: String, joinCriteria: JoinReceiver): Unit =
         applyToDsl(joinCriteria) { jc ->
             join(table, alias, jc.onJoinCriterion, jc.andJoinCriteria)
         }
@@ -185,17 +177,17 @@ abstract class KotlinBaseJoiningBuilder<D : AbstractQueryExpressionDSL<*, *>, B 
     fun join(
         subQuery: KotlinQualifiedSubQueryBuilder.() -> Unit,
         joinCriteria: JoinReceiver
-    ): B =
+    ): Unit =
         applyToDsl(subQuery, joinCriteria) { sq, jc ->
             join(sq, sq.correlationName, jc.onJoinCriterion, jc.andJoinCriteria)
         }
 
-    fun fullJoin(table: SqlTable, joinCriteria: JoinReceiver): B =
+    fun fullJoin(table: SqlTable, joinCriteria: JoinReceiver): Unit =
         applyToDsl(joinCriteria) { jc ->
             fullJoin(table, jc.onJoinCriterion, jc.andJoinCriteria)
         }
 
-    fun fullJoin(table: SqlTable, alias: String, joinCriteria: JoinReceiver): B =
+    fun fullJoin(table: SqlTable, alias: String, joinCriteria: JoinReceiver): Unit =
         applyToDsl(joinCriteria) { jc ->
             fullJoin(table, alias, jc.onJoinCriterion, jc.andJoinCriteria)
         }
@@ -203,17 +195,17 @@ abstract class KotlinBaseJoiningBuilder<D : AbstractQueryExpressionDSL<*, *>, B 
     fun fullJoin(
         subQuery: KotlinQualifiedSubQueryBuilder.() -> Unit,
         joinCriteria: JoinReceiver
-    ): B =
+    ): Unit =
         applyToDsl(subQuery, joinCriteria) { sq, jc ->
             fullJoin(sq, sq.correlationName, jc.onJoinCriterion, jc.andJoinCriteria)
         }
 
-    fun leftJoin(table: SqlTable, joinCriteria: JoinReceiver): B =
+    fun leftJoin(table: SqlTable, joinCriteria: JoinReceiver): Unit =
         applyToDsl(joinCriteria) { jc ->
             leftJoin(table, jc.onJoinCriterion, jc.andJoinCriteria)
         }
 
-    fun leftJoin(table: SqlTable, alias: String, joinCriteria: JoinReceiver): B =
+    fun leftJoin(table: SqlTable, alias: String, joinCriteria: JoinReceiver): Unit =
         applyToDsl(joinCriteria) { jc ->
             leftJoin(table, alias, jc.onJoinCriterion, jc.andJoinCriteria)
         }
@@ -221,17 +213,17 @@ abstract class KotlinBaseJoiningBuilder<D : AbstractQueryExpressionDSL<*, *>, B 
     fun leftJoin(
         subQuery: KotlinQualifiedSubQueryBuilder.() -> Unit,
         joinCriteria: JoinReceiver
-    ): B =
+    ): Unit =
         applyToDsl(subQuery, joinCriteria) { sq, jc ->
             leftJoin(sq, sq.correlationName, jc.onJoinCriterion, jc.andJoinCriteria)
         }
 
-    fun rightJoin(table: SqlTable, joinCriteria: JoinReceiver): B =
+    fun rightJoin(table: SqlTable, joinCriteria: JoinReceiver): Unit =
         applyToDsl(joinCriteria) { jc ->
             rightJoin(table, jc.onJoinCriterion, jc.andJoinCriteria)
         }
 
-    fun rightJoin(table: SqlTable, alias: String, joinCriteria: JoinReceiver): B =
+    fun rightJoin(table: SqlTable, alias: String, joinCriteria: JoinReceiver): Unit =
         applyToDsl(joinCriteria) { jc ->
             rightJoin(table, alias, jc.onJoinCriterion, jc.andJoinCriteria)
         }
@@ -239,22 +231,20 @@ abstract class KotlinBaseJoiningBuilder<D : AbstractQueryExpressionDSL<*, *>, B 
     fun rightJoin(
         subQuery: KotlinQualifiedSubQueryBuilder.() -> Unit,
         joinCriteria: JoinReceiver
-    ): B =
+    ): Unit =
         applyToDsl(subQuery, joinCriteria) { sq, jc ->
             rightJoin(sq, sq.correlationName, jc.onJoinCriterion, jc.andJoinCriteria)
         }
 
-    private fun applyToDsl(joinCriteria: JoinReceiver, applyJoin: D.(JoinCollector) -> Unit): B {
+    private fun applyToDsl(joinCriteria: JoinReceiver, applyJoin: D.(JoinCollector) -> Unit) {
         getDsl().applyJoin(JoinCollector().apply(joinCriteria))
-        return self()
     }
 
     private fun applyToDsl(
         subQuery: KotlinQualifiedSubQueryBuilder.() -> Unit,
         joinCriteria: JoinReceiver,
         applyJoin: D.(KotlinQualifiedSubQueryBuilder, JoinCollector) -> Unit
-    ): B {
+    ) {
         getDsl().applyJoin(KotlinQualifiedSubQueryBuilder().apply(subQuery), JoinCollector().apply(joinCriteria))
-        return self()
     }
 }

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinBaseBuilders.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinBaseBuilders.kt
@@ -147,7 +147,7 @@ abstract class KotlinBaseBuilder<D : AbstractWhereSupport<*>> {
 
     fun allRows() {}
 
-    private fun applyToWhere(block: AbstractWhereDSL<*>.() -> Unit): Unit {
+    private fun applyToWhere(block: AbstractWhereDSL<*>.() -> Unit) {
         getDsl().where().apply(block)
     }
 

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinBaseBuilders.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinBaseBuilders.kt
@@ -154,7 +154,7 @@ abstract class KotlinBaseBuilder<D : AbstractWhereSupport<*>> {
     private fun applyToWhere(
         subCriteria: CriteriaReceiver,
         block: AbstractWhereDSL<*>.(List<AndOrCriteriaGroup>) -> Unit
-    ): Unit {
+    ) {
         getDsl().where().block(CriteriaCollector().apply(subCriteria).criteria)
     }
 

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinCountBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinCountBuilder.kt
@@ -23,7 +23,7 @@ import org.mybatis.dynamic.sql.util.Buildable
 typealias CountCompleter = KotlinCountBuilder.() -> Unit
 
 class KotlinCountBuilder(private val fromGatherer: CountDSL.FromGatherer<SelectModel>) :
-    KotlinBaseJoiningBuilder<CountDSL<SelectModel>, KotlinCountBuilder>(),
+    KotlinBaseJoiningBuilder<CountDSL<SelectModel>>(),
     Buildable<SelectModel> {
 
     private lateinit var dsl: CountDSL<SelectModel>
@@ -34,8 +34,6 @@ class KotlinCountBuilder(private val fromGatherer: CountDSL.FromGatherer<SelectM
         }
 
     override fun build(): SelectModel = getDsl().build()
-
-    override fun self(): KotlinCountBuilder = this
 
     override fun getDsl(): CountDSL<SelectModel> {
         try {

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinCountBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinCountBuilder.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinDeleteBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinDeleteBuilder.kt
@@ -22,11 +22,9 @@ import org.mybatis.dynamic.sql.util.Buildable
 typealias DeleteCompleter = KotlinDeleteBuilder.() -> Unit
 
 class KotlinDeleteBuilder(private val dsl: DeleteDSL<DeleteModel>) :
-    KotlinBaseBuilder<DeleteDSL<DeleteModel>, KotlinDeleteBuilder>(), Buildable<DeleteModel> {
+    KotlinBaseBuilder<DeleteDSL<DeleteModel>>(), Buildable<DeleteModel> {
 
     override fun build(): DeleteModel = dsl.build()
 
     override fun getDsl(): DeleteDSL<DeleteModel> = dsl
-
-    override fun self(): KotlinDeleteBuilder = this
 }

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinDeleteBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinDeleteBuilder.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinSelectBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinSelectBuilder.kt
@@ -30,56 +30,44 @@ class KotlinSelectBuilder(private val fromGatherer: QueryExpressionDSL.FromGathe
 
     private lateinit var dsl: QueryExpressionDSL<SelectModel>
 
-    fun from(table: SqlTable): KotlinSelectBuilder =
-        apply {
-            dsl = fromGatherer.from(table)
-        }
+    fun from(table: SqlTable) {
+        dsl = fromGatherer.from(table)
+    }
 
-    fun from(table: SqlTable, alias: String): KotlinSelectBuilder =
-        apply {
-            dsl = fromGatherer.from(table, alias)
-        }
+    fun from(table: SqlTable, alias: String) {
+        dsl = fromGatherer.from(table, alias)
+    }
 
-    fun from(subQuery: KotlinQualifiedSubQueryBuilder.() -> Unit): KotlinSelectBuilder =
-        apply {
-            val builder = KotlinQualifiedSubQueryBuilder().apply(subQuery)
-            dsl = fromGatherer.from(builder, builder.correlationName)
-        }
+    fun from(subQuery: KotlinQualifiedSubQueryBuilder.() -> Unit) {
+        val builder = KotlinQualifiedSubQueryBuilder().apply(subQuery)
+        dsl = fromGatherer.from(builder, builder.correlationName)
+    }
 
-    fun groupBy(vararg columns: BasicColumn): KotlinSelectBuilder =
-        apply {
-            getDsl().groupBy(columns.toList())
-        }
+    fun groupBy(vararg columns: BasicColumn) {
+        getDsl().groupBy(columns.toList())
+    }
 
-    fun orderBy(vararg columns: SortSpecification): KotlinSelectBuilder =
-        apply {
-            getDsl().orderBy(columns.toList())
-        }
+    fun orderBy(vararg columns: SortSpecification) {
+        getDsl().orderBy(columns.toList())
+    }
 
-    fun limit(limit: Long): KotlinSelectBuilder =
-        apply {
-            getDsl().limit(limit)
-        }
+    fun limit(limit: Long) {
+        getDsl().limit(limit)
+    }
 
-    fun offset(offset: Long): KotlinSelectBuilder =
-        apply {
-            getDsl().offset(offset)
-        }
+    fun offset(offset: Long) {
+        getDsl().offset(offset)
+    }
 
-    fun fetchFirst(fetchFirstRows: Long): KotlinSelectBuilder =
-        apply {
-            getDsl().fetchFirst(fetchFirstRows).rowsOnly()
-        }
+    fun fetchFirst(fetchFirstRows: Long) {
+        getDsl().fetchFirst(fetchFirstRows).rowsOnly()
+    }
 
-    fun union(union: KotlinUnionBuilder.() -> Unit): KotlinSelectBuilder =
-        apply {
-            union(KotlinUnionBuilder(getDsl().union()))
-        }
+    fun union(union: KotlinUnionBuilder.() -> Unit): Unit =
+        union(KotlinUnionBuilder(getDsl().union()))
 
-    fun unionAll(unionAll: KotlinUnionBuilder.() -> Unit): KotlinSelectBuilder =
-        apply {
-            unionAll(KotlinUnionBuilder(getDsl().unionAll()))
-        }
+    fun unionAll(unionAll: KotlinUnionBuilder.() -> Unit): Unit =
+        unionAll(KotlinUnionBuilder(getDsl().unionAll()))
 
     override fun build(): SelectModel = getDsl().build()
 

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinSelectBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinSelectBuilder.kt
@@ -26,7 +26,7 @@ typealias SelectCompleter = KotlinSelectBuilder.() -> Unit
 
 @Suppress("TooManyFunctions")
 class KotlinSelectBuilder(private val fromGatherer: QueryExpressionDSL.FromGatherer<SelectModel>) :
-    KotlinBaseJoiningBuilder<QueryExpressionDSL<SelectModel>, KotlinSelectBuilder>(), Buildable<SelectModel> {
+    KotlinBaseJoiningBuilder<QueryExpressionDSL<SelectModel>>(), Buildable<SelectModel> {
 
     private lateinit var dsl: QueryExpressionDSL<SelectModel>
 
@@ -82,8 +82,6 @@ class KotlinSelectBuilder(private val fromGatherer: QueryExpressionDSL.FromGathe
         }
 
     override fun build(): SelectModel = getDsl().build()
-
-    override fun self(): KotlinSelectBuilder = this
 
     override fun getDsl(): QueryExpressionDSL<SelectModel> {
         try {

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinSelectBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinSelectBuilder.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinSubQueryBuilders.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinSubQueryBuilders.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -22,24 +22,22 @@ import org.mybatis.dynamic.sql.select.SelectModel
 import org.mybatis.dynamic.sql.util.Buildable
 
 @MyBatisDslMarker
-sealed class KotlinBaseSubQueryBuilder<T : KotlinBaseSubQueryBuilder<T>> : Buildable<SelectModel> {
+sealed class KotlinBaseSubQueryBuilder : Buildable<SelectModel> {
     private lateinit var selectBuilder: KotlinSelectBuilder
 
-    fun select(vararg selectList: BasicColumn, completer: SelectCompleter): T =
+    fun select(vararg selectList: BasicColumn, completer: SelectCompleter): Unit =
         select(selectList.toList(), completer)
 
-    fun select(selectList: List<BasicColumn>, completer: SelectCompleter): T =
-        applySelf {
-            selectBuilder = KotlinSelectBuilder(SqlBuilder.select(selectList)).apply(completer)
-        }
+    fun select(selectList: List<BasicColumn>, completer: SelectCompleter) {
+        selectBuilder = KotlinSelectBuilder(SqlBuilder.select(selectList)).apply(completer)
+    }
 
-    fun selectDistinct(vararg selectList: BasicColumn, completer: SelectCompleter): T =
+    fun selectDistinct(vararg selectList: BasicColumn, completer: SelectCompleter): Unit =
         selectDistinct(selectList.toList(), completer)
 
-    fun selectDistinct(selectList: List<BasicColumn>, completer: SelectCompleter): T =
-        applySelf {
-            selectBuilder = KotlinSelectBuilder(SqlBuilder.selectDistinct(selectList)).apply(completer)
-        }
+    fun selectDistinct(selectList: List<BasicColumn>, completer: SelectCompleter) {
+        selectBuilder = KotlinSelectBuilder(SqlBuilder.selectDistinct(selectList)).apply(completer)
+    }
 
     override fun build(): SelectModel =
         try {
@@ -49,29 +47,19 @@ sealed class KotlinBaseSubQueryBuilder<T : KotlinBaseSubQueryBuilder<T>> : Build
                 "You must specify a select statement", e
             )
         }
-
-    private fun applySelf(block: T.() -> Unit): T =
-        self().apply { block() }
-
-    protected abstract fun self(): T
 }
 
-class KotlinSubQueryBuilder : KotlinBaseSubQueryBuilder<KotlinSubQueryBuilder>() {
-    override fun self(): KotlinSubQueryBuilder = this
-}
+class KotlinSubQueryBuilder : KotlinBaseSubQueryBuilder() {}
 
-class KotlinQualifiedSubQueryBuilder : KotlinBaseSubQueryBuilder<KotlinQualifiedSubQueryBuilder>() {
+class KotlinQualifiedSubQueryBuilder : KotlinBaseSubQueryBuilder() {
     var correlationName: String? = null
 
-    operator fun String.unaryPlus(): KotlinQualifiedSubQueryBuilder {
+    operator fun String.unaryPlus() {
         correlationName = this
-        return self()
     }
-
-    override fun self(): KotlinQualifiedSubQueryBuilder = this
 }
 
-class KotlinInsertSelectSubQueryBuilder : KotlinBaseSubQueryBuilder<KotlinInsertSelectSubQueryBuilder>() {
+class KotlinInsertSelectSubQueryBuilder : KotlinBaseSubQueryBuilder() {
     private lateinit var lateColumnList: List<SqlColumn<*>>
 
     val columnList: List<SqlColumn<*>>
@@ -84,13 +72,9 @@ class KotlinInsertSelectSubQueryBuilder : KotlinBaseSubQueryBuilder<KotlinInsert
                 )
             }
 
-    fun columns(vararg columnList: SqlColumn<*>): KotlinInsertSelectSubQueryBuilder =
-        columns(columnList.asList())
+    fun columns(vararg columnList: SqlColumn<*>): Unit = columns(columnList.asList())
 
-    fun columns(columnList: List<SqlColumn<*>>): KotlinInsertSelectSubQueryBuilder =
-        apply {
-            this.lateColumnList = columnList
-        }
-
-    override fun self(): KotlinInsertSelectSubQueryBuilder = this
+    fun columns(columnList: List<SqlColumn<*>>) {
+        this.lateColumnList = columnList
+    }
 }

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinSubQueryBuilders.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinSubQueryBuilders.kt
@@ -49,7 +49,7 @@ sealed class KotlinBaseSubQueryBuilder : Buildable<SelectModel> {
         }
 }
 
-class KotlinSubQueryBuilder : KotlinBaseSubQueryBuilder() {}
+class KotlinSubQueryBuilder : KotlinBaseSubQueryBuilder()
 
 class KotlinQualifiedSubQueryBuilder : KotlinBaseSubQueryBuilder() {
     var correlationName: String? = null

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinUpdateBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinUpdateBuilder.kt
@@ -24,15 +24,13 @@ import org.mybatis.dynamic.sql.util.Buildable
 typealias UpdateCompleter = KotlinUpdateBuilder.() -> Unit
 
 class KotlinUpdateBuilder(private val dsl: UpdateDSL<UpdateModel>) :
-    KotlinBaseBuilder<UpdateDSL<UpdateModel>, KotlinUpdateBuilder>(), Buildable<UpdateModel> {
+    KotlinBaseBuilder<UpdateDSL<UpdateModel>>(), Buildable<UpdateModel> {
 
     fun <T> set(column: SqlColumn<T>): KotlinSetClauseFinisher<T> = KotlinSetClauseFinisher(column)
 
     override fun build(): UpdateModel = dsl.build()
 
     override fun getDsl(): UpdateDSL<UpdateModel> = dsl
-
-    override fun self(): KotlinUpdateBuilder = this
 
     @MyBatisDslMarker
     @Suppress("TooManyFunctions")

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinUpdateBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinUpdateBuilder.kt
@@ -35,55 +35,54 @@ class KotlinUpdateBuilder(private val dsl: UpdateDSL<UpdateModel>) :
     @MyBatisDslMarker
     @Suppress("TooManyFunctions")
     inner class KotlinSetClauseFinisher<T>(private val column: SqlColumn<T>) {
-        fun equalToNull(): KotlinUpdateBuilder =
+        fun equalToNull(): Unit =
             applyToDsl {
                 set(column).equalToNull()
             }
 
-        fun equalToConstant(constant: String): KotlinUpdateBuilder =
+        fun equalToConstant(constant: String): Unit =
             applyToDsl {
                 set(column).equalToConstant(constant)
             }
 
-        fun equalToStringConstant(constant: String): KotlinUpdateBuilder =
+        fun equalToStringConstant(constant: String): Unit =
             applyToDsl {
                 set(column).equalToStringConstant(constant)
             }
 
-        fun equalTo(value: T): KotlinUpdateBuilder = equalTo { value }
+        fun equalTo(value: T): Unit = equalTo { value }
 
-        fun equalTo(value: () -> T): KotlinUpdateBuilder =
+        fun equalTo(value: () -> T): Unit =
             applyToDsl {
                 set(column).equalTo(value)
             }
 
-        fun equalTo(rightColumn: BasicColumn): KotlinUpdateBuilder =
+        fun equalTo(rightColumn: BasicColumn): Unit =
             applyToDsl {
                 set(column).equalTo(rightColumn)
             }
 
-        fun equalToOrNull(value: T?): KotlinUpdateBuilder = equalToOrNull { value }
+        fun equalToOrNull(value: T?): Unit = equalToOrNull { value }
 
-        fun equalToOrNull(value: () -> T?): KotlinUpdateBuilder =
+        fun equalToOrNull(value: () -> T?): Unit =
             applyToDsl {
                 set(column).equalToOrNull(value)
             }
 
-        fun equalToQueryResult(subQuery: KotlinSubQueryBuilder.() -> Unit): KotlinUpdateBuilder =
+        fun equalToQueryResult(subQuery: KotlinSubQueryBuilder.() -> Unit): Unit =
             applyToDsl {
                 set(column).equalTo(KotlinSubQueryBuilder().apply(subQuery))
             }
 
-        fun equalToWhenPresent(value: () -> T?): KotlinUpdateBuilder =
+        fun equalToWhenPresent(value: () -> T?): Unit =
             applyToDsl {
                 set(column).equalToWhenPresent(value)
             }
 
-        fun equalToWhenPresent(value: T?): KotlinUpdateBuilder = equalToWhenPresent { value }
+        fun equalToWhenPresent(value: T?): Unit = equalToWhenPresent { value }
 
-        private fun applyToDsl(block: UpdateDSL<UpdateModel>.() -> Unit): KotlinUpdateBuilder =
-            this@KotlinUpdateBuilder.apply {
-                dsl.apply(block)
-            }
+        private fun applyToDsl(block: UpdateDSL<UpdateModel>.() -> Unit) {
+            this@KotlinUpdateBuilder.dsl.apply(block)
+        }
     }
 }

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinUpdateBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinUpdateBuilder.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2016-2021 the original author or authors.
+       Copyright 2016-2022 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.

--- a/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonMapperExtensions.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonMapperExtensions.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonWithAddressMapperExtensions.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonWithAddressMapperExtensions.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/kotlin/examples/kotlin/mybatis3/column/comparison/ColumnComparisonTest.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/column/comparison/ColumnComparisonTest.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/kotlin/examples/kotlin/mybatis3/custom/render/KCustomRenderingTest.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/custom/render/KCustomRenderingTest.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/kotlin/examples/kotlin/mybatis3/general/GeneralKotlinTest.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/general/GeneralKotlinTest.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/kotlin/examples/kotlin/mybatis3/joins/JoinMapperTest.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/joins/JoinMapperTest.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/kotlin/examples/kotlin/spring/canonical/CanonicalSpringKotlinTemplateDirectTest.kt
+++ b/src/test/kotlin/examples/kotlin/spring/canonical/CanonicalSpringKotlinTemplateDirectTest.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/kotlin/examples/kotlin/spring/canonical/CanonicalSpringKotlinTest.kt
+++ b/src/test/kotlin/examples/kotlin/spring/canonical/CanonicalSpringKotlinTest.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/kotlin/examples/kotlin/spring/canonical/KotlinElementsTest.kt
+++ b/src/test/kotlin/examples/kotlin/spring/canonical/KotlinElementsTest.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/kotlin/examples/kotlin/spring/canonical/SpringKotlinSubQueryTest.kt
+++ b/src/test/kotlin/examples/kotlin/spring/canonical/SpringKotlinSubQueryTest.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/kotlin/org/mybatis/dynamic/sql/util/kotlin/model/ModelBuilderTest.kt
+++ b/src/test/kotlin/org/mybatis/dynamic/sql/util/kotlin/model/ModelBuilderTest.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Most DSL functions are now unit functions. This greatly simplifies the type hierarchy of the builder classes and should be source code compatible with code from prior versions.
