### PR TITLE
[Kotlin] Improve Insert DSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ This log will detail notable changes to MyBatis Dynamic SQL. Full details are av
 
 ## Release 1.4.0 - Unreleased
 
+The release includes new function in the Where Clause DSL to support arbitrary grouping of conditions, and also use
+of a "not" condition. It should now be possible to write any type of where clause.
+
+Additionally, there were significant updates to the Kotlin DSL - both to support the new functionality in the
+where clause, and significant updates to insert statements. There were also many minor updates in Kotlin
+to make more use of Kotlin language features like infix functions and operator overloads.
+
 GitHub milestone: [https://github.com/mybatis/mybatis-dynamic-sql/issues?q=milestone%3A1.4.0+](https://github.com/mybatis/mybatis-dynamic-sql/issues?q=milestone%3A1.4.0+)
 
 1. Added support for arbitrary placement of nested criteria. For example, it is now
@@ -33,6 +40,10 @@ GitHub milestone: [https://github.com/mybatis/mybatis-dynamic-sql/issues?q=miles
    ([#446](https://github.com/mybatis/mybatis-dynamic-sql/pull/446))
 6. Minor update the Kotlin join DSL to make it closer to natural SQL. The existing join methods are deprecated and
    will be removed in version 1.5.0. ([#447](https://github.com/mybatis/mybatis-dynamic-sql/pull/447))
+7. Updated most of the Kotlin insert DSL functions to be more like natural SQL. The main difference is that for insert,
+   insertBatch, and insertMultiple, the "into" function is moved inside the completer lambda. The old methods are now
+   deprecated and will be removed in version 1.5.0 of the library. This also allowed us to make some insert DSL
+   methods into infix functions.
 
 ## Release 1.3.1 - December 18, 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ GitHub milestone: [https://github.com/mybatis/mybatis-dynamic-sql/issues?q=miles
 7. Updated most of the Kotlin insert DSL functions to be more like natural SQL. The main difference is that for insert,
    insertBatch, and insertMultiple, the "into" function is moved inside the completer lambda. The old methods are now
    deprecated and will be removed in version 1.5.0 of the library. This also allowed us to make some insert DSL
-   methods into infix functions.
+   methods into infix functions. ([#452](https://github.com/mybatis/mybatis-dynamic-sql/pull/452))
 
 ## Release 1.3.1 - December 18, 2021
 

--- a/src/main/java/org/mybatis/dynamic/sql/insert/InsertDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/InsertDSL.java
@@ -16,7 +16,9 @@
 package org.mybatis.dynamic.sql.insert;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Supplier;
 
 import org.jetbrains.annotations.NotNull;
@@ -34,11 +36,12 @@ public class InsertDSL<T> implements Buildable<InsertModel<T>> {
 
     private final T row;
     private final SqlTable table;
-    private final List<AbstractColumnMapping> columnMappings = new ArrayList<>();
+    private final List<AbstractColumnMapping> columnMappings;
 
-    private InsertDSL(T row, SqlTable table) {
-        this.row = row;
-        this.table = table;
+    private InsertDSL(Builder<T> builder) {
+        this.row = Objects.requireNonNull(builder.row);
+        this.table = Objects.requireNonNull(builder.table);
+        columnMappings = builder.columnMappings;
     }
 
     public <F> ColumnMappingFinisher<F> map(SqlColumn<F> column) {
@@ -66,7 +69,7 @@ public class InsertDSL<T> implements Buildable<InsertModel<T>> {
         }
 
         public InsertDSL<T> into(SqlTable table) {
-            return new InsertDSL<>(row, table);
+            return new InsertDSL.Builder<T>().withRow(row).withTable(table).build();
         }
     }
 
@@ -100,6 +103,31 @@ public class InsertDSL<T> implements Buildable<InsertModel<T>> {
         public InsertDSL<T> toStringConstant(String constant) {
             columnMappings.add(StringConstantMapping.of(column, constant));
             return InsertDSL.this;
+        }
+    }
+
+    public static class Builder<T> {
+        private T row;
+        private SqlTable table;
+        private final List<AbstractColumnMapping> columnMappings = new ArrayList<>();
+
+        public Builder<T> withRow(T row) {
+            this.row = row;
+            return this;
+        }
+
+        public Builder<T> withTable(SqlTable table) {
+            this.table = table;
+            return this;
+        }
+
+        public Builder<T> withColumnMappings(Collection<AbstractColumnMapping> columnMappings) {
+            this.columnMappings.addAll(columnMappings);
+            return this;
+        }
+
+        public InsertDSL<T> build() {
+            return new InsertDSL<>(this);
         }
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/insert/InsertDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/InsertDSL.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/GroupingCriteriaCollector.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/GroupingCriteriaCollector.kt
@@ -47,7 +47,8 @@ class GroupingCriteriaCollector {
     internal var initialCriterion: SqlCriterion? = null
         private set(value) {
             if (field != null) {
-                throw DuplicateInitialCriterionException()
+                throw KInvalidSQLException("Setting more than one initial criterion is not allowed. " +
+                        "Additional criteria should be added with \"and\" or \"or\" expression")
             }
             field = value
         }

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/JoinCollector.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/JoinCollector.kt
@@ -24,12 +24,14 @@ typealias JoinReceiver = JoinCollector.() -> Unit
 
 @MyBatisDslMarker
 class JoinCollector {
-    val onJoinCriterion: JoinCriterion by lazy { internalOnCriterion }
-    val andJoinCriteria = mutableListOf<JoinCriterion>()
-    private lateinit var internalOnCriterion: JoinCriterion
+    private var onJoinCriterion: JoinCriterion? = null
+    internal val andJoinCriteria = mutableListOf<JoinCriterion>()
+
+    internal fun onJoinCriterion() : JoinCriterion =
+        onJoinCriterion?: throw KInvalidSQLException("You must specify an \"on\" condition in a join")
 
     fun on(leftColumn: BasicColumn): RightColumnCollector = RightColumnCollector {
-        internalOnCriterion = JoinCriterion.Builder()
+        onJoinCriterion = JoinCriterion.Builder()
             .withConnector("on")
             .withJoinColumn(leftColumn)
             .withJoinCondition(it)
@@ -48,7 +50,7 @@ class JoinCollector {
 
     @Deprecated("Please use: on(leftColumn) equalTo rightColumn")
     fun on(column: BasicColumn, condition: JoinCondition) {
-        internalOnCriterion = JoinCriterion.Builder()
+        onJoinCriterion = JoinCriterion.Builder()
             .withConnector("on")
             .withJoinColumn(column)
             .withJoinCondition(condition)

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KInvalidSQLException.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KInvalidSQLException.kt
@@ -16,11 +16,6 @@
 package org.mybatis.dynamic.sql.util.kotlin
 
 /**
- * This exception is thrown when a where clause contains more than one criterion and there
- * is not an "and" or an "or" to connect them.
- *
- * @since 1.4.0
+ * This exception is thrown if the library detects misuse of the Kotlin DSL that would result in invalid SQL
  */
-class DuplicateInitialCriterionException : RuntimeException(
-    "Setting more than one initial criterion is not allowed. " +
-            "Additional criteria should be added with \"and\" or \"or\" expression")
+class KInvalidSQLException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinBaseBuilders.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinBaseBuilders.kt
@@ -180,12 +180,12 @@ abstract class KotlinBaseJoiningBuilder<D : AbstractQueryExpressionDSL<*, *>> : 
 
     fun join(table: SqlTable, joinCriteria: JoinReceiver): Unit =
         applyToDsl(joinCriteria) { jc ->
-            join(table, jc.onJoinCriterion, jc.andJoinCriteria)
+            join(table, jc.onJoinCriterion(), jc.andJoinCriteria)
         }
 
     fun join(table: SqlTable, alias: String, joinCriteria: JoinReceiver): Unit =
         applyToDsl(joinCriteria) { jc ->
-            join(table, alias, jc.onJoinCriterion, jc.andJoinCriteria)
+            join(table, alias, jc.onJoinCriterion(), jc.andJoinCriteria)
         }
 
     fun join(
@@ -193,17 +193,17 @@ abstract class KotlinBaseJoiningBuilder<D : AbstractQueryExpressionDSL<*, *>> : 
         joinCriteria: JoinReceiver
     ): Unit =
         applyToDsl(subQuery, joinCriteria) { sq, jc ->
-            join(sq, sq.correlationName, jc.onJoinCriterion, jc.andJoinCriteria)
+            join(sq, sq.correlationName, jc.onJoinCriterion(), jc.andJoinCriteria)
         }
 
     fun fullJoin(table: SqlTable, joinCriteria: JoinReceiver): Unit =
         applyToDsl(joinCriteria) { jc ->
-            fullJoin(table, jc.onJoinCriterion, jc.andJoinCriteria)
+            fullJoin(table, jc.onJoinCriterion(), jc.andJoinCriteria)
         }
 
     fun fullJoin(table: SqlTable, alias: String, joinCriteria: JoinReceiver): Unit =
         applyToDsl(joinCriteria) { jc ->
-            fullJoin(table, alias, jc.onJoinCriterion, jc.andJoinCriteria)
+            fullJoin(table, alias, jc.onJoinCriterion(), jc.andJoinCriteria)
         }
 
     fun fullJoin(
@@ -211,17 +211,17 @@ abstract class KotlinBaseJoiningBuilder<D : AbstractQueryExpressionDSL<*, *>> : 
         joinCriteria: JoinReceiver
     ): Unit =
         applyToDsl(subQuery, joinCriteria) { sq, jc ->
-            fullJoin(sq, sq.correlationName, jc.onJoinCriterion, jc.andJoinCriteria)
+            fullJoin(sq, sq.correlationName, jc.onJoinCriterion(), jc.andJoinCriteria)
         }
 
     fun leftJoin(table: SqlTable, joinCriteria: JoinReceiver): Unit =
         applyToDsl(joinCriteria) { jc ->
-            leftJoin(table, jc.onJoinCriterion, jc.andJoinCriteria)
+            leftJoin(table, jc.onJoinCriterion(), jc.andJoinCriteria)
         }
 
     fun leftJoin(table: SqlTable, alias: String, joinCriteria: JoinReceiver): Unit =
         applyToDsl(joinCriteria) { jc ->
-            leftJoin(table, alias, jc.onJoinCriterion, jc.andJoinCriteria)
+            leftJoin(table, alias, jc.onJoinCriterion(), jc.andJoinCriteria)
         }
 
     fun leftJoin(
@@ -229,17 +229,17 @@ abstract class KotlinBaseJoiningBuilder<D : AbstractQueryExpressionDSL<*, *>> : 
         joinCriteria: JoinReceiver
     ): Unit =
         applyToDsl(subQuery, joinCriteria) { sq, jc ->
-            leftJoin(sq, sq.correlationName, jc.onJoinCriterion, jc.andJoinCriteria)
+            leftJoin(sq, sq.correlationName, jc.onJoinCriterion(), jc.andJoinCriteria)
         }
 
     fun rightJoin(table: SqlTable, joinCriteria: JoinReceiver): Unit =
         applyToDsl(joinCriteria) { jc ->
-            rightJoin(table, jc.onJoinCriterion, jc.andJoinCriteria)
+            rightJoin(table, jc.onJoinCriterion(), jc.andJoinCriteria)
         }
 
     fun rightJoin(table: SqlTable, alias: String, joinCriteria: JoinReceiver): Unit =
         applyToDsl(joinCriteria) { jc ->
-            rightJoin(table, alias, jc.onJoinCriterion, jc.andJoinCriteria)
+            rightJoin(table, alias, jc.onJoinCriterion(), jc.andJoinCriteria)
         }
 
     fun rightJoin(
@@ -247,7 +247,7 @@ abstract class KotlinBaseJoiningBuilder<D : AbstractQueryExpressionDSL<*, *>> : 
         joinCriteria: JoinReceiver
     ): Unit =
         applyToDsl(subQuery, joinCriteria) { sq, jc ->
-            rightJoin(sq, sq.correlationName, jc.onJoinCriterion, jc.andJoinCriteria)
+            rightJoin(sq, sq.correlationName, jc.onJoinCriterion(), jc.andJoinCriteria)
         }
 
     private fun applyToDsl(joinCriteria: JoinReceiver, applyJoin: D.(JoinCollector) -> Unit) {

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinBatchInsertBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinBatchInsertBuilder.kt
@@ -1,0 +1,78 @@
+/*
+ *    Copyright 2016-2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.dynamic.sql.util.kotlin
+
+import org.mybatis.dynamic.sql.SqlBuilder
+import org.mybatis.dynamic.sql.SqlColumn
+import org.mybatis.dynamic.sql.SqlTable
+import org.mybatis.dynamic.sql.insert.BatchInsertDSL
+import org.mybatis.dynamic.sql.insert.BatchInsertModel
+import org.mybatis.dynamic.sql.util.Buildable
+
+typealias KotlinBatchInsertCompleter<T> = KotlinBatchInsertBuilder<T>.() -> Unit
+
+@MyBatisDslMarker
+class KotlinBatchInsertBuilder<T> (private val rows: Collection<T>): Buildable<BatchInsertModel<T>> {
+
+    private lateinit var dsl: BatchInsertDSL<T>
+
+    fun into(table: SqlTable) {
+        dsl = SqlBuilder.insertBatch(rows).into(table)
+    }
+
+    infix fun <C : Any> map(column: SqlColumn<C>) = MapCompleter(column)
+
+    override fun build(): BatchInsertModel<T> {
+        return getDsl().build()
+    }
+
+    private fun getDsl(): BatchInsertDSL<T> {
+        try {
+            return dsl
+        } catch (e: UninitializedPropertyAccessException) {
+            throw UninitializedPropertyAccessException(
+                "You must specify an \"into\" clause before any other clauses in an insertBatch statement", e
+            )
+        }
+    }
+
+    @MyBatisDslMarker
+    inner class MapCompleter<C : Any> (private val column: SqlColumn<C>) {
+        infix fun toProperty(property: String) =
+            applyToDsl {
+                map(column).toProperty(property)
+            }
+
+        fun toNull() =
+            applyToDsl {
+                map(column).toNull()
+            }
+
+        infix fun toConstant(constant: String) =
+            applyToDsl {
+                map(column).toConstant(constant)
+            }
+
+        infix fun toStringConstant(constant: String) =
+            applyToDsl {
+                map(column).toStringConstant(constant)
+            }
+
+        private fun applyToDsl(block: BatchInsertDSL<T>.() -> Unit) {
+            this@KotlinBatchInsertBuilder.getDsl().apply(block)
+        }
+    }
+}

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinBatchInsertBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinBatchInsertBuilder.kt
@@ -15,64 +15,33 @@
  */
 package org.mybatis.dynamic.sql.util.kotlin
 
-import org.mybatis.dynamic.sql.SqlBuilder
 import org.mybatis.dynamic.sql.SqlColumn
 import org.mybatis.dynamic.sql.SqlTable
 import org.mybatis.dynamic.sql.insert.BatchInsertDSL
 import org.mybatis.dynamic.sql.insert.BatchInsertModel
+import org.mybatis.dynamic.sql.util.AbstractColumnMapping
 import org.mybatis.dynamic.sql.util.Buildable
 
 typealias KotlinBatchInsertCompleter<T> = KotlinBatchInsertBuilder<T>.() -> Unit
 
 @MyBatisDslMarker
 class KotlinBatchInsertBuilder<T> (private val rows: Collection<T>): Buildable<BatchInsertModel<T>> {
-
-    private lateinit var dsl: BatchInsertDSL<T>
+    private var table: SqlTable? = null
+    private val columnMappings = mutableListOf<AbstractColumnMapping>()
 
     fun into(table: SqlTable) {
-        dsl = SqlBuilder.insertBatch(rows).into(table)
+        this.table = table
     }
 
-    infix fun <C : Any> map(column: SqlColumn<C>) = MapCompleter(column)
-
-    override fun build(): BatchInsertModel<T> {
-        return getDsl().build()
+    fun <C : Any> map(column: SqlColumn<C>) = MultiRowInsertColumnMapCompleter(column) {
+        columnMappings.add(it)
     }
 
-    private fun getDsl(): BatchInsertDSL<T> {
-        try {
-            return dsl
-        } catch (e: UninitializedPropertyAccessException) {
-            throw UninitializedPropertyAccessException(
-                "You must specify an \"into\" clause before any other clauses in an insertBatch statement", e
-            )
-        }
-    }
-
-    @MyBatisDslMarker
-    inner class MapCompleter<C : Any> (private val column: SqlColumn<C>) {
-        infix fun toProperty(property: String) =
-            applyToDsl {
-                map(column).toProperty(property)
-            }
-
-        fun toNull() =
-            applyToDsl {
-                map(column).toNull()
-            }
-
-        infix fun toConstant(constant: String) =
-            applyToDsl {
-                map(column).toConstant(constant)
-            }
-
-        infix fun toStringConstant(constant: String) =
-            applyToDsl {
-                map(column).toStringConstant(constant)
-            }
-
-        private fun applyToDsl(block: BatchInsertDSL<T>.() -> Unit) {
-            this@KotlinBatchInsertBuilder.getDsl().apply(block)
-        }
-    }
+    override fun build(): BatchInsertModel<T> =
+        with(BatchInsertDSL.Builder<T>()) {
+            withRecords(rows)
+            withTable(table)
+            withColumnMappings(columnMappings)
+            build()
+        }.build()
 }

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinBatchInsertBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinBatchInsertBuilder.kt
@@ -38,10 +38,14 @@ class KotlinBatchInsertBuilder<T> (private val rows: Collection<T>): Buildable<B
     }
 
     override fun build(): BatchInsertModel<T> =
-        with(BatchInsertDSL.Builder<T>()) {
-            withRecords(rows)
-            withTable(table)
-            withColumnMappings(columnMappings)
-            build()
-        }.build()
+        if (table == null) {
+            throw KInvalidSQLException("Batch Insert Statements Must Contain an \"into\" phrase.")
+        } else {
+            with(BatchInsertDSL.Builder<T>()) {
+                withRecords(rows)
+                withTable(table)
+                withColumnMappings(columnMappings)
+                build()
+            }.build()
+        }
 }

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinCountBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinCountBuilder.kt
@@ -26,7 +26,7 @@ class KotlinCountBuilder(private val fromGatherer: CountDSL.FromGatherer<SelectM
     KotlinBaseJoiningBuilder<CountDSL<SelectModel>>(),
     Buildable<SelectModel> {
 
-    private lateinit var dsl: CountDSL<SelectModel>
+    private var dsl: CountDSL<SelectModel>? = null
 
     fun from(table: SqlTable): KotlinCountBuilder =
         apply {
@@ -35,13 +35,7 @@ class KotlinCountBuilder(private val fromGatherer: CountDSL.FromGatherer<SelectM
 
     override fun build(): SelectModel = getDsl().build()
 
-    override fun getDsl(): CountDSL<SelectModel> {
-        try {
-            return dsl
-        } catch (e: UninitializedPropertyAccessException) {
-            throw UninitializedPropertyAccessException(
-                "You must specify a \"from\" clause before any other clauses in a count statement", e
-            )
-        }
-    }
+    override fun getDsl(): CountDSL<SelectModel> =
+        dsl?: throw KInvalidSQLException(
+            "You must specify a \"from\" clause before any other clauses in a count statement")
 }

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinGeneralInsertBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinGeneralInsertBuilder.kt
@@ -16,22 +16,11 @@
 package org.mybatis.dynamic.sql.util.kotlin
 
 import org.mybatis.dynamic.sql.SqlColumn
-import org.mybatis.dynamic.sql.insert.BatchInsertDSL
 import org.mybatis.dynamic.sql.insert.GeneralInsertDSL
 import org.mybatis.dynamic.sql.insert.GeneralInsertModel
-import org.mybatis.dynamic.sql.insert.InsertDSL
-import org.mybatis.dynamic.sql.insert.MultiRowInsertDSL
 import org.mybatis.dynamic.sql.util.Buildable
 
 typealias GeneralInsertCompleter = @MyBatisDslMarker KotlinGeneralInsertBuilder.() -> Unit
-
-typealias InsertCompleter<T> = @MyBatisDslMarker InsertDSL<T>.() -> Unit
-
-typealias MultiRowInsertCompleter<T> = @MyBatisDslMarker MultiRowInsertDSL<T>.() -> Unit
-
-typealias BatchInsertCompleter<T> = @MyBatisDslMarker BatchInsertDSL<T>.() -> Unit
-
-typealias InsertSelectCompleter = @MyBatisDslMarker KotlinInsertSelectSubQueryBuilder.() -> Unit
 
 @MyBatisDslMarker
 class KotlinGeneralInsertBuilder(private val dsl: GeneralInsertDSL) : Buildable<GeneralInsertModel> {

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinInsertBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinInsertBuilder.kt
@@ -30,7 +30,7 @@ class KotlinInsertBuilder<T> (private val row: T): Buildable<InsertModel<T>> {
     private val columnMappings = mutableListOf<AbstractColumnMapping>()
 
     fun into(table: SqlTable) {
-        this.table = table;
+        this.table = table
     }
 
     fun <C : Any> map(column: SqlColumn<C>) = SingleRowInsertColumnMapCompleter(column) {
@@ -38,10 +38,14 @@ class KotlinInsertBuilder<T> (private val row: T): Buildable<InsertModel<T>> {
     }
 
     override fun build(): InsertModel<T> =
-        with(InsertDSL.Builder<T>()) {
-            withRow(row)
-            withTable(table)
-            withColumnMappings(columnMappings)
-            build()
-        }.build()
+        if (table == null) {
+            throw KInvalidSQLException("Insert Statements Must Contain an \"into\" phrase.")
+        } else {
+            with(InsertDSL.Builder<T>()) {
+                withRow(row)
+                withTable(table)
+                withColumnMappings(columnMappings)
+                build()
+            }.build()
+        }
 }

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinInsertBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinInsertBuilder.kt
@@ -1,0 +1,83 @@
+/*
+ *    Copyright 2016-2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.dynamic.sql.util.kotlin
+
+import org.mybatis.dynamic.sql.SqlBuilder
+import org.mybatis.dynamic.sql.SqlColumn
+import org.mybatis.dynamic.sql.SqlTable
+import org.mybatis.dynamic.sql.insert.InsertDSL
+import org.mybatis.dynamic.sql.insert.InsertModel
+import org.mybatis.dynamic.sql.util.Buildable
+
+typealias KotlinInsertCompleter<T> = KotlinInsertBuilder<T>.() -> Unit
+
+@MyBatisDslMarker
+class KotlinInsertBuilder<T> (private val row: T): Buildable<InsertModel<T>> {
+
+    private lateinit var dsl: InsertDSL<T>
+
+    fun into(table: SqlTable) {
+        dsl = SqlBuilder.insert(row).into(table)
+    }
+
+    fun <C : Any> map(column: SqlColumn<C>) = MapCompleter(column)
+
+    override fun build(): InsertModel<T> {
+        return getDsl().build()
+    }
+
+    private fun getDsl(): InsertDSL<T> {
+        try {
+            return dsl
+        } catch (e: UninitializedPropertyAccessException) {
+            throw UninitializedPropertyAccessException(
+                "You must specify an \"into\" clause before any other clauses in an insert statement", e
+            )
+        }
+    }
+
+    @MyBatisDslMarker
+    inner class MapCompleter<C : Any> (private val column: SqlColumn<C>) {
+        infix fun toProperty(property: String) =
+            applyToDsl {
+                map(column).toProperty(property)
+            }
+
+        fun toNull() =
+            applyToDsl {
+                map(column).toNull()
+            }
+
+        infix fun toConstant(constant: String) =
+            applyToDsl {
+                map(column).toConstant(constant)
+            }
+
+        infix fun toStringConstant(constant: String) =
+            applyToDsl {
+                map(column).toStringConstant(constant)
+            }
+
+        fun toPropertyWhenPresent(property: String, valueSupplier: () -> C?) =
+            applyToDsl {
+                map(column).toPropertyWhenPresent(property, valueSupplier)
+            }
+
+        private fun applyToDsl(block: InsertDSL<T>.() -> Unit) {
+            this@KotlinInsertBuilder.getDsl().apply(block)
+        }
+    }
+}

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinInsertColumnMapCompleters.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinInsertColumnMapCompleters.kt
@@ -1,0 +1,76 @@
+/*
+ *    Copyright 2016-2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.dynamic.sql.util.kotlin
+
+import org.mybatis.dynamic.sql.SqlColumn
+import org.mybatis.dynamic.sql.util.AbstractColumnMapping
+import org.mybatis.dynamic.sql.util.ConstantMapping
+import org.mybatis.dynamic.sql.util.NullMapping
+import org.mybatis.dynamic.sql.util.PropertyMapping
+import org.mybatis.dynamic.sql.util.PropertyWhenPresentMapping
+import org.mybatis.dynamic.sql.util.StringConstantMapping
+import org.mybatis.dynamic.sql.util.ValueMapping
+import org.mybatis.dynamic.sql.util.ValueOrNullMapping
+import org.mybatis.dynamic.sql.util.ValueWhenPresentMapping
+
+@MyBatisDslMarker
+sealed class AbstractInsertColumnMapCompleter<T : Any>(
+    internal val column: SqlColumn<T>,
+    internal val mappingConsumer: (AbstractColumnMapping) -> Unit) {
+
+    fun toNull() = mappingConsumer.invoke(NullMapping.of(column))
+
+    infix fun toConstant(constant: String) = mappingConsumer.invoke(ConstantMapping.of(column, constant))
+
+    infix fun toStringConstant(constant: String) = mappingConsumer.invoke(StringConstantMapping.of(column, constant))
+}
+
+class MultiRowInsertColumnMapCompleter<T : Any>(
+    column: SqlColumn<T>,
+    mappingConsumer: (AbstractColumnMapping) -> Unit)
+    : AbstractInsertColumnMapCompleter<T>(column, mappingConsumer) {
+
+    infix fun toProperty(property: String) = mappingConsumer.invoke(PropertyMapping.of(column, property))
+}
+
+class SingleRowInsertColumnMapCompleter<T : Any>(
+    column: SqlColumn<T>,
+    mappingConsumer: (AbstractColumnMapping) -> Unit)
+    : AbstractInsertColumnMapCompleter<T>(column, mappingConsumer) {
+
+    infix fun toProperty(property: String) = mappingConsumer.invoke(PropertyMapping.of(column, property))
+
+    fun toPropertyWhenPresent(property: String, valueSupplier: () -> T?) =
+        mappingConsumer.invoke(PropertyWhenPresentMapping.of(column, property, valueSupplier))
+}
+
+class GeneralInsertColumnSetCompleter<T : Any>(
+    column: SqlColumn<T>,
+    mappingConsumer: (AbstractColumnMapping) -> Unit)
+    : AbstractInsertColumnMapCompleter<T>(column, mappingConsumer) {
+
+    infix fun toValue(value: T) = toValue { value }
+
+    infix fun toValue(value: () -> T) = mappingConsumer.invoke(ValueMapping.of(column, value))
+
+    infix fun toValueOrNull(value: T?) = toValueOrNull { value }
+
+    infix fun toValueOrNull(value: () -> T?) = mappingConsumer.invoke(ValueOrNullMapping.of(column, value))
+
+    infix fun toValueWhenPresent(value: T?) = toValueWhenPresent { value }
+
+    infix fun toValueWhenPresent(value: () -> T?) = mappingConsumer.invoke(ValueWhenPresentMapping.of(column, value))
+}

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinMultiRowInsertBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinMultiRowInsertBuilder.kt
@@ -1,0 +1,78 @@
+/*
+ *    Copyright 2016-2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.dynamic.sql.util.kotlin
+
+import org.mybatis.dynamic.sql.SqlBuilder
+import org.mybatis.dynamic.sql.SqlColumn
+import org.mybatis.dynamic.sql.SqlTable
+import org.mybatis.dynamic.sql.insert.MultiRowInsertDSL
+import org.mybatis.dynamic.sql.insert.MultiRowInsertModel
+import org.mybatis.dynamic.sql.util.Buildable
+
+typealias KotlinMultiRowInsertCompleter<T> = KotlinMultiRowInsertBuilder<T>.() -> Unit
+
+@MyBatisDslMarker
+class KotlinMultiRowInsertBuilder<T> (private val rows: Collection<T>): Buildable<MultiRowInsertModel<T>> {
+
+    private lateinit var dsl: MultiRowInsertDSL<T>
+
+    fun into(table: SqlTable) {
+        dsl = SqlBuilder.insertMultiple(rows).into(table)
+    }
+
+    infix fun <C : Any> map(column: SqlColumn<C>) = MapCompleter(column)
+
+    override fun build(): MultiRowInsertModel<T> {
+        return getDsl().build()
+    }
+
+    private fun getDsl(): MultiRowInsertDSL<T> {
+        try {
+            return dsl
+        } catch (e: UninitializedPropertyAccessException) {
+            throw UninitializedPropertyAccessException(
+                "You must specify an \"into\" clause before any other clauses in an insertMultiple statement", e
+            )
+        }
+    }
+
+    @MyBatisDslMarker
+    inner class MapCompleter<C : Any> (private val column: SqlColumn<C>) {
+        infix fun toProperty(property: String) =
+            applyToDsl {
+                map(column).toProperty(property)
+            }
+
+        fun toNull() =
+            applyToDsl {
+                map(column).toNull()
+            }
+
+        infix fun toConstant(constant: String) =
+            applyToDsl {
+                map(column).toConstant(constant)
+            }
+
+        infix fun toStringConstant(constant: String) =
+            applyToDsl {
+                map(column).toStringConstant(constant)
+            }
+
+        private fun applyToDsl(block: MultiRowInsertDSL<T>.() -> Unit) {
+            this@KotlinMultiRowInsertBuilder.getDsl().apply(block)
+        }
+    }
+}

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinMultiRowInsertBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinMultiRowInsertBuilder.kt
@@ -38,10 +38,14 @@ class KotlinMultiRowInsertBuilder<T> (private val rows: Collection<T>): Buildabl
     }
 
     override fun build(): MultiRowInsertModel<T> =
-        with(MultiRowInsertDSL.Builder<T>()) {
-            withRecords(rows)
-            withTable(table)
-            withColumnMappings(columnMappings)
-            build()
-        }.build()
+        if (table == null) {
+            throw KInvalidSQLException("Multi Row Insert Statements Must Contain an \"into\" phrase.")
+        } else {
+            with(MultiRowInsertDSL.Builder<T>()) {
+                withRecords(rows)
+                withTable(table)
+                withColumnMappings(columnMappings)
+                build()
+            }.build()
+        }
 }

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinSelectBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinSelectBuilder.kt
@@ -28,7 +28,7 @@ typealias SelectCompleter = KotlinSelectBuilder.() -> Unit
 class KotlinSelectBuilder(private val fromGatherer: QueryExpressionDSL.FromGatherer<SelectModel>) :
     KotlinBaseJoiningBuilder<QueryExpressionDSL<SelectModel>>(), Buildable<SelectModel> {
 
-    private lateinit var dsl: QueryExpressionDSL<SelectModel>
+    private var dsl: QueryExpressionDSL<SelectModel>? = null
 
     fun from(table: SqlTable) {
         dsl = fromGatherer.from(table)
@@ -72,13 +72,7 @@ class KotlinSelectBuilder(private val fromGatherer: QueryExpressionDSL.FromGathe
     override fun build(): SelectModel = getDsl().build()
 
     override fun getDsl(): QueryExpressionDSL<SelectModel> {
-        try {
-            return dsl
-        } catch (e: UninitializedPropertyAccessException) {
-            throw UninitializedPropertyAccessException(
-                "You must specify a \"from\" clause before any other clauses in a select statement",
-                e
-            )
-        }
+        return dsl?: throw KInvalidSQLException(
+            "You must specify a \"from\" clause before any other clauses in a select statement")
     }
 }

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinSubQueryBuilders.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinSubQueryBuilders.kt
@@ -59,6 +59,8 @@ class KotlinQualifiedSubQueryBuilder : KotlinBaseSubQueryBuilder() {
     }
 }
 
+typealias InsertSelectCompleter = KotlinInsertSelectSubQueryBuilder.() -> Unit
+
 class KotlinInsertSelectSubQueryBuilder : KotlinBaseSubQueryBuilder() {
     private lateinit var lateColumnList: List<SqlColumn<*>>
 

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/elements/InsertStatements.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/elements/InsertStatements.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -22,12 +22,17 @@ import org.mybatis.dynamic.sql.insert.MultiRowInsertDSL
 
 // These insert functions help avoid the use of org.mybatis.dynamic.sql.SqlBuilder in Kotlin
 
+@Deprecated("Please see the deprecation message on the following \"into\" function for advice")
 fun <T> insert(row: T): InsertDSL.IntoGatherer<T> = SqlBuilder.insert(row)
 
+@Deprecated("Please see the deprecation message on the following \"into\" function for advice")
 fun <T> insertBatch(vararg records: T): BatchInsertDSL.IntoGatherer<T> = insertBatch(records.asList())
 
+@Deprecated("Please see the deprecation message on the following \"into\" function for advice")
 fun <T> insertBatch(records: Collection<T>): BatchInsertDSL.IntoGatherer<T> = SqlBuilder.insertBatch(records)
 
+@Deprecated("Please see the deprecation message on the following \"into\" function for advice")
 fun <T> insertMultiple(vararg records: T): MultiRowInsertDSL.IntoGatherer<T> = insertMultiple(records.asList())
 
+@Deprecated("Please see the deprecation message on the following \"into\" function for advice")
 fun <T> insertMultiple(records: Collection<T>): MultiRowInsertDSL.IntoGatherer<T> = SqlBuilder.insertMultiple(records)

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/model/ModelBuilderFunctions.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/model/ModelBuilderFunctions.kt
@@ -22,7 +22,6 @@ import org.mybatis.dynamic.sql.SqlTable
 import org.mybatis.dynamic.sql.delete.DeleteModel
 import org.mybatis.dynamic.sql.insert.BatchInsertDSL
 import org.mybatis.dynamic.sql.insert.BatchInsertModel
-import org.mybatis.dynamic.sql.insert.GeneralInsertDSL
 import org.mybatis.dynamic.sql.insert.GeneralInsertModel
 import org.mybatis.dynamic.sql.insert.InsertDSL
 import org.mybatis.dynamic.sql.insert.InsertModel
@@ -70,7 +69,7 @@ fun <T> insertBatch(rows: Collection<T>, completer: KotlinBatchInsertCompleter<T
     KotlinBatchInsertBuilder(rows).apply(completer).build()
 
 fun insertInto(table: SqlTable, completer: GeneralInsertCompleter): GeneralInsertModel =
-    KotlinGeneralInsertBuilder(GeneralInsertDSL.insertInto(table)).apply(completer).build()
+    KotlinGeneralInsertBuilder(table).apply(completer).build()
 
 fun <T> insertMultiple(rows: Collection<T>, completer: KotlinMultiRowInsertCompleter<T>): MultiRowInsertModel<T> =
     KotlinMultiRowInsertBuilder(rows).apply(completer).build()

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/model/ModelBuilderFunctions.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/model/ModelBuilderFunctions.kt
@@ -77,7 +77,7 @@ fun <T> insertMultiple(rows: Collection<T>, completer: KotlinMultiRowInsertCompl
 fun insertSelect(table: SqlTable, completer: InsertSelectCompleter): InsertSelectModel =
     with(KotlinInsertSelectSubQueryBuilder().apply(completer)) {
         SqlBuilder.insertInto(table)
-            .withColumnList(columnList)
+            .withColumnList(columnList())
             .withSelectStatement(this)
             .build()
     }

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/model/ModelBuilderFunctions.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/model/ModelBuilderFunctions.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -31,19 +31,22 @@ import org.mybatis.dynamic.sql.insert.MultiRowInsertDSL
 import org.mybatis.dynamic.sql.insert.MultiRowInsertModel
 import org.mybatis.dynamic.sql.select.SelectModel
 import org.mybatis.dynamic.sql.update.UpdateModel
-import org.mybatis.dynamic.sql.util.kotlin.BatchInsertCompleter
 import org.mybatis.dynamic.sql.util.kotlin.CountCompleter
 import org.mybatis.dynamic.sql.util.kotlin.DeleteCompleter
 import org.mybatis.dynamic.sql.util.kotlin.GeneralInsertCompleter
-import org.mybatis.dynamic.sql.util.kotlin.InsertCompleter
 import org.mybatis.dynamic.sql.util.kotlin.InsertSelectCompleter
+import org.mybatis.dynamic.sql.util.kotlin.KotlinBatchInsertBuilder
+import org.mybatis.dynamic.sql.util.kotlin.KotlinBatchInsertCompleter
 import org.mybatis.dynamic.sql.util.kotlin.KotlinCountBuilder
 import org.mybatis.dynamic.sql.util.kotlin.KotlinDeleteBuilder
 import org.mybatis.dynamic.sql.util.kotlin.KotlinGeneralInsertBuilder
+import org.mybatis.dynamic.sql.util.kotlin.KotlinInsertBuilder
+import org.mybatis.dynamic.sql.util.kotlin.KotlinInsertCompleter
 import org.mybatis.dynamic.sql.util.kotlin.KotlinInsertSelectSubQueryBuilder
+import org.mybatis.dynamic.sql.util.kotlin.KotlinMultiRowInsertBuilder
+import org.mybatis.dynamic.sql.util.kotlin.KotlinMultiRowInsertCompleter
 import org.mybatis.dynamic.sql.util.kotlin.KotlinSelectBuilder
 import org.mybatis.dynamic.sql.util.kotlin.KotlinUpdateBuilder
-import org.mybatis.dynamic.sql.util.kotlin.MultiRowInsertCompleter
 import org.mybatis.dynamic.sql.util.kotlin.SelectCompleter
 import org.mybatis.dynamic.sql.util.kotlin.UpdateCompleter
 
@@ -60,8 +63,17 @@ fun countFrom(table: SqlTable, completer: CountCompleter): SelectModel =
 fun deleteFrom(table: SqlTable, completer: DeleteCompleter): DeleteModel =
     KotlinDeleteBuilder(SqlBuilder.deleteFrom(table)).apply(completer).build()
 
+fun <T> insert(row: T, completer: KotlinInsertCompleter<T>): InsertModel<T> =
+    KotlinInsertBuilder(row).apply(completer).build()
+
+fun <T> insertBatch(rows: Collection<T>, completer: KotlinBatchInsertCompleter<T>): BatchInsertModel<T> =
+    KotlinBatchInsertBuilder(rows).apply(completer).build()
+
 fun insertInto(table: SqlTable, completer: GeneralInsertCompleter): GeneralInsertModel =
     KotlinGeneralInsertBuilder(GeneralInsertDSL.insertInto(table)).apply(completer).build()
+
+fun <T> insertMultiple(rows: Collection<T>, completer: KotlinMultiRowInsertCompleter<T>): MultiRowInsertModel<T> =
+    KotlinMultiRowInsertBuilder(rows).apply(completer).build()
 
 fun insertSelect(table: SqlTable, completer: InsertSelectCompleter): InsertSelectModel =
     with(KotlinInsertSelectSubQueryBuilder().apply(completer)) {
@@ -71,15 +83,21 @@ fun insertSelect(table: SqlTable, completer: InsertSelectCompleter): InsertSelec
             .build()
     }
 
-fun <T> BatchInsertDSL.IntoGatherer<T>.into(table: SqlTable, completer: BatchInsertCompleter<T>): BatchInsertModel<T> =
+@Deprecated("Please switch to the insertBatch statement in the model package")
+fun <T> BatchInsertDSL.IntoGatherer<T>.into(
+    table: SqlTable,
+    completer: BatchInsertDSL<T>.() -> Unit
+): BatchInsertModel<T> =
     into(table).apply(completer).build()
 
-fun <T> InsertDSL.IntoGatherer<T>.into(table: SqlTable, completer: InsertCompleter<T>): InsertModel<T> =
+@Deprecated("Please switch to the insert statement in the model package")
+fun <T> InsertDSL.IntoGatherer<T>.into(table: SqlTable, completer: InsertDSL<T>.() -> Unit): InsertModel<T> =
     into(table).apply(completer).build()
 
+@Deprecated("Please switch to the insertMultiple statement in the model package")
 fun <T> MultiRowInsertDSL.IntoGatherer<T>.into(
     table: SqlTable,
-    completer: MultiRowInsertCompleter<T>
+    completer: MultiRowInsertDSL<T>.() -> Unit
 ): MultiRowInsertModel<T> =
     into(table).apply(completer).build()
 

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/mybatis3/MapperSupportFunctions.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/mybatis3/MapperSupportFunctions.kt
@@ -19,7 +19,6 @@ package org.mybatis.dynamic.sql.util.kotlin.mybatis3
 import org.mybatis.dynamic.sql.BasicColumn
 import org.mybatis.dynamic.sql.SqlTable
 import org.mybatis.dynamic.sql.delete.render.DeleteStatementProvider
-import org.mybatis.dynamic.sql.insert.render.BatchInsert
 import org.mybatis.dynamic.sql.insert.render.GeneralInsertStatementProvider
 import org.mybatis.dynamic.sql.insert.render.InsertSelectStatementProvider
 import org.mybatis.dynamic.sql.insert.render.InsertStatementProvider
@@ -75,9 +74,6 @@ fun <T> insert(
         run(completer)
     }.run(mapper)
 
-fun <T> BatchInsert<T>.execute(mapper: (InsertStatementProvider<T>) -> Int): List<Int> =
-    insertStatements().map(mapper)
-
 /**
  * This function simply inserts all rows using the supplied mapper. It is up
  * to the user to manage MyBatis3 batch processing externally. When executed with a SqlSession
@@ -94,7 +90,7 @@ fun <T> insertBatch(
     insertBatch(records) {
         into(table)
         run(completer)
-    }.execute(mapper)
+    }.insertStatements().map(mapper)
 
 fun insertInto(
     mapper: (GeneralInsertStatementProvider) -> Int,

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/mybatis3/ProviderBuilderFunctions.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/mybatis3/ProviderBuilderFunctions.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -30,20 +30,23 @@ import org.mybatis.dynamic.sql.insert.render.MultiRowInsertStatementProvider
 import org.mybatis.dynamic.sql.render.RenderingStrategies
 import org.mybatis.dynamic.sql.select.render.SelectStatementProvider
 import org.mybatis.dynamic.sql.update.render.UpdateStatementProvider
-import org.mybatis.dynamic.sql.util.kotlin.BatchInsertCompleter
 import org.mybatis.dynamic.sql.util.kotlin.CountCompleter
 import org.mybatis.dynamic.sql.util.kotlin.DeleteCompleter
 import org.mybatis.dynamic.sql.util.kotlin.GeneralInsertCompleter
-import org.mybatis.dynamic.sql.util.kotlin.InsertCompleter
 import org.mybatis.dynamic.sql.util.kotlin.InsertSelectCompleter
-import org.mybatis.dynamic.sql.util.kotlin.MultiRowInsertCompleter
+import org.mybatis.dynamic.sql.util.kotlin.KotlinBatchInsertCompleter
+import org.mybatis.dynamic.sql.util.kotlin.KotlinInsertCompleter
+import org.mybatis.dynamic.sql.util.kotlin.KotlinMultiRowInsertCompleter
 import org.mybatis.dynamic.sql.util.kotlin.SelectCompleter
 import org.mybatis.dynamic.sql.util.kotlin.UpdateCompleter
 import org.mybatis.dynamic.sql.util.kotlin.model.count
 import org.mybatis.dynamic.sql.util.kotlin.model.countDistinct
 import org.mybatis.dynamic.sql.util.kotlin.model.countFrom
 import org.mybatis.dynamic.sql.util.kotlin.model.deleteFrom
+import org.mybatis.dynamic.sql.util.kotlin.model.insert
+import org.mybatis.dynamic.sql.util.kotlin.model.insertBatch
 import org.mybatis.dynamic.sql.util.kotlin.model.insertInto
+import org.mybatis.dynamic.sql.util.kotlin.model.insertMultiple
 import org.mybatis.dynamic.sql.util.kotlin.model.insertSelect
 import org.mybatis.dynamic.sql.util.kotlin.model.into
 import org.mybatis.dynamic.sql.util.kotlin.model.select
@@ -62,21 +65,33 @@ fun countFrom(table: SqlTable, completer: CountCompleter): SelectStatementProvid
 fun deleteFrom(table: SqlTable, completer: DeleteCompleter): DeleteStatementProvider =
     deleteFrom(table, completer).render(RenderingStrategies.MYBATIS3)
 
+fun <T> insert(row: T, completer: KotlinInsertCompleter<T>): InsertStatementProvider<T> =
+    insert(row, completer).render(RenderingStrategies.MYBATIS3)
+
+fun <T> insertBatch(rows: Collection<T>, completer: KotlinBatchInsertCompleter<T>): BatchInsert<T> =
+    insertBatch(rows, completer).render(RenderingStrategies.MYBATIS3)
+
 fun insertInto(table: SqlTable, completer: GeneralInsertCompleter): GeneralInsertStatementProvider =
     insertInto(table, completer).render(RenderingStrategies.MYBATIS3)
+
+fun <T> insertMultiple(rows: Collection<T>, completer: KotlinMultiRowInsertCompleter<T>): MultiRowInsertStatementProvider<T> =
+    insertMultiple(rows, completer).render(RenderingStrategies.MYBATIS3)
 
 fun insertSelect(table: SqlTable, completer: InsertSelectCompleter): InsertSelectStatementProvider =
     insertSelect(table, completer).render(RenderingStrategies.MYBATIS3)
 
-fun <T> BatchInsertDSL.IntoGatherer<T>.into(table: SqlTable, completer: BatchInsertCompleter<T>): BatchInsert<T> =
+@Deprecated("Please switch to the insertBatch statement in the mybatis3 package")
+fun <T> BatchInsertDSL.IntoGatherer<T>.into(table: SqlTable, completer: BatchInsertDSL<T>.() -> Unit): BatchInsert<T> =
     into(table, completer).render(RenderingStrategies.MYBATIS3)
 
-fun <T> InsertDSL.IntoGatherer<T>.into(table: SqlTable, completer: InsertCompleter<T>): InsertStatementProvider<T> =
+@Deprecated("Please switch to the insert statement in the mybatis3 package")
+fun <T> InsertDSL.IntoGatherer<T>.into(table: SqlTable, completer: InsertDSL<T>.() -> Unit): InsertStatementProvider<T> =
     into(table, completer).render(RenderingStrategies.MYBATIS3)
 
+@Deprecated("Please switch to the insertMultiple statement in the mybatis3 package")
 fun <T> MultiRowInsertDSL.IntoGatherer<T>.into(
     table: SqlTable,
-    completer: MultiRowInsertCompleter<T>
+    completer: MultiRowInsertDSL<T>.() -> Unit
 ): MultiRowInsertStatementProvider<T> =
     into(table, completer).render(RenderingStrategies.MYBATIS3)
 

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/mybatis3/ProviderBuilderFunctions.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/mybatis3/ProviderBuilderFunctions.kt
@@ -74,7 +74,10 @@ fun <T> insertBatch(rows: Collection<T>, completer: KotlinBatchInsertCompleter<T
 fun insertInto(table: SqlTable, completer: GeneralInsertCompleter): GeneralInsertStatementProvider =
     insertInto(table, completer).render(RenderingStrategies.MYBATIS3)
 
-fun <T> insertMultiple(rows: Collection<T>, completer: KotlinMultiRowInsertCompleter<T>): MultiRowInsertStatementProvider<T> =
+fun <T> insertMultiple(
+    rows: Collection<T>,
+    completer: KotlinMultiRowInsertCompleter<T>
+): MultiRowInsertStatementProvider<T> =
     insertMultiple(rows, completer).render(RenderingStrategies.MYBATIS3)
 
 fun insertSelect(table: SqlTable, completer: InsertSelectCompleter): InsertSelectStatementProvider =
@@ -85,7 +88,10 @@ fun <T> BatchInsertDSL.IntoGatherer<T>.into(table: SqlTable, completer: BatchIns
     into(table, completer).render(RenderingStrategies.MYBATIS3)
 
 @Deprecated("Please switch to the insert statement in the mybatis3 package")
-fun <T> InsertDSL.IntoGatherer<T>.into(table: SqlTable, completer: InsertDSL<T>.() -> Unit): InsertStatementProvider<T> =
+fun <T> InsertDSL.IntoGatherer<T>.into(
+    table: SqlTable,
+    completer: InsertDSL<T>.() -> Unit
+): InsertStatementProvider<T> =
     into(table, completer).render(RenderingStrategies.MYBATIS3)
 
 @Deprecated("Please switch to the insertMultiple statement in the mybatis3 package")

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/spring/NamedParameterJdbcTemplateExtensions.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/spring/NamedParameterJdbcTemplateExtensions.kt
@@ -67,10 +67,16 @@ fun NamedParameterJdbcTemplate.deleteFrom(table: SqlTable, completer: DeleteComp
 fun <T> NamedParameterJdbcTemplate.insertBatch(insertStatement: BatchInsert<T>): IntArray =
     batchUpdate(insertStatement.insertStatementSQL, SqlParameterSourceUtils.createBatch(insertStatement.records))
 
-fun <T : Any> NamedParameterJdbcTemplate.insertBatch(vararg records: T, completer: KotlinBatchInsertCompleter<T>): IntArray =
+fun <T : Any> NamedParameterJdbcTemplate.insertBatch(
+    vararg records: T,
+    completer: KotlinBatchInsertCompleter<T>
+): IntArray =
     insertBatch(records.asList(), completer)
 
-fun <T : Any> NamedParameterJdbcTemplate.insertBatch(records: List<T>, completer: KotlinBatchInsertCompleter<T>): IntArray =
+fun <T : Any> NamedParameterJdbcTemplate.insertBatch(
+    records: List<T>,
+    completer: KotlinBatchInsertCompleter<T>
+): IntArray =
     insertBatch(org.mybatis.dynamic.sql.util.kotlin.spring.insertBatch(records, completer))
 
 @Deprecated("Please move the into phrase inside the lambda")
@@ -112,10 +118,16 @@ fun NamedParameterJdbcTemplate.insertInto(table: SqlTable, completer: GeneralIns
     generalInsert(org.mybatis.dynamic.sql.util.kotlin.spring.insertInto(table, completer))
 
 // multiple row insert
-fun <T : Any> NamedParameterJdbcTemplate.insertMultiple(vararg records: T, completer: KotlinMultiRowInsertCompleter<T>): Int =
+fun <T : Any> NamedParameterJdbcTemplate.insertMultiple(
+    vararg records: T
+    , completer: KotlinMultiRowInsertCompleter<T>
+): Int =
     insertMultiple(records.asList(), completer)
 
-fun <T : Any> NamedParameterJdbcTemplate.insertMultiple(records: List<T>, completer: KotlinMultiRowInsertCompleter<T>): Int =
+fun <T : Any> NamedParameterJdbcTemplate.insertMultiple(
+    records: List<T>,
+    completer: KotlinMultiRowInsertCompleter<T>
+): Int =
     insertMultiple(org.mybatis.dynamic.sql.util.kotlin.spring.insertMultiple(records, completer))
 
 @Deprecated("Please move the into phrase inside the lambda")

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/spring/NamedParameterJdbcTemplateExtensions.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/spring/NamedParameterJdbcTemplateExtensions.kt
@@ -148,8 +148,8 @@ fun NamedParameterJdbcTemplate.insertSelect(
     update(insertStatement.insertStatement, MapSqlParameterSource(insertStatement.parameters), keyHolder)
 
 // insert with KeyHolder support
-fun NamedParameterJdbcTemplate.withKeyHolder(keyHolder: KeyHolder, build: KeyHolderHelper.() -> Int): Int =
-    build(KeyHolderHelper(keyHolder, this))
+fun NamedParameterJdbcTemplate.withKeyHolder(keyHolder: KeyHolder, block: KeyHolderHelper.() -> Int): Int =
+    KeyHolderHelper(keyHolder, this).run(block)
 
 fun NamedParameterJdbcTemplate.select(
     vararg selectList: BasicColumn,

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/spring/ProviderBuilderFunctions.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/spring/ProviderBuilderFunctions.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -30,20 +30,23 @@ import org.mybatis.dynamic.sql.insert.render.MultiRowInsertStatementProvider
 import org.mybatis.dynamic.sql.render.RenderingStrategies
 import org.mybatis.dynamic.sql.select.render.SelectStatementProvider
 import org.mybatis.dynamic.sql.update.render.UpdateStatementProvider
-import org.mybatis.dynamic.sql.util.kotlin.BatchInsertCompleter
 import org.mybatis.dynamic.sql.util.kotlin.CountCompleter
 import org.mybatis.dynamic.sql.util.kotlin.DeleteCompleter
 import org.mybatis.dynamic.sql.util.kotlin.GeneralInsertCompleter
-import org.mybatis.dynamic.sql.util.kotlin.InsertCompleter
 import org.mybatis.dynamic.sql.util.kotlin.InsertSelectCompleter
-import org.mybatis.dynamic.sql.util.kotlin.MultiRowInsertCompleter
+import org.mybatis.dynamic.sql.util.kotlin.KotlinBatchInsertCompleter
+import org.mybatis.dynamic.sql.util.kotlin.KotlinInsertCompleter
+import org.mybatis.dynamic.sql.util.kotlin.KotlinMultiRowInsertCompleter
 import org.mybatis.dynamic.sql.util.kotlin.SelectCompleter
 import org.mybatis.dynamic.sql.util.kotlin.UpdateCompleter
 import org.mybatis.dynamic.sql.util.kotlin.model.count
 import org.mybatis.dynamic.sql.util.kotlin.model.countDistinct
 import org.mybatis.dynamic.sql.util.kotlin.model.countFrom
 import org.mybatis.dynamic.sql.util.kotlin.model.deleteFrom
+import org.mybatis.dynamic.sql.util.kotlin.model.insert
+import org.mybatis.dynamic.sql.util.kotlin.model.insertBatch
 import org.mybatis.dynamic.sql.util.kotlin.model.insertInto
+import org.mybatis.dynamic.sql.util.kotlin.model.insertMultiple
 import org.mybatis.dynamic.sql.util.kotlin.model.insertSelect
 import org.mybatis.dynamic.sql.util.kotlin.model.into
 import org.mybatis.dynamic.sql.util.kotlin.model.select
@@ -62,21 +65,39 @@ fun countFrom(table: SqlTable, completer: CountCompleter): SelectStatementProvid
 fun deleteFrom(table: SqlTable, completer: DeleteCompleter): DeleteStatementProvider =
     deleteFrom(table, completer).render(RenderingStrategies.SPRING_NAMED_PARAMETER)
 
+fun <T> insert(row: T, completer: KotlinInsertCompleter<T>): InsertStatementProvider<T> =
+    insert(row, completer).render(RenderingStrategies.SPRING_NAMED_PARAMETER)
+
+fun <T> insertBatch(rows: Collection<T>, completer: KotlinBatchInsertCompleter<T>): BatchInsert<T> =
+    insertBatch(rows, completer).render(RenderingStrategies.SPRING_NAMED_PARAMETER)
+
 fun insertInto(table: SqlTable, completer: GeneralInsertCompleter): GeneralInsertStatementProvider =
     insertInto(table, completer).render(RenderingStrategies.SPRING_NAMED_PARAMETER)
+
+fun <T> insertMultiple(
+    rows: Collection<T>,
+    completer: KotlinMultiRowInsertCompleter<T>
+): MultiRowInsertStatementProvider<T> =
+    insertMultiple(rows, completer).render(RenderingStrategies.SPRING_NAMED_PARAMETER)
 
 fun insertSelect(table: SqlTable, completer: InsertSelectCompleter): InsertSelectStatementProvider =
     insertSelect(table, completer).render(RenderingStrategies.SPRING_NAMED_PARAMETER)
 
-fun <T> BatchInsertDSL.IntoGatherer<T>.into(table: SqlTable, completer: BatchInsertCompleter<T>): BatchInsert<T> =
+@Deprecated("Please switch to the insertBatch statement in the spring package")
+fun <T> BatchInsertDSL.IntoGatherer<T>.into(table: SqlTable, completer: BatchInsertDSL<T>.() -> Unit): BatchInsert<T> =
     into(table, completer).render(RenderingStrategies.SPRING_NAMED_PARAMETER)
 
-fun <T> InsertDSL.IntoGatherer<T>.into(table: SqlTable, completer: InsertCompleter<T>): InsertStatementProvider<T> =
+@Deprecated("Please switch to the insert statement in the spring package")
+fun <T> InsertDSL.IntoGatherer<T>.into(
+    table: SqlTable,
+    completer: InsertDSL<T>.() -> Unit
+): InsertStatementProvider<T> =
     into(table, completer).render(RenderingStrategies.SPRING_NAMED_PARAMETER)
 
+@Deprecated("Please switch to the insertMultiple statement in the spring package")
 fun <T> MultiRowInsertDSL.IntoGatherer<T>.into(
     table: SqlTable,
-    completer: MultiRowInsertCompleter<T>
+    completer: MultiRowInsertDSL<T>.() -> Unit
 ): MultiRowInsertStatementProvider<T> =
     into(table, completer).render(RenderingStrategies.SPRING_NAMED_PARAMETER)
 

--- a/src/site/markdown/docs/kotlinMyBatis3.md
+++ b/src/site/markdown/docs/kotlinMyBatis3.md
@@ -349,13 +349,13 @@ import org.mybatis.dynamic.sql.util.kotlin.mybatis3.insert
 
 fun PersonMapper.insert(row: PersonRecord) =
     insert(this::insert, row, Person) {
-        map(id).toProperty("id")
-        map(firstName).toProperty("firstName")
-        map(lastName).toProperty("lastName")
-        map(birthDate).toProperty("birthDate")
-        map(employed).toProperty("employed")
-        map(occupation).toProperty("occupation")
-        map(addressId).toProperty("addressId")
+        map(id) toProperty "id"
+        map(firstName) toProperty "firstName"
+        map(lastName) toProperty "lastName"
+        map(birthDate) toProperty "birthDate"
+        map(employed) toProperty "employed"
+        map(occupation) toProperty "occupation"
+        map(addressId) toProperty "addressId"
     }
 ```
 
@@ -440,13 +440,13 @@ method as follows:
 
 ```kotlin
 val rows = mapper.generalInsert {
-    set(id).toValue(100)
-    set(firstName).toValue("Joe")
-    set(lastName).toValue(LastName("Jones"))
-    set(employed).toValue(true)
-    set(occupation).toValue("Developer")
-    set(addressId).toValue(1)
-    set(birthDate).toValue(Date())
+    set(id) toValue 100
+    set(firstName) toValue "Joe"
+    set(lastName) toValue LastName("Jones")
+    set(employed) toValue true
+    set(occupation) toValue "Developer"
+    set(addressId) toValue 1
+    set(birthDate) toValue Date()
 }
 ```
 
@@ -532,13 +532,13 @@ fun PersonMapper.insertMultiple(vararg records: PersonRecord) =
 
 fun PersonMapper.insertMultiple(records: Collection<PersonRecord>) =
     insertMultiple(this::insertMultiple, records, person) {
-        map(id).toProperty("id")
-        map(firstName).toProperty("firstName")
-        map(lastName).toProperty("lastName")
-        map(birthDate).toProperty("birthDate")
-        map(employed).toProperty("employed")
-        map(occupation).toProperty("occupation")
-        map(addressId).toProperty("addressId")
+        map(id) toProperty "id"
+        map(firstName) toProperty "firstName"
+        map(lastName) toProperty "lastName"
+        map(birthDate) toProperty "birthDate"
+        map(employed) toProperty "employed"
+        map(occupation) toProperty "occupation"
+        map(addressId) toProperty "addressId"
     }
 ```
 
@@ -677,13 +677,13 @@ fun PersonMapper.insertBatch(vararg records: PersonRecord): List<Int> =
 
 fun PersonMapper.insertBatch(records: Collection<PersonRecord>): List<Int> =
     insertBatch(this::insert, records, person) {
-        map(id).toProperty("id")
-        map(firstName).toProperty("firstName")
-        map(lastName).toProperty("lastName")
-        map(birthDate).toProperty("birthDate")
-        map(employed).toProperty("employed")
-        map(occupation).toProperty("occupation")
-        map(addressId).toProperty("addressId")
+        map(id) toProperty "id"
+        map(firstName) toProperty "firstName"
+        map(lastName) toProperty "lastName"
+        map(birthDate) toProperty "birthDate"
+        map(employed) toProperty "employed"
+        map(occupation) toProperty "occupation"
+        map(addressId) toProperty "addressId"
     }
 ```
 

--- a/src/site/markdown/docs/kotlinOverview.md
+++ b/src/site/markdown/docs/kotlinOverview.md
@@ -228,20 +228,22 @@ data class PersonRecord(
 
 val row = PersonRecord(100, "Joe", "Jones", Date(), true, "Developer", 1)
 
-val insertRecordStatement = insert(row).into(person) {
-   map(id).toProperty("id")
-   map(firstName).toProperty("firstName")
-   map(lastName).toProperty("lastName")
-   map(birthDate).toProperty("birthDate")
-   map(employed).toProperty("employedAsString")
+val insertRecordStatement = insert(row) {
+   into(person)
+   map(id) toProperty "id" 
+   map(firstName) toProperty "firstName"
+   map(lastName) toProperty "lastName"
+   map(birthDate) toProperty "birthDate"
+   map(employed) toProperty "employedAsString"
    map(occupation).toPropertyWhenPresent("occupation", row::occupation)
-   map(addressId).toProperty("addressId")
+   map(addressId) toProperty "addressId"
 }
 ```
 
 This statement maps insert columns to properties in a class. Note the use of the `toPropertyWhenPresent` mapping - this
 will only set the insert value if the value of the property is non-null. Also note that you can use other mapping
-methods to map insert fields to nulls and constants if desired.
+methods to map insert fields to nulls and constants if desired. Many of the mappings can be called via infix
+as shown above.
 
 This method creates models or providers depending on which package is used:
 
@@ -260,13 +262,13 @@ The DSL for general insert statements looks like this:
 
 ```kotlin
 val generalInsertStatement = insertInto(person) {
-    set(id).toValue(100)
-    set(firstName).toValue("Joe")
-    set(lastName).toValue("Jones")
-    set(birthDate).toValue(Date())
-    set(employed).toValue(true)
-    set(occupation).toValue("Developer")
-    set(addressId).toValue(1)
+    set(id) toValue 100
+    set(firstName) toValue "Joe"
+    set(lastName) toValue "Jones"
+    set(birthDate) toValue Date()
+    set(employed) toValue true
+    set(occupation) toValue "Developer"
+    set(addressId) toValue 1
 }
 ```
 
@@ -302,18 +304,23 @@ The DSL for multi-row insert statements looks like this:
 val record1 = PersonRecord(100, "Joe", "Jones", Date(), true, "Developer", 1)
 val record2 = PersonRecord(101, "Sarah", "Smith", Date(), true, "Architect", 2)
 
-val multiRowInsertStatement = insertMultiple(record1, record2).into(person) {
-   map(id).toProperty("id")
-   map(firstName).toProperty("firstName")
-   map(lastName).toProperty("lastNameAsString")
-   map(birthDate).toProperty("birthDate")
-   map(employed).toProperty("employedAsString")
-   map(occupation).toProperty("occupation")
-   map(addressId).toProperty("addressId")
+val multiRowInsertStatement = insertMultiple(listOf(record1, record2)) {
+   into(person)
+   map(id) toProperty "id"
+   map(firstName) toProperty "firstName"
+   map(lastName) toProperty "lastNameAsString"
+   map(birthDate) toProperty "birthDate"
+   map(employed) toProperty "employedAsString"
+   map(occupation) toProperty "occupation"
+   map(addressId) toProperty "addressId"
 }
 ```
 
 Note there is no `toPropertyWhenPresent` mapping available on a multi-row insert.
+
+Also note that there is no overload of this function that accepts a vararg of rows because it would cause an overload
+resolution ambiguity error. This limitation is overcome in the utility functions for MyBatis and Spring as shown on
+the documentation pages for those utilities.
 
 This method creates models or providers depending on which package is used:
 
@@ -340,18 +347,23 @@ The DSL for batch insert statements looks like this:
 val record1 = PersonRecord(100, "Joe", "Jones", Date(), true, "Developer", 1)
 val record2 = PersonRecord(101, "Sarah", "Smith", Date(), true, "Architect", 2)
 
-val batchInsertStatement = insertBatch(record1, record2).into(person) {
-   map(id).toProperty("id")
-   map(firstName).toProperty("firstName")
-   map(lastName).toProperty("lastNameAsString")
-   map(birthDate).toProperty("birthDate")
-   map(employed).toProperty("employedAsString")
-   map(occupation).toProperty("occupation")
-   map(addressId).toProperty("addressId")
+val batchInsertStatement = insertBatch(listOf(record1, record2)) {
+   into(person)
+   map(id) toProperty "id"
+   map(firstName) toProperty "firstName"
+   map(lastName) toProperty "lastNameAsString"
+   map(birthDate) toProperty "birthDate"
+   map(employed) toProperty "employedAsString"
+   map(occupation) toProperty "occupation"
+   map(addressId) toProperty "addressId"
 }
 ```
 
 Note there is no `toPropertyWhenPresent` mapping available on a batch insert.
+
+Also note that there is no overload of this function that accepts a vararg of rows because it would cause an overload
+resolution ambiguity error. This limitation is overcome in the utility functions for MyBatis and Spring as shown on
+the documentation pages for those utilities.
 
 This method creates models or providers depending on which package is used:
 

--- a/src/site/markdown/docs/kotlinSpring.md
+++ b/src/site/markdown/docs/kotlinSpring.md
@@ -196,14 +196,15 @@ Single record insert statements can be constructed and executed in a single step
 ```kotlin
 val row = PersonRecord(100, "Joe", "Jones", Date(), true, "Developer", 1)
 
-val rows = template.insert(row).into(Person) {
-    map(id).toProperty("id")
-    map(firstName).toProperty("firstName")
-    map(lastName).toProperty("lastName")
-    map(birthDate).toProperty("birthDate")
-    map(employed).toProperty("employedAsString")
+val rows = template.insert(row) {
+    into(Person)
+    map(id) toProperty "id"
+    map(firstName) toProperty "firstName"
+    map(lastName) toProperty "lastName"
+    map(birthDate) toProperty "birthDate"
+    map(employed) toProperty "employedAsString"
     map(occupation).toPropertyWhenPresent("occupation", row::occupation)
-    map(addressId).toProperty("addressId")
+    map(addressId) toProperty "addressId"
 }
 ```
 
@@ -217,14 +218,15 @@ val keyHolder = GeneratedKeyHolder()
 val row = PersonRecord(100, "Joe", "Jones", Date(), true, "Developer", 1)
 
 val rows = template.withKeyHolder(keyHolder) {
-    insert(row).into(Person) {
-        map(id).toProperty("id")
-        map(firstName).toProperty("firstName")
-        map(lastName).toProperty("lastName")
-        map(birthDate).toProperty("birthDate")
-        map(employed).toProperty("employedAsString")
+    insert(row) {
+        into(Person)
+        map(id) toProperty"id"
+        map(firstName) toProperty "firstName"
+        map(lastName) toProperty "lastName"
+        map(birthDate) toProperty "birthDate"
+        map(employed) toProperty "employedAsString"
         map(occupation).toPropertyWhenPresent("occupation", row::occupation)
-        map(addressId).toProperty("addressId")
+        map(addressId) toProperty "addressId"
     }
 }
 ```
@@ -255,13 +257,13 @@ General insert statements can be constructed and executed in a single step with 
 val myOccupation = "Developer"
 
 val rows = template.insertInto(Person) {
-    set(id).toValue(100)
-    set(firstName).toValue("Joe")
-    set(lastName).toValue("Jones")
-    set(birthDate).toValue(Date())
-    set(employed).toValue(true)
-    set(occupation).toValueWhenPresent(myOccupation)
-    set(addressId).toValue(1)
+    set(id) toValue 100
+    set(firstName) toValue "Joe"
+    set(lastName) toValue "Jones"
+    set(birthDate) toValue Date()
+    set(employed) toValue true
+    set(occupation) toValueWhenPresent myOccupation
+    set(addressId) toValue 1
 }
 ```
 
@@ -276,13 +278,13 @@ val myOccupation = "Developer"
 
 val rows = template.withKeyHolder(keyHolder) {
     insertInto(Person) {
-        set(id).toValue(100)
-        set(firstName).toValue("Joe")
-        set(lastName).toValue("Jones")
-        set(birthDate).toValue(Date())
-        set(employed).toValue(true)
-        set(occupation).toValueWhenPresent(myOccupation)
-        set(addressId).toValue(1)
+        set(id) toValue 100
+        set(firstName) toValue "Joe"
+        set(lastName) toValue "Jones"
+        set(birthDate) toValue Date()
+        set(employed) toValue true
+        set(occupation) toValueWhenPresent myOccupation
+        set(addressId) toValue 1
     }
 }
 ```
@@ -313,14 +315,15 @@ Multi-Row insert statements can be constructed and executed in a single step wit
 val record1 = PersonRecord(100, "Joe", LastName("Jones"), Date(), true, "Developer", 1)
 val record2 = PersonRecord(101, "Sarah", LastName("Smith"), Date(), true, "Architect", 2)
 
-val rows = template.insertMultiple(record1, record2).into(Person) {
-    map(id).toProperty("id")
-    map(firstName).toProperty("firstName")
-    map(lastName).toProperty("lastNameAsString")
-    map(birthDate).toProperty("birthDate")
-    map(employed).toProperty("employedAsString")
-    map(occupation).toProperty("occupation")
-    map(addressId).toProperty("addressId")
+val rows = template.insertMultiple(record1, record2) {
+    into(Person)
+    map(id) toProperty "id"
+    map(firstName) toProperty "firstName"
+    map(lastName) toProperty "lastNameAsString"
+    map(birthDate) toProperty "birthDate"
+    map(employed) toProperty "employedAsString"
+    map(occupation) toProperty "occupation"
+    map(addressId) toProperty "addressId"
 }
 ```
 
@@ -332,14 +335,15 @@ val record1 = PersonRecord(100, "Joe", LastName("Jones"), Date(), true, "Develop
 val record2 = PersonRecord(101, "Sarah", LastName("Smith"), Date(), true, "Architect", 2)
 
 val rows = template.withKeyHolder(keyHolder) {
-    insertMultiple(record1, record2).into(Person) {
-        map(id).toProperty("id")
-        map(firstName).toProperty("firstName")
-        map(lastName).toProperty("lastNameAsString")
-        map(birthDate).toProperty("birthDate")
-        map(employed).toProperty("employedAsString")
-        map(occupation).toProperty("occupation")
-        map(addressId).toProperty("addressId")
+    insertMultiple(record1, record2) {
+        into(Person)
+        map(id) toProperty "id"
+        map(firstName) toProperty "firstName"
+        map(lastName) toProperty "lastNameAsString"
+        map(birthDate) toProperty "birthDate"
+        map(employed) toProperty "employedAsString"
+        map(occupation) toProperty "occupation"
+        map(addressId) toProperty "addressId"
     }
 }
 ```
@@ -365,14 +369,15 @@ Batch statements can be constructed and executed in a single step with code like
 val record1 = PersonRecord(100, "Joe", LastName("Jones"), Date(), true, "Developer", 1)
 val record2 = PersonRecord(101, "Sarah", LastName("Smith"), Date(), true, "Architect", 2)
 
-val rows = template.insertBatch(record1, record2).into(Person) {
-    map(id).toProperty("id")
-    map(firstName).toProperty("firstName")
-    map(lastName).toProperty("lastNameAsString")
-    map(birthDate).toProperty("birthDate")
-    map(employed).toProperty("employedAsString")
-    map(occupation).toProperty("occupation")
-    map(addressId).toProperty("addressId")
+val rows = template.insertBatch(record1, record2) {
+    into(Person)
+    map(id) toProperty "id"
+    map(firstName) toProperty "firstName"
+    map(lastName) toProperty "lastNameAsString"
+    map(birthDate) toProperty "birthDate"
+    map(employed) toProperty "employedAsString"
+    map(occupation) toProperty "occupation"
+    map(addressId) toProperty "addressId"
 }
 ```
 

--- a/src/test/kotlin/examples/kotlin/mybatis3/canonical/GeneratedAlwaysMapper.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/canonical/GeneratedAlwaysMapper.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -49,21 +49,23 @@ interface GeneratedAlwaysMapper {
 
 fun GeneratedAlwaysMapper.insert(record: GeneratedAlwaysRecord): Int {
     return insert(this::insert, record, generatedAlways) {
-        map(firstName).toProperty("firstName")
-        map(lastName).toProperty("lastName")
+        map(firstName) toProperty "firstName"
+        map(lastName) toProperty "lastName"
     }
 }
 
+fun GeneratedAlwaysMapper.insertMultiple(vararg records: GeneratedAlwaysRecord): Int = insertMultiple(records.asList())
+
 fun GeneratedAlwaysMapper.insertMultiple(records: Collection<GeneratedAlwaysRecord>): Int {
     return insertMultipleWithGeneratedKeys(this::insertMultiple, records, generatedAlways) {
-        map(firstName).toProperty("firstName")
-        map(lastName).toProperty("lastName")
+        map(firstName) toProperty "firstName"
+        map(lastName) toProperty "lastName"
     }
 }
 
 fun GeneratedAlwaysMapper.insertBatch(records: Collection<GeneratedAlwaysRecord>): List<Int> {
     return insertBatch(this::insert, records, generatedAlways) {
-        map(firstName).toProperty("firstName")
-        map(lastName).toProperty("lastName")
+        map(firstName) toProperty "firstName"
+        map(lastName) toProperty "lastName"
     }
 }

--- a/src/test/kotlin/examples/kotlin/mybatis3/canonical/GeneratedAlwaysTest.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/canonical/GeneratedAlwaysTest.kt
@@ -84,7 +84,7 @@ class GeneratedAlwaysTest {
                 lastName = "Rubble"
             )
 
-            val rows = mapper.insertMultiple(listOf(record1, record2))
+            val rows = mapper.insertMultiple(record1, record2)
 
             assertThat(rows).isEqualTo(2)
             assertThat(record1.id).isEqualTo(22)

--- a/src/test/kotlin/examples/kotlin/mybatis3/canonical/GeneratedAlwaysTest.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/canonical/GeneratedAlwaysTest.kt
@@ -28,7 +28,9 @@ import org.apache.ibatis.session.SqlSessionFactoryBuilder
 import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.mybatis.dynamic.sql.util.kotlin.elements.insertBatch
 import org.mybatis.dynamic.sql.util.kotlin.mybatis3.insertInto
+import org.mybatis.dynamic.sql.util.kotlin.mybatis3.into
 import java.io.InputStreamReader
 import java.sql.DriverManager
 
@@ -108,6 +110,40 @@ class GeneratedAlwaysTest {
             )
 
             mapper.insertBatch(listOf(record1, record2))
+
+            val batchResults = mapper.flush()
+
+            assertThat(batchResults).hasSize(1)
+            assertThat(batchResults[0].updateCounts).hasSize(2)
+            assertThat(batchResults[0].updateCounts[0]).isEqualTo(1)
+            assertThat(batchResults[0].updateCounts[1]).isEqualTo(1)
+
+            assertThat(record1.id).isEqualTo(22)
+            assertThat(record1.fullName).isEqualTo("Fred Flintstone")
+            assertThat(record2.id).isEqualTo(23)
+            assertThat(record2.fullName).isEqualTo("Barney Rubble")
+        }
+    }
+
+    @Test
+    fun testDeprecatedInsertBatch() {
+        newSession(ExecutorType.BATCH).use { session ->
+            val mapper = session.getMapper(GeneratedAlwaysMapper::class.java)
+
+            val record1 = GeneratedAlwaysRecord(
+                firstName = "Fred",
+                lastName = "Flintstone"
+            )
+
+            val record2 = GeneratedAlwaysRecord(
+                firstName = "Barney",
+                lastName = "Rubble"
+            )
+
+            insertBatch(record1, record2).into(generatedAlways) {
+                map(firstName).toProperty("firstName")
+                map(lastName).toProperty("lastName")
+            }.insertStatements().map(mapper::insert)
 
             val batchResults = mapper.flush()
 

--- a/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonMapperExtensions.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonMapperExtensions.kt
@@ -65,13 +65,13 @@ fun PersonMapper.deleteByPrimaryKey(id_: Int) =
 
 fun PersonMapper.insert(record: PersonRecord) =
     insert(this::insert, record, person) {
-        map(id).toProperty("id")
-        map(firstName).toProperty("firstName")
-        map(lastName).toProperty("lastName")
-        map(birthDate).toProperty("birthDate")
-        map(employed).toProperty("employed")
-        map(occupation).toProperty("occupation")
-        map(addressId).toProperty("addressId")
+        map(id) toProperty "id"
+        map(firstName) toProperty "firstName"
+        map(lastName) toProperty "lastName"
+        map(birthDate) toProperty "birthDate"
+        map(employed) toProperty "employed"
+        map(occupation) toProperty "occupation"
+        map(addressId) toProperty "addressId"
     }
 
 fun PersonMapper.generalInsert(completer: GeneralInsertCompleter) =
@@ -85,13 +85,13 @@ fun PersonMapper.insertBatch(vararg records: PersonRecord): List<Int> =
 
 fun PersonMapper.insertBatch(records: Collection<PersonRecord>): List<Int> =
     insertBatch(this::insert, records, person) {
-        map(id).toProperty("id")
-        map(firstName).toProperty("firstName")
-        map(lastName).toProperty("lastName")
-        map(birthDate).toProperty("birthDate")
-        map(employed).toProperty("employed")
-        map(occupation).toProperty("occupation")
-        map(addressId).toProperty("addressId")
+        map(id) toProperty "id"
+        map(firstName) toProperty "firstName"
+        map(lastName) toProperty "lastName"
+        map(birthDate) toProperty "birthDate"
+        map(employed) toProperty "employed"
+        map(occupation) toProperty "occupation"
+        map(addressId) toProperty "addressId"
     }
 
 fun PersonMapper.insertMultiple(vararg records: PersonRecord) =
@@ -99,13 +99,13 @@ fun PersonMapper.insertMultiple(vararg records: PersonRecord) =
 
 fun PersonMapper.insertMultiple(records: Collection<PersonRecord>) =
     insertMultiple(this::insertMultiple, records, person) {
-        map(id).toProperty("id")
-        map(firstName).toProperty("firstName")
-        map(lastName).toProperty("lastName")
-        map(birthDate).toProperty("birthDate")
-        map(employed).toProperty("employed")
-        map(occupation).toProperty("occupation")
-        map(addressId).toProperty("addressId")
+        map(id) toProperty "id"
+        map(firstName) toProperty "firstName"
+        map(lastName) toProperty "lastName"
+        map(birthDate) toProperty "birthDate"
+        map(employed) toProperty "employed"
+        map(occupation) toProperty "occupation"
+        map(addressId) toProperty "addressId"
     }
 
 fun PersonMapper.insertSelective(record: PersonRecord) =

--- a/src/test/kotlin/examples/kotlin/mybatis3/custom/render/KCustomRenderingTest.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/custom/render/KCustomRenderingTest.kt
@@ -31,11 +31,10 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.mybatis.dynamic.sql.SqlColumn
 import org.mybatis.dynamic.sql.util.kotlin.elements.`as`
-import org.mybatis.dynamic.sql.util.kotlin.elements.insert
-import org.mybatis.dynamic.sql.util.kotlin.elements.insertMultiple
 import org.mybatis.dynamic.sql.util.kotlin.mybatis3.deleteFrom
+import org.mybatis.dynamic.sql.util.kotlin.mybatis3.insert
 import org.mybatis.dynamic.sql.util.kotlin.mybatis3.insertInto
-import org.mybatis.dynamic.sql.util.kotlin.mybatis3.into
+import org.mybatis.dynamic.sql.util.kotlin.mybatis3.insertMultiple
 import org.mybatis.dynamic.sql.util.kotlin.mybatis3.select
 import org.mybatis.dynamic.sql.util.kotlin.mybatis3.update
 import org.mybatis.dynamic.sql.util.mybatis3.CommonSelectMapper
@@ -84,10 +83,11 @@ class KCustomRenderingTest {
                 info = "{\"firstName\": \"Fred\", \"lastName\": \"Flintstone\", \"age\": 30}"
             )
 
-            var insertStatement = insert(record).into(jsonTest) {
-                map(id).toProperty("id")
-                map(description).toProperty("description")
-                map(info).toProperty("info")
+            var insertStatement = insert(record) {
+                into(jsonTest)
+                map(id) toProperty "id"
+                map(description) toProperty "description"
+                map(info) toProperty "info"
             }
             val expected = "insert into JsonTest (id, description, info) " +
                 "values (#{record.id,jdbcType=INTEGER}, #{record.description,jdbcType=VARCHAR}, " +
@@ -101,10 +101,11 @@ class KCustomRenderingTest {
                 info = "{\"firstName\": \"Wilma\", \"lastName\": \"Flintstone\", \"age\": 25}"
             )
 
-            insertStatement = insert(record).into(jsonTest) {
-                map(id).toProperty("id")
-                map(description).toProperty("description")
-                map(info).toProperty("info")
+            insertStatement = insert(record) {
+                into(jsonTest)
+                map(id) toProperty "id"
+                map(description) toProperty "description"
+                map(info) toProperty "info"
             }
             rows = mapper.insert(insertStatement)
             assertThat(rows).isEqualTo(1)
@@ -170,10 +171,11 @@ class KCustomRenderingTest {
                 description = "Wilma",
                 info = "{\"firstName\": \"Wilma\", \"lastName\": \"Flintstone\", \"age\": 25}"
             )
-            val insertStatement = insertMultiple(record1, record2).into(jsonTest) {
-                map(id).toProperty("id")
-                map(description).toProperty("description")
-                map(info).toProperty("info")
+            val insertStatement = insertMultiple(listOf(record1, record2)) {
+                into(jsonTest)
+                map(id) toProperty "id"
+                map(description) toProperty "description"
+                map(info) toProperty "info"
             }
             val expected = "insert into JsonTest (id, description, info) " +
                 "values (#{records[0].id,jdbcType=INTEGER}, #{records[0].description,jdbcType=VARCHAR}, " +
@@ -210,10 +212,11 @@ class KCustomRenderingTest {
                 description = "Wilma",
                 info = "{\"firstName\": \"Wilma\", \"lastName\": \"Flintstone\", \"age\": 25}"
             )
-            val insertStatement = insertMultiple(record1, record2).into(jsonTest) {
-                map(id).toProperty("id")
-                map(description).toProperty("description")
-                map(info).toProperty("info")
+            val insertStatement = insertMultiple(listOf(record1, record2)) {
+                into(jsonTest)
+                map(id) toProperty "id"
+                map(description) toProperty "description"
+                map(info) toProperty "info"
             }
             var rows = mapper.insertMultiple(insertStatement)
             assertThat(rows).isEqualTo(2)
@@ -254,10 +257,11 @@ class KCustomRenderingTest {
                 description = "Wilma",
                 info = "{\"firstName\": \"Wilma\", \"lastName\": \"Flintstone\", \"age\": 25}"
             )
-            val insertStatement = insertMultiple(record1, record2).into(jsonTest) {
-                map(id).toProperty("id")
-                map(description).toProperty("description")
-                map(info).toProperty("info")
+            val insertStatement = insertMultiple(listOf(record1, record2)) {
+                into(jsonTest)
+                map(id) toProperty "id"
+                map(description) toProperty "description"
+                map(info) toProperty "info"
             }
             val rows = mapper.insertMultiple(insertStatement)
             assertThat(rows).isEqualTo(2)
@@ -291,10 +295,11 @@ class KCustomRenderingTest {
                 description = "Wilma",
                 info = "{\"firstName\": \"Wilma\", \"lastName\": \"Flintstone\", \"age\": 25}"
             )
-            val insertStatement = insertMultiple(record1, record2).into(jsonTest) {
-                map(id).toProperty("id")
-                map(description).toProperty("description")
-                map(info).toProperty("info")
+            val insertStatement = insertMultiple(listOf(record1, record2)) {
+                into(jsonTest)
+                map(id) toProperty "id"
+                map(description) toProperty "description"
+                map(info) toProperty "info"
             }
             val rows = mapper.insertMultiple(insertStatement)
             assertThat(rows).isEqualTo(2)

--- a/src/test/kotlin/examples/kotlin/mybatis3/general/GeneralKotlinTest.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/general/GeneralKotlinTest.kt
@@ -41,6 +41,7 @@ import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.jupiter.api.Test
+import org.mybatis.dynamic.sql.util.kotlin.KInvalidSQLException
 import org.mybatis.dynamic.sql.util.kotlin.elements.`as`
 import org.mybatis.dynamic.sql.util.kotlin.elements.count
 import org.mybatis.dynamic.sql.util.kotlin.elements.insert
@@ -656,7 +657,7 @@ class GeneralKotlinTest {
 
     @Test
     fun testRawSelectWithoutFrom() {
-        assertThatExceptionOfType(UninitializedPropertyAccessException::class.java).isThrownBy {
+        assertThatExceptionOfType(KInvalidSQLException::class.java).isThrownBy {
             select(id `as` "A_ID", firstName, lastName, birthDate, employed, occupation, addressId) {
                 where { id isEqualTo 5 }
                 or {
@@ -674,7 +675,7 @@ class GeneralKotlinTest {
 
     @Test
     fun testRawCountWithoutFrom() {
-        assertThatExceptionOfType(UninitializedPropertyAccessException::class.java).isThrownBy {
+        assertThatExceptionOfType(KInvalidSQLException::class.java).isThrownBy {
             count(id) {
                 where { id isEqualTo 5 }
                 or {

--- a/src/test/kotlin/examples/kotlin/mybatis3/general/GeneralKotlinTest.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/general/GeneralKotlinTest.kt
@@ -291,7 +291,7 @@ class GeneralKotlinTest {
     }
 
     @Test
-    fun testInsert() {
+    fun testDeprecatedInsert() {
         newSession().use { session ->
             val mapper = session.getMapper(PersonMapper::class.java)
 
@@ -326,7 +326,7 @@ class GeneralKotlinTest {
     }
 
     @Test
-    fun testInsertMultiple() {
+    fun testDeprecatedInsertMultiple() {
         newSession().use { session ->
             val mapper = session.getMapper(PersonMapper::class.java)
 

--- a/src/test/kotlin/examples/kotlin/spring/canonical/CanonicalSpringKotlinTemplateDirectTest.kt
+++ b/src/test/kotlin/examples/kotlin/spring/canonical/CanonicalSpringKotlinTemplateDirectTest.kt
@@ -175,6 +175,24 @@ open class CanonicalSpringKotlinTemplateDirectTest {
     fun testInsert() {
         val record = PersonRecord(100, "Joe", LastName("Jones"), Date(), true, "Developer", 1)
 
+        val rows = template.insert(record) {
+            into(person)
+            map(id) toProperty "id"
+            map(firstName) toProperty "firstName"
+            map(lastName) toProperty "lastNameAsString"
+            map(birthDate) toProperty "birthDate"
+            map(employed) toProperty "employedAsString"
+            map(occupation).toPropertyWhenPresent("occupation", record::occupation)
+            map(addressId) toProperty "addressId"
+        }
+
+        assertThat(rows).isEqualTo(1)
+    }
+
+    @Test
+    fun testDeprecatedInsert() {
+        val record = PersonRecord(100, "Joe", LastName("Jones"), Date(), true, "Developer", 1)
+
         val rows = template.insert(record).into(person) {
             map(id).toProperty("id")
             map(firstName).toProperty("firstName")
@@ -208,6 +226,25 @@ open class CanonicalSpringKotlinTemplateDirectTest {
         val record1 = PersonRecord(100, "Joe", LastName("Jones"), Date(), true, "Developer", 1)
         val record2 = PersonRecord(101, "Sarah", LastName("Smith"), Date(), true, "Architect", 2)
 
+        val rows = template.insertMultiple(record1, record2) {
+            into(person)
+            map(id).toProperty("id")
+            map(firstName).toProperty("firstName")
+            map(lastName).toProperty("lastNameAsString")
+            map(birthDate).toProperty("birthDate")
+            map(employed).toProperty("employedAsString")
+            map(occupation).toProperty("occupation")
+            map(addressId).toProperty("addressId")
+        }
+
+        assertThat(rows).isEqualTo(2)
+    }
+
+    @Test
+    fun testDeprecatedMultiRowInsert() {
+        val record1 = PersonRecord(100, "Joe", LastName("Jones"), Date(), true, "Developer", 1)
+        val record2 = PersonRecord(101, "Sarah", LastName("Smith"), Date(), true, "Architect", 2)
+
         val rows = template.insertMultiple(record1, record2).into(person) {
             map(id).toProperty("id")
             map(firstName).toProperty("firstName")
@@ -223,6 +260,27 @@ open class CanonicalSpringKotlinTemplateDirectTest {
 
     @Test
     fun testBatchInsert() {
+        val record1 = PersonRecord(100, "Joe", LastName("Jones"), Date(), true, "Developer", 1)
+        val record2 = PersonRecord(101, "Sarah", LastName("Smith"), Date(), true, "Architect", 2)
+
+        val rows = template.insertBatch(record1, record2) {
+            into(person)
+            map(id).toProperty("id")
+            map(firstName).toProperty("firstName")
+            map(lastName).toProperty("lastNameAsString")
+            map(birthDate).toProperty("birthDate")
+            map(employed).toProperty("employedAsString")
+            map(occupation).toProperty("occupation")
+            map(addressId).toProperty("addressId")
+        }
+
+        assertThat(rows).hasSize(2)
+        assertThat(rows[0]).isEqualTo(1)
+        assertThat(rows[1]).isEqualTo(1)
+    }
+
+    @Test
+    fun testDeprecatedBatchInsert() {
         val record1 = PersonRecord(100, "Joe", LastName("Jones"), Date(), true, "Developer", 1)
         val record2 = PersonRecord(101, "Sarah", LastName("Smith"), Date(), true, "Architect", 2)
 
@@ -298,6 +356,26 @@ open class CanonicalSpringKotlinTemplateDirectTest {
         val keyHolder = GeneratedKeyHolder()
 
         val rows = template.withKeyHolder(keyHolder) {
+            insert(command) {
+                into(generatedAlways)
+                map(generatedAlways.firstName).toProperty("firstName")
+                map(generatedAlways.lastName).toProperty("lastName")
+            }
+        }
+
+        assertThat(rows).isEqualTo(1)
+        assertThat(keyHolder.keys).containsEntry("ID", 22)
+        assertThat(keyHolder.keys).containsEntry("FULL_NAME", "Fred Flintstone")
+    }
+
+    @Test
+    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+    fun testDeprecatedInsertWithGeneratedKey() {
+        val command = GeneratedAlwaysCommand(firstName = "Fred", lastName = "Flintstone")
+
+        val keyHolder = GeneratedKeyHolder()
+
+        val rows = template.withKeyHolder(keyHolder) {
             insert(command).into(generatedAlways) {
                 map(generatedAlways.firstName).toProperty("firstName")
                 map(generatedAlways.lastName).toProperty("lastName")
@@ -312,6 +390,29 @@ open class CanonicalSpringKotlinTemplateDirectTest {
     @Test
     @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
     fun testMultiRowInsertWithGeneratedKey() {
+        val command1 = GeneratedAlwaysCommand(firstName = "Fred", lastName = "Flintstone")
+        val command2 = GeneratedAlwaysCommand(firstName = "Barney", lastName = "Rubble")
+
+        val keyHolder = GeneratedKeyHolder()
+
+        val rows = template.withKeyHolder(keyHolder) {
+            insertMultiple(command1, command2) {
+                into(generatedAlways)
+                map(generatedAlways.firstName).toProperty("firstName")
+                map(generatedAlways.lastName).toProperty("lastName")
+            }
+        }
+
+        assertThat(rows).isEqualTo(2)
+        assertThat(keyHolder.keyList[0]).containsEntry("ID", 22)
+        assertThat(keyHolder.keyList[0]).containsEntry("FULL_NAME", "Fred Flintstone")
+        assertThat(keyHolder.keyList[1]).containsEntry("ID", 23)
+        assertThat(keyHolder.keyList[1]).containsEntry("FULL_NAME", "Barney Rubble")
+    }
+
+    @Test
+    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+    fun testDeprecatedMultiRowInsertWithGeneratedKey() {
         val command1 = GeneratedAlwaysCommand(firstName = "Fred", lastName = "Flintstone")
         val command2 = GeneratedAlwaysCommand(firstName = "Barney", lastName = "Rubble")
 

--- a/src/test/kotlin/examples/kotlin/spring/canonical/CanonicalSpringKotlinTemplateDirectTest.kt
+++ b/src/test/kotlin/examples/kotlin/spring/canonical/CanonicalSpringKotlinTemplateDirectTest.kt
@@ -52,6 +52,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig
 import org.springframework.transaction.annotation.Transactional
 import java.util.Date
 
+@Suppress("LargeClass")
 @SpringJUnitConfig(classes = [SpringConfiguration::class])
 @Transactional
 open class CanonicalSpringKotlinTemplateDirectTest {

--- a/src/test/kotlin/examples/kotlin/spring/canonical/CanonicalSpringKotlinTemplateDirectTest.kt
+++ b/src/test/kotlin/examples/kotlin/spring/canonical/CanonicalSpringKotlinTemplateDirectTest.kt
@@ -229,13 +229,13 @@ open class CanonicalSpringKotlinTemplateDirectTest {
 
         val rows = template.insertMultiple(record1, record2) {
             into(person)
-            map(id).toProperty("id")
-            map(firstName).toProperty("firstName")
-            map(lastName).toProperty("lastNameAsString")
-            map(birthDate).toProperty("birthDate")
-            map(employed).toProperty("employedAsString")
-            map(occupation).toProperty("occupation")
-            map(addressId).toProperty("addressId")
+            map(id) toProperty "id"
+            map(firstName) toProperty "firstName"
+            map(lastName) toProperty "lastNameAsString"
+            map(birthDate) toProperty "birthDate"
+            map(employed) toProperty "employedAsString"
+            map(occupation) toProperty "occupation"
+            map(addressId) toProperty "addressId"
         }
 
         assertThat(rows).isEqualTo(2)
@@ -266,13 +266,13 @@ open class CanonicalSpringKotlinTemplateDirectTest {
 
         val rows = template.insertBatch(record1, record2) {
             into(person)
-            map(id).toProperty("id")
-            map(firstName).toProperty("firstName")
-            map(lastName).toProperty("lastNameAsString")
-            map(birthDate).toProperty("birthDate")
-            map(employed).toProperty("employedAsString")
-            map(occupation).toProperty("occupation")
-            map(addressId).toProperty("addressId")
+            map(id) toProperty "id"
+            map(firstName) toProperty "firstName"
+            map(lastName) toProperty "lastNameAsString"
+            map(birthDate) toProperty "birthDate"
+            map(employed) toProperty "employedAsString"
+            map(occupation) toProperty "occupation"
+            map(addressId) toProperty "addressId"
         }
 
         assertThat(rows).hasSize(2)
@@ -359,8 +359,8 @@ open class CanonicalSpringKotlinTemplateDirectTest {
         val rows = template.withKeyHolder(keyHolder) {
             insert(command) {
                 into(generatedAlways)
-                map(generatedAlways.firstName).toProperty("firstName")
-                map(generatedAlways.lastName).toProperty("lastName")
+                map(generatedAlways.firstName) toProperty "firstName"
+                map(generatedAlways.lastName) toProperty "lastName"
             }
         }
 
@@ -399,8 +399,8 @@ open class CanonicalSpringKotlinTemplateDirectTest {
         val rows = template.withKeyHolder(keyHolder) {
             insertMultiple(command1, command2) {
                 into(generatedAlways)
-                map(generatedAlways.firstName).toProperty("firstName")
-                map(generatedAlways.lastName).toProperty("lastName")
+                map(generatedAlways.firstName) toProperty "firstName"
+                map(generatedAlways.lastName) toProperty "lastName"
             }
         }
 

--- a/src/test/kotlin/examples/kotlin/spring/canonical/CanonicalSpringKotlinTest.kt
+++ b/src/test/kotlin/examples/kotlin/spring/canonical/CanonicalSpringKotlinTest.kt
@@ -244,7 +244,8 @@ open class CanonicalSpringKotlinTest {
 
         val record = PersonRecord(100, "Joe", LastName("Jones"), Date(), true, "Developer", 1)
 
-        val insertStatement = insert(record).into(person) {
+        val insertStatement = insert(record) {
+            into(person)
             map(id).toProperty("id")
             map(firstName).toProperty("firstName")
             map(lastName).toProperty("lastNameAsString")
@@ -261,6 +262,36 @@ open class CanonicalSpringKotlinTest {
                 " :lastNameAsString," +
                 " :birthDate, :employedAsString," +
                 " :occupation, :addressId)"
+
+        assertThat(insertStatement.insertStatement).isEqualTo(expected)
+
+        val rows = template.insert(insertStatement)
+
+        assertThat(rows).isEqualTo(1)
+    }
+
+    @Test
+    fun testDeprecatedInsert() {
+
+        val record = PersonRecord(100, "Joe", LastName("Jones"), Date(), true, "Developer", 1)
+
+        val insertStatement = insert(record).into(person) {
+            map(id).toProperty("id")
+            map(firstName).toProperty("firstName")
+            map(lastName).toProperty("lastNameAsString")
+            map(birthDate).toProperty("birthDate")
+            map(employed).toProperty("employedAsString")
+            map(occupation).toProperty("occupation")
+            map(addressId).toProperty("addressId")
+        }
+
+        val expected =
+            "insert into Person (id, first_name, last_name, birth_date, employed, occupation, address_id)" +
+                    " values" +
+                    " (:id, :firstName," +
+                    " :lastNameAsString," +
+                    " :birthDate, :employedAsString," +
+                    " :occupation, :addressId)"
 
         assertThat(insertStatement.insertStatement).isEqualTo(expected)
 
@@ -348,7 +379,8 @@ open class CanonicalSpringKotlinTest {
         val record1 = PersonRecord(100, "Joe", LastName("Jones"), Date(), true, "Developer", 1)
         val record2 = PersonRecord(101, "Sarah", LastName("Smith"), Date(), true, "Architect", 2)
 
-        val insertStatement = insertMultiple(record1, record2).into(person) {
+        val insertStatement = insertMultiple(listOf(record1, record2)) {
+            into(person)
             map(id).toProperty("id")
             map(firstName).toProperty("firstName")
             map(lastName).toProperty("lastNameAsString")
@@ -365,6 +397,34 @@ open class CanonicalSpringKotlinTest {
                 ":records[0].occupation, :records[0].addressId), " +
                 "(:records[1].id, :records[1].firstName, :records[1].lastNameAsString, " +
                 ":records[1].birthDate, :records[1].employedAsString, :records[1].occupation, :records[1].addressId)"
+        )
+
+        val rows = template.insertMultiple(insertStatement)
+        assertThat(rows).isEqualTo(2)
+    }
+
+    @Test
+    fun testDeprecatedMultiRowInsert() {
+        val record1 = PersonRecord(100, "Joe", LastName("Jones"), Date(), true, "Developer", 1)
+        val record2 = PersonRecord(101, "Sarah", LastName("Smith"), Date(), true, "Architect", 2)
+
+        val insertStatement = insertMultiple(record1, record2).into(person) {
+            map(id).toProperty("id")
+            map(firstName).toProperty("firstName")
+            map(lastName).toProperty("lastNameAsString")
+            map(birthDate).toProperty("birthDate")
+            map(employed).toProperty("employedAsString")
+            map(occupation).toProperty("occupation")
+            map(addressId).toProperty("addressId")
+        }
+
+        assertThat(insertStatement.insertStatement).isEqualTo(
+            "insert into Person (id, first_name, last_name, birth_date, employed, occupation, address_id) " +
+                    "values (:records[0].id, :records[0].firstName, :records[0].lastNameAsString, " +
+                    ":records[0].birthDate, :records[0].employedAsString, " +
+                    ":records[0].occupation, :records[0].addressId), " +
+                    "(:records[1].id, :records[1].firstName, :records[1].lastNameAsString, " +
+                    ":records[1].birthDate, :records[1].employedAsString, :records[1].occupation, :records[1].addressId)"
         )
 
         val rows = template.insertMultiple(insertStatement)

--- a/src/test/kotlin/examples/kotlin/spring/canonical/CanonicalSpringKotlinTest.kt
+++ b/src/test/kotlin/examples/kotlin/spring/canonical/CanonicalSpringKotlinTest.kt
@@ -455,13 +455,13 @@ open class CanonicalSpringKotlinTest {
 
         val insertStatement = insertBatch(listOf(record1, record2)) {
             into(person)
-            map(id).toProperty("id")
-            map(firstName).toProperty("firstName")
-            map(lastName).toProperty("lastNameAsString")
-            map(birthDate).toProperty("birthDate")
-            map(employed).toProperty("employedAsString")
-            map(occupation).toProperty("occupation")
-            map(addressId).toProperty("addressId")
+            map(id) toProperty "id"
+            map(firstName) toProperty "firstName"
+            map(lastName) toProperty "lastNameAsString"
+            map(birthDate) toProperty "birthDate"
+            map(employed) toProperty "employedAsString"
+            map(occupation) toProperty "occupation"
+            map(addressId) toProperty "addressId"
         }
 
         val rows = template.insertBatch(insertStatement)
@@ -588,8 +588,8 @@ open class CanonicalSpringKotlinTest {
 
         val insertStatement = insert(command) {
             into(generatedAlways)
-            map(generatedAlways.firstName).toProperty("firstName")
-            map(generatedAlways.lastName).toProperty("lastName")
+            map(generatedAlways.firstName) toProperty "firstName"
+            map(generatedAlways.lastName) toProperty "lastName"
         }
 
         val keyHolder = GeneratedKeyHolder()
@@ -608,8 +608,8 @@ open class CanonicalSpringKotlinTest {
 
         val insertStatement = insertMultiple(listOf(command1, command2)) {
             into(generatedAlways)
-            map(generatedAlways.firstName).toProperty("firstName")
-            map(generatedAlways.lastName).toProperty("lastName")
+            map(generatedAlways.firstName) toProperty "firstName"
+            map(generatedAlways.lastName) toProperty "lastName"
         }
 
         val keyHolder = GeneratedKeyHolder()

--- a/src/test/kotlin/examples/kotlin/spring/canonical/CanonicalSpringKotlinTest.kt
+++ b/src/test/kotlin/examples/kotlin/spring/canonical/CanonicalSpringKotlinTest.kt
@@ -424,7 +424,8 @@ open class CanonicalSpringKotlinTest {
                     ":records[0].birthDate, :records[0].employedAsString, " +
                     ":records[0].occupation, :records[0].addressId), " +
                     "(:records[1].id, :records[1].firstName, :records[1].lastNameAsString, " +
-                    ":records[1].birthDate, :records[1].employedAsString, :records[1].occupation, :records[1].addressId)"
+                    ":records[1].birthDate, :records[1].employedAsString, :records[1].occupation, " +
+                    ":records[1].addressId)"
         )
 
         val rows = template.insertMultiple(insertStatement)
@@ -433,8 +434,62 @@ open class CanonicalSpringKotlinTest {
 
     @Test
     fun testBatchInsert() {
-        val record1 = PersonRecord(100, "Joe", LastName("Jones"), Date(), true, "Developer", 1)
-        val record2 = PersonRecord(101, "Sarah", LastName("Smith"), Date(), true, "Architect", 2)
+        val record1 = PersonRecord(
+            100,
+            "Joe",
+            LastName("Jones"),
+            Date(),
+            true,
+            "Developer",
+            1
+        )
+        val record2 = PersonRecord(
+            101,
+            "Sarah",
+            LastName("Smith"),
+            Date(),
+            true,
+            "Architect",
+            2
+        )
+
+        val insertStatement = insertBatch(listOf(record1, record2)) {
+            into(person)
+            map(id).toProperty("id")
+            map(firstName).toProperty("firstName")
+            map(lastName).toProperty("lastNameAsString")
+            map(birthDate).toProperty("birthDate")
+            map(employed).toProperty("employedAsString")
+            map(occupation).toProperty("occupation")
+            map(addressId).toProperty("addressId")
+        }
+
+        val rows = template.insertBatch(insertStatement)
+        assertThat(rows).hasSize(2)
+        assertThat(rows[0]).isEqualTo(1)
+        assertThat(rows[1]).isEqualTo(1)
+    }
+
+    @Test
+    fun testDeprecatedBatchInsert() {
+        val record1 = PersonRecord(
+            100,
+            "Joe",
+            LastName("Jones"),
+            Date(),
+            true,
+            "Developer",
+            1
+        )
+        val record2 = PersonRecord(
+            101,
+            "Sarah",
+            LastName("Smith"),
+            Date(),
+            true,
+            "Architect",
+            2
+        )
 
         val insertStatement = insertBatch(record1, record2).into(person) {
             map(id).toProperty("id")
@@ -531,7 +586,8 @@ open class CanonicalSpringKotlinTest {
     fun testInsertWithGeneratedKey() {
         val command = GeneratedAlwaysCommand(firstName = "Fred", lastName = "Flintstone")
 
-        val insertStatement = insert(command).into(generatedAlways) {
+        val insertStatement = insert(command) {
+            into(generatedAlways)
             map(generatedAlways.firstName).toProperty("firstName")
             map(generatedAlways.lastName).toProperty("lastName")
         }
@@ -550,7 +606,8 @@ open class CanonicalSpringKotlinTest {
         val command1 = GeneratedAlwaysCommand(firstName = "Fred", lastName = "Flintstone")
         val command2 = GeneratedAlwaysCommand(firstName = "Barney", lastName = "Rubble")
 
-        val insertStatement = insertMultiple(command1, command2).into(generatedAlways) {
+        val insertStatement = insertMultiple(listOf(command1, command2)) {
+            into(generatedAlways)
             map(generatedAlways.firstName).toProperty("firstName")
             map(generatedAlways.lastName).toProperty("lastName")
         }

--- a/src/test/kotlin/examples/kotlin/spring/canonical/InfixElementsTest.kt
+++ b/src/test/kotlin/examples/kotlin/spring/canonical/InfixElementsTest.kt
@@ -24,7 +24,7 @@ import examples.kotlin.spring.canonical.PersonDynamicSqlSupport.lastName
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.jupiter.api.Test
-import org.mybatis.dynamic.sql.util.kotlin.DuplicateInitialCriterionException
+import org.mybatis.dynamic.sql.util.kotlin.KInvalidSQLException
 import org.mybatis.dynamic.sql.util.kotlin.elements.isLike
 import org.mybatis.dynamic.sql.util.kotlin.elements.stringConstant
 import org.mybatis.dynamic.sql.util.kotlin.elements.upper
@@ -960,7 +960,7 @@ open class InfixElementsTest {
 
     @Test
     fun testThatTwoInitialCriteriaThrowsException() {
-        assertThatExceptionOfType(DuplicateInitialCriterionException::class.java).isThrownBy {
+        assertThatExceptionOfType(KInvalidSQLException::class.java).isThrownBy {
             select(lastName) {
                 from(person)
                 where {


### PR DESCRIPTION
Write full Kotlin implementations of all the different insert DSLs. This allows us to use some additional Kotlin DSL features.

The main difference in practice is that the "into" function is moved inside the completer lambda. This is similar to the change we made for select statements and adds another level of consistency to the Kotlin DSL.
