### PR TITLE
Expose Table Aliases to Sub Queries in Where Clauses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ GitHub milestone: [https://github.com/mybatis/mybatis-dynamic-sql/issues?q=miles
 8. Updated the where clause to expose table aliases specified in an outer query to sub queries in the where clause
    (either an "exists" clause, or a sub query to column comparison condition) This makes it easier to use these types
    of sub queries without having to re-specify the aliases for columns from the outer query.
-   ([#437](https://github.com/mybatis/mybatis-dynamic-sql/issues/437))
+   ([#459](https://github.com/mybatis/mybatis-dynamic-sql/pull/459))
 
 ## Release 1.3.1 - December 18, 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,8 +44,9 @@ GitHub milestone: [https://github.com/mybatis/mybatis-dynamic-sql/issues?q=miles
    insertBatch, and insertMultiple, the "into" function is moved inside the completer lambda. The old methods are now
    deprecated and will be removed in version 1.5.0 of the library. This also allowed us to make some insert DSL
    methods into infix functions. ([#452](https://github.com/mybatis/mybatis-dynamic-sql/pull/452))
-8. Updated the "exists" support to expose table aliases specified in the outer query to the query in the exists
-   clause. This makes it easier to use exists without having to re-specify the aliases for columns from the outer query.
+8. Updated the where clause to expose table aliases specified in an outer query to sub queries in the where clause
+   (either an "exists" clause, or a sub query to column comparison condition) This makes it easier to use these types
+   of sub queries without having to re-specify the aliases for columns from the outer query.
    ([#437](https://github.com/mybatis/mybatis-dynamic-sql/issues/437))
 
 ## Release 1.3.1 - December 18, 2021

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This log will detail notable changes to MyBatis Dynamic SQL. Full details are av
 
 ## Release 1.4.0 - Unreleased
 
-The release includes new function in the Where Clause DSL to support arbitrary grouping of conditions, and also use
+The release includes new functionality in the Where Clause DSL to support arbitrary grouping of conditions, and also use
 of a "not" condition. It should now be possible to write any type of where clause.
 
 Additionally, there were significant updates to the Kotlin DSL - both to support the new functionality in the
@@ -44,6 +44,9 @@ GitHub milestone: [https://github.com/mybatis/mybatis-dynamic-sql/issues?q=miles
    insertBatch, and insertMultiple, the "into" function is moved inside the completer lambda. The old methods are now
    deprecated and will be removed in version 1.5.0 of the library. This also allowed us to make some insert DSL
    methods into infix functions. ([#452](https://github.com/mybatis/mybatis-dynamic-sql/pull/452))
+8. Updated the "exists" support to expose table aliases specified in the outer query to the query in the exists
+   clause. This makes it easier to use exists without having to re-specify the aliases for columns from the outer query.
+   ([#437](https://github.com/mybatis/mybatis-dynamic-sql/issues/437))
 
 ## Release 1.3.1 - December 18, 2021
 

--- a/src/main/java/org/mybatis/dynamic/sql/insert/render/InsertStatementProvider.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/render/InsertStatementProvider.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@ public interface InsertStatementProvider<T> {
     /**
      * Return the row associated with this insert statement.
      *
-     * @deprecated in favor of {@link InsertStatementProvider#getRow()}
      * @return the row associated with this insert statement.
+     * @deprecated in favor of {@link InsertStatementProvider#getRow()}
      */
     @Deprecated
     T getRecord();

--- a/src/main/java/org/mybatis/dynamic/sql/render/ExplicitTableAliasCalculator.java
+++ b/src/main/java/org/mybatis/dynamic/sql/render/ExplicitTableAliasCalculator.java
@@ -15,12 +15,12 @@
  */
 package org.mybatis.dynamic.sql.render;
 
-import org.mybatis.dynamic.sql.SqlTable;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+
+import org.mybatis.dynamic.sql.SqlTable;
 
 public class ExplicitTableAliasCalculator implements TableAliasCalculator {
     private final Map<SqlTable, String> aliases;

--- a/src/main/java/org/mybatis/dynamic/sql/render/ExplicitTableAliasCalculator.java
+++ b/src/main/java/org/mybatis/dynamic/sql/render/ExplicitTableAliasCalculator.java
@@ -1,0 +1,60 @@
+/*
+ *    Copyright 2016-2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.dynamic.sql.render;
+
+import org.mybatis.dynamic.sql.SqlTable;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+public class ExplicitTableAliasCalculator implements TableAliasCalculator {
+    private final Map<SqlTable, String> aliases;
+
+    protected ExplicitTableAliasCalculator(Map<SqlTable, String> aliases) {
+        this.aliases = Objects.requireNonNull(aliases);
+    }
+
+    @Override
+    public Optional<String> aliasForColumn(SqlTable table) {
+        return explicitAliasOrTableAlias(table);
+    }
+
+    @Override
+    public Optional<String> aliasForTable(SqlTable table) {
+        return explicitAliasOrTableAlias(table);
+    }
+
+    private Optional<String> explicitAliasOrTableAlias(SqlTable table) {
+        String alias = aliases.get(table);
+        if (alias == null) {
+            return table.tableAlias();
+        } else {
+            return Optional.of(alias);
+        }
+    }
+
+    public static TableAliasCalculator of(SqlTable table, String alias) {
+        Map<SqlTable, String> tableAliases = new HashMap<>();
+        tableAliases.put(table, alias);
+        return of(tableAliases);
+    }
+
+    public static TableAliasCalculator of(Map<SqlTable, String> aliases) {
+        return new ExplicitTableAliasCalculator(aliases);
+    }
+}

--- a/src/main/java/org/mybatis/dynamic/sql/render/GuaranteedTableAliasCalculator.java
+++ b/src/main/java/org/mybatis/dynamic/sql/render/GuaranteedTableAliasCalculator.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import org.mybatis.dynamic.sql.SqlTable;
  * @author Jeff Butler
  *
  */
-public class GuaranteedTableAliasCalculator extends TableAliasCalculator {
+public class GuaranteedTableAliasCalculator extends ExplicitTableAliasCalculator {
 
     private GuaranteedTableAliasCalculator(Map<SqlTable, String> aliases) {
         super(aliases);

--- a/src/main/java/org/mybatis/dynamic/sql/render/TableAliasCalculator.java
+++ b/src/main/java/org/mybatis/dynamic/sql/render/TableAliasCalculator.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,50 +15,27 @@
  */
 package org.mybatis.dynamic.sql.render;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 
 import org.mybatis.dynamic.sql.SqlTable;
 
-public class TableAliasCalculator {
+public interface TableAliasCalculator {
 
-    private final Map<SqlTable, String> aliases;
+    Optional<String> aliasForColumn(SqlTable table);
 
-    protected TableAliasCalculator(Map<SqlTable, String> aliases) {
-        this.aliases = Objects.requireNonNull(aliases);
-    }
+    Optional<String> aliasForTable(SqlTable table);
 
-    public Optional<String> aliasForColumn(SqlTable table) {
-        return explicitAliasOrTableAlias(table);
-    }
+    static TableAliasCalculator empty() {
+        return new TableAliasCalculator() {
+            @Override
+            public Optional<String> aliasForColumn(SqlTable table) {
+                return Optional.empty();
+            }
 
-    public Optional<String> aliasForTable(SqlTable table) {
-        return explicitAliasOrTableAlias(table);
-    }
-
-    private Optional<String> explicitAliasOrTableAlias(SqlTable table) {
-        String alias = aliases.get(table);
-        if (alias == null) {
-            return table.tableAlias();
-        } else {
-            return Optional.of(alias);
-        }
-    }
-
-    public static TableAliasCalculator of(SqlTable table, String alias) {
-        Map<SqlTable, String> tableAliases = new HashMap<>();
-        tableAliases.put(table, alias);
-        return of(tableAliases);
-    }
-
-    public static TableAliasCalculator of(Map<SqlTable, String> aliases) {
-        return new TableAliasCalculator(aliases);
-    }
-
-    public static TableAliasCalculator empty() {
-        return of(Collections.emptyMap());
+            @Override
+            public Optional<String> aliasForTable(SqlTable table) {
+                return Optional.empty();
+            }
+        };
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/render/TableAliasCalculatorWithParent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/render/TableAliasCalculatorWithParent.java
@@ -1,0 +1,49 @@
+/*
+ *    Copyright 2016-2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.dynamic.sql.render;
+
+import org.mybatis.dynamic.sql.SqlTable;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public class TableAliasCalculatorWithParent implements TableAliasCalculator {
+    private final TableAliasCalculator parent;
+    private final TableAliasCalculator child;
+
+    public TableAliasCalculatorWithParent(TableAliasCalculator parent, TableAliasCalculator child) {
+        this.parent = Objects.requireNonNull(parent);
+        this.child = Objects.requireNonNull(child);
+    }
+
+    @Override
+    public Optional<String> aliasForColumn(SqlTable table) {
+        Optional<String> answer = child.aliasForColumn(table);
+        if (answer.isPresent()) {
+            return answer;
+        }
+        return parent.aliasForColumn(table);
+    }
+
+    @Override
+    public Optional<String> aliasForTable(SqlTable table) {
+        Optional<String> answer = child.aliasForTable(table);
+        if (answer.isPresent()) {
+            return answer;
+        }
+        return parent.aliasForTable(table);
+    }
+}

--- a/src/main/java/org/mybatis/dynamic/sql/render/TableAliasCalculatorWithParent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/render/TableAliasCalculatorWithParent.java
@@ -15,10 +15,10 @@
  */
 package org.mybatis.dynamic.sql.render;
 
-import org.mybatis.dynamic.sql.SqlTable;
-
 import java.util.Objects;
 import java.util.Optional;
+
+import org.mybatis.dynamic.sql.SqlTable;
 
 public class TableAliasCalculatorWithParent implements TableAliasCalculator {
     private final TableAliasCalculator parent;

--- a/src/main/java/org/mybatis/dynamic/sql/render/TableAliasCalculatorWithParent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/render/TableAliasCalculatorWithParent.java
@@ -24,9 +24,9 @@ public class TableAliasCalculatorWithParent implements TableAliasCalculator {
     private final TableAliasCalculator parent;
     private final TableAliasCalculator child;
 
-    public TableAliasCalculatorWithParent(TableAliasCalculator parent, TableAliasCalculator child) {
-        this.parent = Objects.requireNonNull(parent);
-        this.child = Objects.requireNonNull(child);
+    private TableAliasCalculatorWithParent(Builder builder) {
+        parent = Objects.requireNonNull(builder.parent);
+        child = Objects.requireNonNull(builder.child);
     }
 
     @Override
@@ -45,5 +45,24 @@ public class TableAliasCalculatorWithParent implements TableAliasCalculator {
             return answer;
         }
         return parent.aliasForTable(table);
+    }
+
+    public static class Builder {
+        private TableAliasCalculator parent;
+        private TableAliasCalculator child;
+
+        public Builder withParent(TableAliasCalculator parent) {
+            this.parent = parent;
+            return this;
+        }
+
+        public Builder withChild(TableAliasCalculator child) {
+            this.child = child;
+            return this;
+        }
+
+        public TableAliasCalculatorWithParent build() {
+            return new TableAliasCalculatorWithParent(this);
+        }
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/select/QueryExpressionModel.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/QueryExpressionModel.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2020 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -27,8 +27,6 @@ import java.util.stream.Stream;
 import org.mybatis.dynamic.sql.BasicColumn;
 import org.mybatis.dynamic.sql.SqlTable;
 import org.mybatis.dynamic.sql.TableExpression;
-import org.mybatis.dynamic.sql.render.GuaranteedTableAliasCalculator;
-import org.mybatis.dynamic.sql.render.TableAliasCalculator;
 import org.mybatis.dynamic.sql.select.join.JoinModel;
 import org.mybatis.dynamic.sql.where.WhereModel;
 
@@ -38,7 +36,7 @@ public class QueryExpressionModel {
     private final List<BasicColumn> selectList;
     private final TableExpression table;
     private final JoinModel joinModel;
-    private final TableAliasCalculator tableAliasCalculator;
+    private final Map<SqlTable, String> tableAliases;
     private final WhereModel whereModel;
     private final GroupByModel groupByModel;
 
@@ -48,20 +46,9 @@ public class QueryExpressionModel {
         selectList = Objects.requireNonNull(builder.selectList);
         table = Objects.requireNonNull(builder.table);
         joinModel = builder.joinModel;
-        tableAliasCalculator = joinModel().map(jm -> determineJoinTableAliasCalculator(jm, builder.tableAliases))
-                .orElseGet(() -> TableAliasCalculator.of(builder.tableAliases));
+        tableAliases = builder.tableAliases;
         whereModel = builder.whereModel;
         groupByModel = builder.groupByModel;
-    }
-
-    private TableAliasCalculator determineJoinTableAliasCalculator(JoinModel joinModel, Map<SqlTable,
-            String> tableAliases) {
-        if (joinModel.containsSubQueries()) {
-            // if there are subQueries, then force explicit qualifiers
-            return TableAliasCalculator.of(tableAliases);
-        } else {
-            return GuaranteedTableAliasCalculator.of(tableAliases);
-        }
     }
 
     public Optional<String> connector() {
@@ -80,8 +67,8 @@ public class QueryExpressionModel {
         return table;
     }
 
-    public TableAliasCalculator tableAliasCalculator() {
-        return tableAliasCalculator;
+    public Map<SqlTable, String> tableAliases() {
+        return tableAliases;
     }
 
     public Optional<WhereModel> whereModel() {

--- a/src/main/java/org/mybatis/dynamic/sql/select/render/AbstractQueryRendererBuilder.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/render/AbstractQueryRendererBuilder.java
@@ -1,0 +1,44 @@
+/*
+ *    Copyright 2016-2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.dynamic.sql.select.render;
+
+import org.mybatis.dynamic.sql.render.RenderingStrategy;
+import org.mybatis.dynamic.sql.render.TableAliasCalculator;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public abstract class AbstractQueryRendererBuilder<T extends AbstractQueryRendererBuilder<T>> {
+    RenderingStrategy renderingStrategy;
+    AtomicInteger sequence;
+    TableAliasCalculator parentTableAliasCalculator;
+
+    public T withRenderingStrategy(RenderingStrategy renderingStrategy) {
+        this.renderingStrategy = renderingStrategy;
+        return getThis();
+    }
+
+    public T withSequence(AtomicInteger sequence) {
+        this.sequence = sequence;
+        return getThis();
+    }
+
+    public T withParentTableAliasCalculator(TableAliasCalculator parentTableAliasCalculator) {
+        this.parentTableAliasCalculator = parentTableAliasCalculator;
+        return getThis();
+    }
+
+    abstract T getThis();
+}

--- a/src/main/java/org/mybatis/dynamic/sql/select/render/AbstractQueryRendererBuilder.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/render/AbstractQueryRendererBuilder.java
@@ -15,10 +15,10 @@
  */
 package org.mybatis.dynamic.sql.select.render;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.mybatis.dynamic.sql.render.RenderingStrategy;
 import org.mybatis.dynamic.sql.render.TableAliasCalculator;
-
-import java.util.concurrent.atomic.AtomicInteger;
 
 public abstract class AbstractQueryRendererBuilder<T extends AbstractQueryRendererBuilder<T>> {
     RenderingStrategy renderingStrategy;

--- a/src/main/java/org/mybatis/dynamic/sql/select/render/JoinRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/render/JoinRenderer.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2020 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.mybatis.dynamic.sql.BasicColumn;
-import org.mybatis.dynamic.sql.select.QueryExpressionModel;
+import org.mybatis.dynamic.sql.render.TableAliasCalculator;
 import org.mybatis.dynamic.sql.select.join.JoinCriterion;
 import org.mybatis.dynamic.sql.select.join.JoinModel;
 import org.mybatis.dynamic.sql.select.join.JoinSpecification;
@@ -31,13 +31,13 @@ import org.mybatis.dynamic.sql.util.FragmentCollector;
 
 public class JoinRenderer {
     private final JoinModel joinModel;
-    private final QueryExpressionModel queryExpression;
     private final TableExpressionRenderer tableExpressionRenderer;
+    private final TableAliasCalculator tableAliasCalculator;
 
     private JoinRenderer(Builder builder) {
         joinModel = Objects.requireNonNull(builder.joinModel);
-        queryExpression = Objects.requireNonNull(builder.queryExpression);
         tableExpressionRenderer = Objects.requireNonNull(builder.tableExpressionRenderer);
+        tableAliasCalculator = Objects.requireNonNull(builder.tableAliasCalculator);
     }
 
     public FragmentAndParameters render() {
@@ -75,7 +75,7 @@ public class JoinRenderer {
     }
 
     private String applyTableAlias(BasicColumn column) {
-        return column.renderWithTableAlias(queryExpression.tableAliasCalculator());
+        return column.renderWithTableAlias(tableAliasCalculator);
     }
 
     public static Builder withJoinModel(JoinModel joinModel) {
@@ -84,21 +84,21 @@ public class JoinRenderer {
 
     public static class Builder {
         private JoinModel joinModel;
-        private QueryExpressionModel queryExpression;
         private TableExpressionRenderer tableExpressionRenderer;
+        private TableAliasCalculator tableAliasCalculator;
 
         public Builder withJoinModel(JoinModel joinModel) {
             this.joinModel = joinModel;
             return this;
         }
 
-        public Builder withQueryExpression(QueryExpressionModel queryExpression) {
-            this.queryExpression = queryExpression;
+        public Builder withTableExpressionRenderer(TableExpressionRenderer tableExpressionRenderer) {
+            this.tableExpressionRenderer = tableExpressionRenderer;
             return this;
         }
 
-        public Builder withTableExpressionRenderer(TableExpressionRenderer tableExpressionRenderer) {
-            this.tableExpressionRenderer = tableExpressionRenderer;
+        public Builder withTableAliasCalculator(TableAliasCalculator tableAliasCalculator) {
+            this.tableAliasCalculator = tableAliasCalculator;
             return this;
         }
 

--- a/src/main/java/org/mybatis/dynamic/sql/select/render/QueryExpressionRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/render/QueryExpressionRenderer.java
@@ -60,13 +60,13 @@ public class QueryExpressionRenderer {
 
     /**
      * This function calculates a table alias calculator to use in the current context. There are several
-     * possibilities: this could be a renderer for a regular select statement, or it could be a renderer for a table
+     * possibilities: this could be a renderer for a top level select statement, or it could be a renderer for a table
      * expression in a join, or a column to sub query where condition, or it could be a renderer for a select
-     * statement in an "exists" condition.
+     * statement in an "exists" condition in a where clause.
      *
-     * <p>In the case of "exists" conditions, we will have a parent table alias calculator. We want to give visibility
-     * to the aliases in the outer select statement to this renderer so columns in aliased tables can be used in exists
-     * conditions without having to re-specify the alias.
+     * <p>In the case of conditions in a where clause, we will have a parent table alias calculator. This will give
+     * visibility to the aliases in the outer select statement to this renderer so columns in aliased tables can be
+     * used in where clause sub query conditions without having to re-specify the alias.
      *
      * <p>Another complication is that we calculate aliases differently if there are joins and sub queries. The
      * cases are as follows:

--- a/src/main/java/org/mybatis/dynamic/sql/select/render/QueryExpressionRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/render/QueryExpressionRenderer.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 
 import org.mybatis.dynamic.sql.BasicColumn;
 import org.mybatis.dynamic.sql.TableExpression;
+import org.mybatis.dynamic.sql.render.ExplicitTableAliasCalculator;
 import org.mybatis.dynamic.sql.render.GuaranteedTableAliasCalculator;
 import org.mybatis.dynamic.sql.render.RenderingStrategy;
 import org.mybatis.dynamic.sql.render.TableAliasCalculator;
@@ -60,13 +61,13 @@ public class QueryExpressionRenderer {
         return queryExpression.joinModel().map(JoinModel::containsSubQueries).map(containsSubQueries -> {
             if (containsSubQueries) {
                 // if there are subQueries, then force explicit qualifiers
-                return TableAliasCalculator.of(queryExpression.tableAliases());
+                return ExplicitTableAliasCalculator.of(queryExpression.tableAliases());
             } else {
                 // there are joins, but no sub-queries. In this case, we can use the
                 // table names as qualifiers without requiring explicit qualifiers
                 return GuaranteedTableAliasCalculator.of(queryExpression.tableAliases());
             }
-        }).orElseGet(() -> TableAliasCalculator.of(queryExpression.tableAliases()));
+        }).orElseGet(() -> ExplicitTableAliasCalculator.of(queryExpression.tableAliases()));
     }
 
     public FragmentAndParameters render() {

--- a/src/main/java/org/mybatis/dynamic/sql/select/render/QueryExpressionRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/render/QueryExpressionRenderer.java
@@ -59,9 +59,10 @@ public class QueryExpressionRenderer {
     }
 
     /**
-     * This function calculates a table alias calculator to use in the current context. In general,
-     * there are two possibilities: this could be a renderer for a regular select statement, or it
-     * could be a renderer for a select statement in an "exists" condition.
+     * This function calculates a table alias calculator to use in the current context. There are several
+     * possibilities: this could be a renderer for a regular select statement, or it could be a renderer for a table
+     * expression in a join, or a column to sub query where condition, or it could be a renderer for a select
+     * statement in an "exists" condition.
      *
      * <p>In the case of "exists" conditions, we will have a parent table alias calculator. We want to give visibility
      * to the aliases in the outer select statement to this renderer so columns in aliased tables can be used in exists
@@ -91,7 +92,10 @@ public class QueryExpressionRenderer {
         if (parentTableAliasCalculator == null) {
             return baseTableAliasCalculator;
         } else {
-            return new TableAliasCalculatorWithParent(parentTableAliasCalculator, baseTableAliasCalculator);
+            return new TableAliasCalculatorWithParent.Builder()
+                    .withParent(parentTableAliasCalculator)
+                    .withChild(baseTableAliasCalculator)
+                    .build();
         }
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/select/render/QueryExpressionRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/render/QueryExpressionRenderer.java
@@ -58,6 +58,29 @@ public class QueryExpressionRenderer {
                 .build();
     }
 
+    /**
+     * This function calculates a table alias calculator to use in the current context. In general,
+     * there are two possibilities: this could be a renderer for a regular select statement, or it
+     * could be a renderer for a select statement in an "exists" condition.
+     *
+     * <p>In the case of "exists" conditions, we will have a parent table alias calculator. We want to give visibility
+     * to the aliases in the outer select statement to this renderer so columns in aliased tables can be used in exists
+     * conditions without having to re-specify the alias.
+     *
+     * <p>Another complication is that we calculate aliases differently if there are joins and sub queries. The
+     * cases are as follows:
+     *
+     * <ol>
+     *     <li>If there are no joins, then we will only use aliases that are explicitly set by the user</li>
+     *     <lI>If there are joins and sub queries, we will also only use explicit aliases</lI>
+     *     <li>If there are joins, but no sub queries, then we will automatically use the table name
+     *     as an alias if no explicit alias has been specified</li>
+     * </ol>
+     *
+     * @param queryExpression the model to render
+     * @param parentTableAliasCalculator table alias calculator from the parent query
+     * @return a table alias calculator appropriate for this context
+     */
     private TableAliasCalculator calculateTableAliasCalculator(QueryExpressionModel queryExpression,
                                                                TableAliasCalculator parentTableAliasCalculator) {
         TableAliasCalculator baseTableAliasCalculator = queryExpression.joinModel()

--- a/src/main/java/org/mybatis/dynamic/sql/select/render/SelectRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/render/SelectRenderer.java
@@ -40,7 +40,7 @@ public class SelectRenderer {
     private SelectRenderer(Builder builder) {
         selectModel = Objects.requireNonNull(builder.selectModel);
         renderingStrategy = Objects.requireNonNull(builder.renderingStrategy);
-        if(builder.sequence == null) {
+        if (builder.sequence == null) {
             sequence = new AtomicInteger(1);
         } else {
             sequence = builder.sequence;

--- a/src/main/java/org/mybatis/dynamic/sql/where/render/CriterionRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/render/CriterionRenderer.java
@@ -127,6 +127,7 @@ public class CriterionRenderer implements SqlCriterionVisitor<Optional<RenderedC
                 .withSelectModel(existsPredicate.selectModelBuilder().build())
                 .withRenderingStrategy(renderingStrategy)
                 .withSequence(sequence)
+                .withParentTableAliasCalculator(tableAliasCalculator)
                 .build()
                 .render();
 

--- a/src/main/java/org/mybatis/dynamic/sql/where/render/WhereConditionVisitor.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/render/WhereConditionVisitor.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -96,6 +96,7 @@ public class WhereConditionVisitor<T> implements ConditionVisitor<T, FragmentAnd
         SelectStatementProvider selectStatement = SelectRenderer.withSelectModel(condition.selectModel())
                 .withRenderingStrategy(renderingStrategy)
                 .withSequence(sequence)
+                .withParentTableAliasCalculator(tableAliasCalculator)
                 .build()
                 .render();
 

--- a/src/test/java/examples/animal/data/AnimalDataTest.java
+++ b/src/test/java/examples/animal/data/AnimalDataTest.java
@@ -53,8 +53,8 @@ import org.mybatis.dynamic.sql.insert.render.BatchInsert;
 import org.mybatis.dynamic.sql.insert.render.GeneralInsertStatementProvider;
 import org.mybatis.dynamic.sql.insert.render.InsertSelectStatementProvider;
 import org.mybatis.dynamic.sql.insert.render.InsertStatementProvider;
+import org.mybatis.dynamic.sql.render.ExplicitTableAliasCalculator;
 import org.mybatis.dynamic.sql.render.RenderingStrategies;
-import org.mybatis.dynamic.sql.render.TableAliasCalculator;
 import org.mybatis.dynamic.sql.select.SelectModel;
 import org.mybatis.dynamic.sql.select.render.SelectStatementProvider;
 import org.mybatis.dynamic.sql.update.render.UpdateStatementProvider;
@@ -314,7 +314,7 @@ class AnimalDataTest {
 
             WhereClauseProvider whereClause = where(id, isEqualTo(1), or(bodyWeight, isGreaterThan(1.0)))
                     .build()
-                    .render(RenderingStrategies.MYBATIS3, TableAliasCalculator.of(animalData, "a"));
+                    .render(RenderingStrategies.MYBATIS3, ExplicitTableAliasCalculator.of(animalData, "a"));
 
             assertThat(whereClause.getWhereClause()).isEqualTo("where (a.id = #{parameters.p1,jdbcType=INTEGER} or a.body_weight > #{parameters.p2,jdbcType=DOUBLE})");
 
@@ -347,7 +347,8 @@ class AnimalDataTest {
 
             WhereClauseProvider whereClause = where(id, isLessThan(60))
                     .build()
-                    .render(RenderingStrategies.MYBATIS3, TableAliasCalculator.of(animalData, "b"),  "whereClauseProvider");
+                    .render(RenderingStrategies.MYBATIS3, ExplicitTableAliasCalculator.of(animalData, "b"),
+                            "whereClauseProvider");
 
             List<AnimalData> animals = mapper.selectWithWhereClauseAliasLimitAndOffset(whereClause, 3, 24);
             assertAll(

--- a/src/test/java/org/mybatis/dynamic/sql/mybatis3/CriterionRendererTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/mybatis3/CriterionRendererTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import org.mybatis.dynamic.sql.ColumnAndConditionCriterion;
 import org.mybatis.dynamic.sql.SqlBuilder;
 import org.mybatis.dynamic.sql.SqlColumn;
 import org.mybatis.dynamic.sql.SqlTable;
+import org.mybatis.dynamic.sql.render.ExplicitTableAliasCalculator;
 import org.mybatis.dynamic.sql.render.RenderingStrategies;
 import org.mybatis.dynamic.sql.render.TableAliasCalculator;
 import org.mybatis.dynamic.sql.util.FragmentAndParameters;
@@ -74,7 +75,7 @@ class CriterionRendererTest {
         CriterionRenderer renderer = new CriterionRenderer.Builder()
                 .withSequence(sequence)
                 .withRenderingStrategy(RenderingStrategies.MYBATIS3)
-                .withTableAliasCalculator(TableAliasCalculator.of(tableAliases))
+                .withTableAliasCalculator(ExplicitTableAliasCalculator.of(tableAliases))
                 .build();
 
         assertThat(criterion.accept(renderer)).hasValueSatisfying(rc -> {
@@ -127,7 +128,7 @@ class CriterionRendererTest {
         CriterionRenderer renderer = new CriterionRenderer.Builder()
                 .withSequence(sequence)
                 .withRenderingStrategy(RenderingStrategies.MYBATIS3)
-                .withTableAliasCalculator(TableAliasCalculator.of(tableAliases))
+                .withTableAliasCalculator(ExplicitTableAliasCalculator.of(tableAliases))
                 .build();
 
         assertThat(criterion.accept(renderer)).hasValueSatisfying(rc -> {

--- a/src/test/java/org/mybatis/dynamic/sql/subselect/FooDynamicSqlSupport.java
+++ b/src/test/java/org/mybatis/dynamic/sql/subselect/FooDynamicSqlSupport.java
@@ -1,0 +1,37 @@
+/*
+ *    Copyright 2016-2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.dynamic.sql.subselect;
+
+import org.mybatis.dynamic.sql.SqlColumn;
+import org.mybatis.dynamic.sql.SqlTable;
+
+import java.sql.JDBCType;
+import java.util.Date;
+
+public class FooDynamicSqlSupport {
+    public static final Foo foo = new Foo();
+    public static final SqlColumn<Date> column1 = foo.column1;
+    static final SqlColumn<Integer> column2 = foo.column2;
+
+    public static class Foo extends SqlTable {
+        public final SqlColumn<Date> column1 = column("column1", JDBCType.DATE);
+        public final SqlColumn<Integer> column2 = column("column2", JDBCType.INTEGER);
+
+        public Foo() {
+            super("foo");
+        }
+    }
+}

--- a/src/test/java/org/mybatis/dynamic/sql/subselect/SubSelectTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/subselect/SubSelectTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2020 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,29 +18,30 @@ package org.mybatis.dynamic.sql.subselect;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mybatis.dynamic.sql.SqlBuilder.*;
+import static org.mybatis.dynamic.sql.subselect.FooDynamicSqlSupport.*;
 
-import java.sql.JDBCType;
 import java.util.Date;
 
 import org.junit.jupiter.api.Test;
-import org.mybatis.dynamic.sql.SqlColumn;
-import org.mybatis.dynamic.sql.SqlTable;
 import org.mybatis.dynamic.sql.render.RenderingStrategies;
 import org.mybatis.dynamic.sql.select.render.SelectStatementProvider;
 
 class SubSelectTest {
 
-    static final SqlTable table = SqlTable.of("foo");
-    static final SqlColumn<Date> column1 = table.column("column1", JDBCType.DATE);
-    static final SqlColumn<Integer> column2 = table.column("column2", JDBCType.INTEGER);
-
     @Test
     void testInSubSelect() {
         Date d = new Date();
 
+        Foo foo2 = new Foo();
+
         SelectStatementProvider selectStatement = select(column1.as("A_COLUMN1"), column2)
-                .from(table, "a")
-                .where(column2, isIn(select(column2).from(table).where(column2, isEqualTo(3))))
+                .from(foo, "a")
+                .where(column2, isIn(
+                        select(foo2.column2)
+                                .from(foo2)
+                                .where(foo2.column2, isEqualTo(3))
+                    )
+                )
                 .and(column1, isLessThan(d))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
@@ -61,9 +62,16 @@ class SubSelectTest {
     void testNotInSubSelect() {
         Date d = new Date();
 
+        Foo foo2 = new Foo();
+
         SelectStatementProvider selectStatement = select(column1.as("A_COLUMN1"), column2)
-                .from(table, "a")
-                .where(column2, isNotIn(select(column2).from(table).where(column2, isEqualTo(3))))
+                .from(foo, "a")
+                .where(column2, isNotIn(
+                        select(foo2.column2)
+                                .from(foo2)
+                                .where(foo2.column2, isEqualTo(3))
+                    )
+                )
                 .and(column1, isLessThan(d))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);

--- a/src/test/java/org/mybatis/dynamic/sql/where/render/CriterionRendererTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/where/render/CriterionRendererTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 the original author or authors.
+ *    Copyright 2016-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.mybatis.dynamic.sql.ColumnAndConditionCriterion;
 import org.mybatis.dynamic.sql.SqlColumn;
 import org.mybatis.dynamic.sql.SqlTable;
+import org.mybatis.dynamic.sql.render.ExplicitTableAliasCalculator;
 import org.mybatis.dynamic.sql.render.RenderingStrategies;
 import org.mybatis.dynamic.sql.render.TableAliasCalculator;
 import org.mybatis.dynamic.sql.util.FragmentAndParameters;
@@ -74,7 +75,7 @@ class CriterionRendererTest {
         CriterionRenderer renderer = new CriterionRenderer.Builder()
                 .withSequence(sequence)
                 .withRenderingStrategy(RenderingStrategies.MYBATIS3)
-                .withTableAliasCalculator(TableAliasCalculator.of(tableAliases))
+                .withTableAliasCalculator(ExplicitTableAliasCalculator.of(tableAliases))
                 .build();
 
         assertThat(criterion.accept(renderer)).hasValueSatisfying(rc -> {

--- a/src/test/kotlin/examples/kotlin/mybatis3/joins/ExistsTest.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/joins/ExistsTest.kt
@@ -95,6 +95,49 @@ class ExistsTest {
     }
 
     @Test
+    fun testExistsPropagatedAliases() {
+        newSession().use { session ->
+            val mapper = session.getMapper(CommonSelectMapper::class.java)
+
+            val selectStatement = select(itemMaster.allColumns()) {
+                from(itemMaster, "im")
+                where {
+                    exists {
+                        select(orderLine.allColumns()) {
+                            from(orderLine, "ol")
+                            where { orderLine.itemId isEqualTo itemMaster.itemId }
+                        }
+                    }
+                }
+                orderBy(itemMaster.itemId)
+            }
+
+            val expectedStatement: String = "select im.* from ItemMaster im" +
+                    " where exists (select ol.* from OrderLine ol where ol.item_id = im.item_id)" +
+                    " order by item_id"
+            assertThat(selectStatement.selectStatement).isEqualTo(expectedStatement)
+
+            val rows = mapper.selectManyMappedRows(selectStatement)
+            assertThat(rows).hasSize(3)
+
+            with(rows[0]) {
+                assertThat(this).containsEntry("ITEM_ID", 22)
+                assertThat(this).containsEntry("DESCRIPTION", "Helmet")
+            }
+
+            with(rows[1]) {
+                assertThat(this).containsEntry("ITEM_ID", 33)
+                assertThat(this).containsEntry("DESCRIPTION", "First Base Glove")
+            }
+
+            with(rows[2]) {
+                assertThat(this).containsEntry("ITEM_ID", 44)
+                assertThat(this).containsEntry("DESCRIPTION", "Outfield Glove")
+            }
+        }
+    }
+
+    @Test
     fun testNotExists() {
         newSession().use { session ->
             val mapper = session.getMapper(CommonSelectMapper::class.java)

--- a/src/test/resources/examples/kotlin/mybatis3/joins/CreateJoinDB.sql
+++ b/src/test/resources/examples/kotlin/mybatis3/joins/CreateJoinDB.sql
@@ -1,5 +1,5 @@
 --
---    Copyright 2016-2019 the original author or authors.
+--    Copyright 2016-2022 the original author or authors.
 --
 --    Licensed under the Apache License, Version 2.0 (the "License");
 --    you may not use this file except in compliance with the License.

--- a/src/test/resources/examples/kotlin/mybatis3/joins/CreateJoinDB.sql
+++ b/src/test/resources/examples/kotlin/mybatis3/joins/CreateJoinDB.sql
@@ -68,7 +68,7 @@ insert into ItemMaster(item_id, description) values(44, 'Outfield Glove');
 insert into ItemMaster(item_id, description) values(55, 'Catcher Glove');
 
 insert into OrderLine(order_id, item_id, line_number, quantity) values(1, 22, 1, 1);
-insert into OrderLine(order_id, item_id, line_number, quantity) values(1, 33, 1, 1);
+insert into OrderLine(order_id, item_id, line_number, quantity) values(1, 33, 2, 1);
 insert into OrderLine(order_id, item_id, line_number, quantity) values(2, 22, 1, 1);
 insert into OrderLine(order_id, item_id, line_number, quantity) values(2, 44, 2, 1);
 insert into OrderLine(order_id, item_id, line_number, quantity) values(2, 66, 3, 6);


### PR DESCRIPTION
When there is a sub query in a where clause (either with an exists clause or a sub query to column condition) it is very common to reference columns in the "outer" query. With this change, if the outer table has an alias, then the alias will automatically be applied to columns in the sub query. This makes it possible to reference outer query columns without having to re specify and alias.

Resolves #437 