### PR TITLE
Add CommonGeneralInsert mapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,8 @@ The pull request for this change is ([#550](https://github.com/mybatis/mybatis-d
 2. Deprecated Kotlin DSL functions have been removed, as well as deprecated support for "EmptyListCallback" in the "in"
    conditions. ([#548](https://github.com/mybatis/mybatis-dynamic-sql/pull/548))
 3. Refactored the common insert mapper support for MyBatis3 by adding a CommonGeneralInsertMapper that can be used
-   without a class that matches the table row. It includes methods for general insert and insert select. 
+   without a class that matches the table row. It includes methods for general insert and insert select.
+   ([#570](https://github.com/mybatis/mybatis-dynamic-sql/pull/570))
       
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ The pull request for this change is ([#550](https://github.com/mybatis/mybatis-d
    please test to make sure it is supported in your database. ([#544](https://github.com/mybatis/mybatis-dynamic-sql/pull/544))
 2. Deprecated Kotlin DSL functions have been removed, as well as deprecated support for "EmptyListCallback" in the "in"
    conditions. ([#548](https://github.com/mybatis/mybatis-dynamic-sql/pull/548))
+3. Refactored the common insert mapper support for MyBatis3 by adding a CommonGeneralInsertMapper that can be used
+   without a class that matches the table row. It includes methods for general insert and insert select. 
       
 
 

--- a/src/main/java/org/mybatis/dynamic/sql/util/mybatis3/CommonGeneralInsertMapper.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/mybatis3/CommonGeneralInsertMapper.java
@@ -1,0 +1,49 @@
+/*
+ *    Copyright 2016-2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.dynamic.sql.util.mybatis3;
+
+import org.apache.ibatis.annotations.InsertProvider;
+import org.mybatis.dynamic.sql.insert.render.GeneralInsertStatementProvider;
+import org.mybatis.dynamic.sql.insert.render.InsertSelectStatementProvider;
+import org.mybatis.dynamic.sql.util.SqlProviderAdapter;
+
+/**
+ * This is a general purpose mapper for executing various non-typed insert statements (general inserts and insert
+ * selects). This mapper is appropriate for insert statements that do NOT expect generated keys.
+ */
+public interface CommonGeneralInsertMapper {
+    /**
+     * Execute an insert statement with input fields supplied directly.
+     *
+     * @param insertStatement
+     *            the insert statement
+     *
+     * @return the number of rows affected
+     */
+    @InsertProvider(type = SqlProviderAdapter.class, method = "generalInsert")
+    int generalInsert(GeneralInsertStatementProvider insertStatement);
+
+    /**
+     * Execute an insert statement with input fields supplied by a select statement.
+     *
+     * @param insertSelectStatement
+     *            the insert statement
+     *
+     * @return the number of rows affected
+     */
+    @InsertProvider(type = SqlProviderAdapter.class, method = "insertSelect")
+    int insertSelect(InsertSelectStatementProvider insertSelectStatement);
+}

--- a/src/main/java/org/mybatis/dynamic/sql/util/mybatis3/CommonInsertMapper.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/mybatis3/CommonInsertMapper.java
@@ -20,8 +20,6 @@ import java.util.List;
 import org.apache.ibatis.annotations.Flush;
 import org.apache.ibatis.annotations.InsertProvider;
 import org.apache.ibatis.executor.BatchResult;
-import org.mybatis.dynamic.sql.insert.render.GeneralInsertStatementProvider;
-import org.mybatis.dynamic.sql.insert.render.InsertSelectStatementProvider;
 import org.mybatis.dynamic.sql.insert.render.InsertStatementProvider;
 import org.mybatis.dynamic.sql.insert.render.MultiRowInsertStatementProvider;
 import org.mybatis.dynamic.sql.util.SqlProviderAdapter;
@@ -33,7 +31,7 @@ import org.mybatis.dynamic.sql.util.SqlProviderAdapter;
  * @param <T>
  *            the type of record associated with this mapper
  */
-public interface CommonInsertMapper<T> {
+public interface CommonInsertMapper<T> extends CommonGeneralInsertMapper {
     /**
      * Execute an insert statement with input fields mapped to values in a POJO.
      *
@@ -44,28 +42,6 @@ public interface CommonInsertMapper<T> {
      */
     @InsertProvider(type = SqlProviderAdapter.class, method = "insert")
     int insert(InsertStatementProvider<T> insertStatement);
-
-    /**
-     * Execute an insert statement with input fields supplied directly.
-     *
-     * @param insertStatement
-     *            the insert statement
-     *
-     * @return the number of rows affected
-     */
-    @InsertProvider(type = SqlProviderAdapter.class, method = "generalInsert")
-    int generalInsert(GeneralInsertStatementProvider insertStatement);
-
-    /**
-     * Execute an insert statement with input fields supplied by a select statement.
-     *
-     * @param insertSelectStatement
-     *            the insert statement
-     *
-     * @return the number of rows affected
-     */
-    @InsertProvider(type = SqlProviderAdapter.class, method = "insertSelect")
-    int insertSelect(InsertSelectStatementProvider insertSelectStatement);
 
     /**
      * Execute an insert statement that inserts multiple rows. The row values are supplied by mapping to values in a

--- a/src/site/markdown/docs/mybatis3.md
+++ b/src/site/markdown/docs/mybatis3.md
@@ -23,14 +23,15 @@ JDBC template.
 These mappers provide utility functions that execute simple queries. They can be used as-as, or can be extended. They
 provide methods as follows:
 
-| Mapper | Methods(s) |
-|---|---|
-| `org.mybatis.dynamic.sql.util.mybatis3.CommonCountMapper` | `long count(SelectStatementProvider)` |
-| `org.mybatis.dynamic.sql.util.mybatis3.CommonDeleteMapper` | `int delete(DeleteStatementProvider)`
-| `org.mybatis.dynamic.sql.util.mybatis3.CommonInsertMapper<T>` | `int insert(InsertStatementProvider<T>)`<br/>`int generalInsert(GeneralInsertStatementProvider)`<br/>`int insertSelect(InsertSelectStatementProvider)`<br/>`int insertMultiple(MultiRowInsertStatementProvider<T>)` |
-| `org.mybatis.dynamic.sql.util.mybatis3.CommonUpdateMapper` | `int update(UpdateStatementProvider)` |
+| Mapper                                                                                                 | Methods(s) |
+|--------------------------------------------------------------------------------------------------------|---|
+| `org.mybatis.dynamic.sql.util.mybatis3.CommonCountMapper`                                              | `long count(SelectStatementProvider)` |
+| `org.mybatis.dynamic.sql.util.mybatis3.CommonDeleteMapper`                                             | `int delete(DeleteStatementProvider)`
+| `org.mybatis.dynamic.sql.util.mybatis3.CommonInsertMapper<T>`<br/>(extends `CommonGeneralInsertMapper`) | `int insert(InsertStatementProvider<T>)`<br/>`int insertMultiple(MultiRowInsertStatementProvider<T>)` |
+| `org.mybatis.dynamic.sql.util.mybatis3.CommonGeneralInsertMapper`                                      | `int generalInsert(GeneralInsertStatementProvider)`<br/>`int insertSelect(InsertSelectStatementProvider)` |
+| `org.mybatis.dynamic.sql.util.mybatis3.CommonUpdateMapper`                                             | `int update(UpdateStatementProvider)` |
 
-These mappers, as well as the common selectmapper, can be used to create a general purpose CRUD mapper as follows:
+These mappers, as well as the `CommonSelectMapper`, can be used to create a general purpose CRUD mapper as follows:
 
 ```java
 import org.apache.ibatis.annotations.Mapper;


### PR DESCRIPTION
This mapper can be used to run the insert statements that do not require a class matching a table row. This includes the general insert, and insert select.
