### PR TITLE
[Kotlin] Deprecate the general and/or methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ want this to look more like true SQL, you can write code like this:
 private final WhereApplier commonWhere = where(id, isEqualTo(1)).or(occupation, isNull()).toWhereApplier();
 ```
 
-This uses a `where` method from `SqlBuilder`. 
+This uses a `where` method from the `SqlBuilder` class. 
 
 ### "Having" Clause Support
 
@@ -59,7 +59,8 @@ as "having" is only needed if there is a "group by".
 
 In the Kotlin DSL, the "group by" restriction is not present because of the free form nature of that DSL - but you 
 should probably only use "having" if there is a "group by". Also note that the freestanding "and" and "or"
-functions in the Kotlin DSL still only apply to the where clause.
+functions in the Kotlin DSL still only apply to the where clause. For this reason, the freestanding "and" and "or"
+methods are deprecated. Please only use the "and" and "or" methods inside a "where" or "having" lambda.
 
 The pull request for this change is ([#550](https://github.com/mybatis/mybatis-dynamic-sql/pull/550))
 
@@ -110,6 +111,7 @@ The pull request for this change is ([#591](https://github.com/mybatis/mybatis-d
    ([#572](https://github.com/mybatis/mybatis-dynamic-sql/pull/572))
 5. Add `SqlBuilder.concat` and the equivalent in Kotlin. This is a concatenate function that works on more databases.
    ([#573](https://github.com/mybatis/mybatis-dynamic-sql/pull/573))
+6. Several classes and methods in the Kotlin DSL are deprecated in response to the new "having" support
 
 ## Release 1.4.1 - October 7, 2022
 

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinBaseBuilders.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinBaseBuilders.kt
@@ -51,20 +51,24 @@ abstract class KotlinBaseBuilder<D : AbstractWhereStarter<*,*>> {
         getDsl().where(criteria)
     }
 
+    @Deprecated("Please move the \"and\" function into the where lambda. If the where lambda has more than one condition, you may need to surround the existing conditions with \"group\" first.")
     fun and(criteria: GroupingCriteriaReceiver): Unit =
         GroupingCriteriaCollector().apply(criteria).let {
             getDsl().where().and(it.initialCriterion, it.subCriteria)
         }
 
+    @Deprecated("Please move the \"and\" function into the where lambda. If the where lambda has more than one condition, you may need to surround the existing conditions with \"group\" first.")
     fun and(criteria: List<AndOrCriteriaGroup>) {
         getDsl().where().and(criteria)
     }
 
+    @Deprecated("Please move the \"or\" function into the where lambda. If the where lambda has more than one condition, you may need to surround the existing conditions with \"group\" first.")
     fun or(criteria: GroupingCriteriaReceiver): Unit =
         GroupingCriteriaCollector().apply(criteria).let {
             getDsl().where().or(it.initialCriterion, it.subCriteria)
         }
 
+    @Deprecated("Please move the \"or\" function into the where lambda. If the where lambda has more than one condition, you may need to surround the existing conditions with \"group\" first.")
     fun or(criteria: List<AndOrCriteriaGroup>) {
         getDsl().where().or(criteria)
     }

--- a/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonMapperTest.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonMapperTest.kt
@@ -63,8 +63,10 @@ class PersonMapperTest {
             val mapper = session.getMapper(PersonMapper::class.java)
 
             val rows = mapper.select {
-                where { id isEqualTo 1 }
-                or { occupation.isNull() }
+                where {
+                    id isEqualTo 1
+                    or { occupation.isNull() }
+                }
             }
 
             assertThat(rows).hasSize(3)
@@ -106,8 +108,10 @@ class PersonMapperTest {
             val mapper = session.getMapper(PersonMapper::class.java)
 
             val rows = mapper.selectDistinct {
-                where { id isGreaterThan 1 }
-                or { occupation.isNull() }
+                where {
+                    id isGreaterThan 1
+                    or { occupation.isNull() }
+                }
             }
 
             assertThat(rows).hasSize(5)
@@ -375,8 +379,10 @@ class PersonMapperTest {
 
             rows = mapper.update {
                 set(occupation) equalTo "Programmer"
-                where { id isEqualTo 100 }
-                and { firstName isEqualTo "Joe" }
+                where {
+                    id isEqualTo 100
+                    and { firstName isEqualTo "Joe" }
+                }
             }
 
             assertThat(rows).isEqualTo(1)
@@ -494,8 +500,10 @@ class PersonMapperTest {
             val mapper = session.getMapper(PersonMapper::class.java)
 
             val rows = mapper.count {
-                where { employed.isTrue() }
-                and { occupation isEqualTo "Brontosaurus Operator" }
+                where {
+                    employed.isTrue()
+                    and { occupation isEqualTo "Brontosaurus Operator" }
+                }
             }
 
             assertThat(rows).isEqualTo(2L)
@@ -524,10 +532,12 @@ class PersonMapperTest {
             val mapper = session.getMapper(PersonMapper::class.java)
 
             val rows = mapper.count {
-                where { id isEqualTo 1 }
-                or {
-                    id isEqualTo 2
-                    or { id isEqualTo 3 }
+                where {
+                    id isEqualTo 1
+                    or {
+                        id isEqualTo 2
+                        or { id isEqualTo 3 }
+                    }
                 }
             }
 
@@ -541,10 +551,12 @@ class PersonMapperTest {
             val mapper = session.getMapper(PersonMapper::class.java)
 
             val rows = mapper.count {
-                where { id isLessThan 5 }
-                and {
-                    id isLessThan 3
-                    and { id isEqualTo 1 }
+                where {
+                    id isLessThan 5
+                    and {
+                        id isLessThan 3
+                        and { id isEqualTo 1 }
+                    }
                 }
             }
 

--- a/src/test/kotlin/examples/kotlin/mybatis3/general/GeneralKotlinTest.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/general/GeneralKotlinTest.kt
@@ -163,8 +163,10 @@ class GeneralKotlinTest {
             val mapper = session.getMapper(PersonMapper::class.java)
 
             val deleteStatement = deleteFrom(person) {
-                where { id isLessThan 4 }
-                and { occupation.isNotNull() }
+                where {
+                    id isLessThan 4
+                    and { occupation.isNotNull() }
+                }
             }
 
             assertThat(deleteStatement.deleteStatement).isEqualTo(
@@ -183,8 +185,10 @@ class GeneralKotlinTest {
             val mapper = session.getMapper(PersonMapper::class.java)
 
             val deleteStatement = deleteFrom(person) {
-                where { id isLessThan 4 }
-                or { occupation.isNotNull() }
+                where {
+                    id isLessThan 4
+                    or { occupation.isNotNull() }
+                }
             }
 
             assertThat(deleteStatement.deleteStatement).isEqualTo(
@@ -204,10 +208,12 @@ class GeneralKotlinTest {
 
             val deleteStatement = deleteFrom(person) {
                 where {
-                    id isLessThan 4
-                    or { occupation.isNotNull() }
+                    group {
+                        id isLessThan 4
+                        or { occupation.isNotNull() }
+                    }
+                    and { employed isEqualTo true }
                 }
-                and { employed isEqualTo true }
             }
 
             val expected = "delete from Person " +
@@ -229,10 +235,12 @@ class GeneralKotlinTest {
             val mapper = session.getMapper(PersonMapper::class.java)
 
             val deleteStatement = deleteFrom(person) {
-                where { id isLessThan 4 }
-                or {
-                    occupation.isNotNull()
-                    and { employed isEqualTo true }
+                where {
+                    id isLessThan 4
+                    or {
+                        occupation.isNotNull()
+                        and { employed isEqualTo true }
+                    }
                 }
             }
 
@@ -255,10 +263,12 @@ class GeneralKotlinTest {
             val mapper = session.getMapper(PersonMapper::class.java)
 
             val deleteStatement = deleteFrom(person) {
-                where { id isLessThan 4 }
-                and {
-                    occupation.isNotNull()
-                    and { employed isEqualTo true }
+                where {
+                    id isLessThan 4
+                    and {
+                        occupation.isNotNull()
+                        and { employed isEqualTo true }
+                    }
                 }
             }
 
@@ -286,10 +296,12 @@ class GeneralKotlinTest {
             ) {
                 from(person)
                 where {
-                    id isLessThan 4
+                    group {
+                        id isLessThan 4
+                        and { occupation.isNotNull() }
+                    }
                     and { occupation.isNotNull() }
                 }
-                and { occupation.isNotNull() }
                 orderBy(id)
                 limit(3)
             }
@@ -320,10 +332,12 @@ class GeneralKotlinTest {
             ) {
                 from(person)
                 where {
-                    id  isLessThan 4
+                    group {
+                        id isLessThan 4
+                        and { occupation.isNotNull() }
+                    }
                     and { occupation.isNotNull() }
                 }
-                and { occupation.isNotNull() }
                 orderBy(id)
                 limit(3)
             }
@@ -392,12 +406,14 @@ class GeneralKotlinTest {
                 join(address) {
                     on(addressId) equalTo address.id
                 }
-                where { id isLessThan 5 }
-                and {
-                    id isLessThan 4
+                where {
+                    id isLessThan 5
                     and {
-                        id isLessThan 3
-                        and { id isLessThan 2 }
+                        id isLessThan 4
+                        and {
+                            id isLessThan 3
+                            and { id isLessThan 2 }
+                        }
                     }
                 }
             }
@@ -433,12 +449,14 @@ class GeneralKotlinTest {
                 join(address) {
                     on(addressId) equalTo address.id
                 }
-                where { id isEqualTo 5 }
-                or {
-                    id  isEqualTo 4
+                where {
+                    id isEqualTo 5
                     or {
-                        id isEqualTo 3
-                        or { id isEqualTo 2 }
+                        id  isEqualTo 4
+                        or {
+                            id isEqualTo 3
+                            or { id isEqualTo 2 }
+                        }
                     }
                 }
                 orderBy(id)
@@ -473,12 +491,14 @@ class GeneralKotlinTest {
                 addressId
             ) {
                 from(person)
-                where { id isLessThan 5 }
-                and {
-                    id isLessThan 4
+                where {
+                    id isLessThan 5
                     and {
-                        id isLessThan 3
-                        and { id isLessThan 2 }
+                        id isLessThan 4
+                        and {
+                            id isLessThan 3
+                            and { id isLessThan 2 }
+                        }
                     }
                 }
                 orderBy(id)
@@ -519,12 +539,14 @@ class GeneralKotlinTest {
                 addressId
             ) {
                 from(person)
-                where { id isEqualTo 5 }
-                or {
-                    id isEqualTo 4
+                where {
+                    id isEqualTo 5
                     or {
-                        id isEqualTo 3
-                        or { id isEqualTo 2 }
+                        id isEqualTo 4
+                        or {
+                            id isEqualTo 3
+                            or { id isEqualTo 2 }
+                        }
                     }
                 }
                 orderBy(id)
@@ -559,12 +581,14 @@ class GeneralKotlinTest {
     fun testRawSelectWithoutFrom() {
         assertThatExceptionOfType(KInvalidSQLException::class.java).isThrownBy {
             select(id `as` "A_ID", firstName, lastName, birthDate, employed, occupation, addressId) {
-                where { id isEqualTo 5 }
-                or {
-                    id isEqualTo 4
+                where {
+                    id isEqualTo 5
                     or {
-                        id isEqualTo 3
-                        or { id isEqualTo 2 }
+                        id isEqualTo 4
+                        or {
+                            id isEqualTo 3
+                            or { id isEqualTo 2 }
+                        }
                     }
                 }
                 orderBy(id)
@@ -577,12 +601,14 @@ class GeneralKotlinTest {
     fun testRawCountWithoutFrom() {
         assertThatExceptionOfType(KInvalidSQLException::class.java).isThrownBy {
             count(id) {
-                where { id isEqualTo 5 }
-                or {
-                    id isEqualTo 4
+                where {
+                    id isEqualTo 5
                     or {
-                        id isEqualTo 3
-                        or { id isEqualTo 2 }
+                        id isEqualTo 4
+                        or {
+                            id isEqualTo 3
+                            or { id isEqualTo 2 }
+                        }
                     }
                 }
             }
@@ -711,10 +737,12 @@ class GeneralKotlinTest {
 
             val updateStatement = update(person) {
                 set(firstName) equalTo "Sam"
-                where { firstName isEqualTo "Fred" }
-                or {
-                    id isEqualTo 5
-                    or { id isEqualTo 6 }
+                where {
+                    firstName isEqualTo "Fred"
+                    or {
+                        id isEqualTo 5
+                        or { id isEqualTo 6 }
+                    }
                 }
             }
 
@@ -738,10 +766,12 @@ class GeneralKotlinTest {
 
             val updateStatement = update(person) {
                 set(firstName) equalTo "Sam"
-                where { firstName isEqualTo "Fred" }
-                and {
-                    id isEqualTo 1
-                    or { id isEqualTo 6 }
+                where {
+                    firstName isEqualTo "Fred"
+                    and {
+                        id isEqualTo 1
+                        or { id isEqualTo 6 }
+                    }
                 }
             }
 
@@ -765,8 +795,10 @@ class GeneralKotlinTest {
 
             val updateStatement = update(person) {
                 set(firstName) equalTo  "Sam"
-                where { firstName isEqualTo "Fred" }
-                or { id isEqualTo 3 }
+                where {
+                    firstName isEqualTo "Fred"
+                    or { id isEqualTo 3 }
+                }
             }
 
             assertThat(updateStatement.updateStatement).isEqualTo(

--- a/src/test/kotlin/examples/kotlin/mybatis3/general/KGroupingTest.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/general/KGroupingTest.kt
@@ -52,13 +52,15 @@ class KGroupingTest {
         val selectStatement = select(A, B, C) {
             from(foo)
             where {
-                A (isBetween(1).and(5).map { it + 3 }.filter{ _ -> true })
-                or { A (isLessThanOrEqualTo(3).map { it + 6 }.filter { true }) }
-                or { A isNotEqualTo 9 }
-                or { C isLike "Fred%" }
+                group {
+                    A(isBetween(1).and(5).map { it + 3 }.filter { _ -> true })
+                    or { A(isLessThanOrEqualTo(3).map { it + 6 }.filter { true }) }
+                    or { A isNotEqualTo 9 }
+                    or { C isLike "Fred%" }
+                }
+                and { B isEqualTo 3 }
+                or { add(A, B) isGreaterThan 4 }
             }
-            and { B isEqualTo 3 }
-            or { add(A, B) isGreaterThan 4 }
         }
 
         val expected = "select A, B, C" +
@@ -83,16 +85,18 @@ class KGroupingTest {
             from(foo)
             where {
                 group {
-                    A isEqualTo 1
-                    or { A isGreaterThan 5 }
+                    group {
+                        A isEqualTo 1
+                        or { A isGreaterThan 5 }
+                    }
+                    and { B isEqualTo 1 }
+                    or {
+                        A isLessThan 0
+                        and { B isEqualTo 2 }
+                    }
                 }
-                and { B isEqualTo 1 }
-                or {
-                    A isLessThan 0
-                    and { B isEqualTo 2 }
-                }
+                and { C isEqualTo "Fred" }
             }
-            and { C isEqualTo "Fred" }
         }
 
         val expected = "select A, B, C" +
@@ -115,22 +119,24 @@ class KGroupingTest {
             from(foo)
             where {
                 group {
-                    exists {
-                        select(foo.allColumns()) {
-                            from(foo)
-                            where { A isEqualTo 3 }
+                    group {
+                        exists {
+                            select(foo.allColumns()) {
+                                from(foo)
+                                where { A isEqualTo 3 }
+                            }
                         }
+                        and { A isEqualTo 1 }
+                        or { A isGreaterThan 5 }
                     }
-                    and { A isEqualTo 1 }
-                    or { A isGreaterThan 5 }
+                    and { B isEqualTo 1 }
+                    or {
+                        A isLessThan 0
+                        and { B isEqualTo 2 }
+                    }
                 }
-                and { B isEqualTo 1 }
-                or {
-                    A isLessThan 0
-                    and { B isEqualTo 2 }
-                }
+                and { C isEqualTo "Fred" }
             }
-            and { C isEqualTo "Fred" }
         }
 
         val expected = "select A, B, C" +
@@ -156,30 +162,32 @@ class KGroupingTest {
             where {
                 group {
                     group {
-                        A isEqualTo 1
-                        or { A isGreaterThan 5 }
-                    }
-                    and { A isGreaterThan 5 }
-                }
-                and {
-                    group {
-                        A isEqualTo 1
-                        or { A isGreaterThan 5 }
-                    }
-                    or { B isEqualTo 1 }
-                }
-                or {
-                    group {
-                        A isEqualTo 1
-                        or { A isGreaterThan 5 }
+                        group {
+                            A isEqualTo 1
+                            or { A isGreaterThan 5 }
+                        }
+                        and { A isGreaterThan 5 }
                     }
                     and {
-                        A isLessThan 0
-                        and { B isEqualTo 2 }
+                        group {
+                            A isEqualTo 1
+                            or { A isGreaterThan 5 }
+                        }
+                        or { B isEqualTo 1 }
+                    }
+                    or {
+                        group {
+                            A isEqualTo 1
+                            or { A isGreaterThan 5 }
+                        }
+                        and {
+                            A isLessThan 0
+                            and { B isEqualTo 2 }
+                        }
                     }
                 }
+                and { C isEqualTo "Fred" }
             }
-            and { C isEqualTo "Fred" }
         }
 
         val expected = "select A, B, C" +
@@ -207,23 +215,25 @@ class KGroupingTest {
     fun testAndOrCriteriaGroups() {
         val selectStatement = select(A, B, C) {
             from(foo)
-            where { A isEqualTo 6 }
-            and { C isEqualTo "Fred" }
-            and {
-                group {
-                    A isEqualTo 1
-                    or { A isGreaterThan 5 }
-                }
-                or { B isEqualTo 1 }
-            }
-            or {
-                group {
-                    A  isEqualTo 1
-                    or { A isGreaterThan 5 }
-                }
+            where {
+                A isEqualTo 6
+                and { C isEqualTo "Fred" }
                 and {
-                    A isLessThan 0
-                    and { B isEqualTo 2 }
+                    group {
+                        A isEqualTo 1
+                        or { A isGreaterThan 5 }
+                    }
+                    or { B isEqualTo 1 }
+                }
+                or {
+                    group {
+                        A  isEqualTo 1
+                        or { A isGreaterThan 5 }
+                    }
+                    and {
+                        A isLessThan 0
+                        and { B isEqualTo 2 }
+                    }
                 }
             }
         }
@@ -260,13 +270,13 @@ class KGroupingTest {
                     }
                     and { A isGreaterThan 3 }
                 }
-            }
-            and { not { A isGreaterThan 4 } }
-            or {
-                not {
-                    group {
-                        B isLessThan 6
-                        and { A isGreaterThanOrEqualTo 7 }
+                and { not { A isGreaterThan 4 } }
+                or {
+                    not {
+                        group {
+                            B isLessThan 6
+                            and { A isGreaterThanOrEqualTo 7 }
+                        }
                     }
                 }
             }

--- a/src/test/kotlin/examples/kotlin/mybatis3/joins/ExistsTest.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/joins/ExistsTest.kt
@@ -243,12 +243,14 @@ class ExistsTest {
 
             val selectStatement = select(itemMaster.allColumns()) {
                 from(itemMaster, "im")
-                where { itemMaster.itemId isEqualTo 22 }
-                and {
-                    exists {
-                        select(orderLine.allColumns()) {
-                            from(orderLine, "ol")
-                            where { orderLine.itemId isEqualTo "im"(itemMaster.itemId) }
+                where {
+                    itemMaster.itemId isEqualTo 22
+                    and {
+                        exists {
+                            select(orderLine.allColumns()) {
+                                from(orderLine, "ol")
+                                where { orderLine.itemId isEqualTo "im"(itemMaster.itemId) }
+                            }
                         }
                     }
                 }
@@ -279,15 +281,17 @@ class ExistsTest {
 
             val selectStatement = select(itemMaster.allColumns()) {
                 from(itemMaster, "im")
-                where { itemMaster.itemId isEqualTo 22 }
-                and {
-                    exists {
-                        select(orderLine.allColumns()) {
-                            from(orderLine, "ol")
-                            where { orderLine.itemId isEqualTo "im"(itemMaster.itemId) }
+                where {
+                    itemMaster.itemId isEqualTo 22
+                    and {
+                        exists {
+                            select(orderLine.allColumns()) {
+                                from(orderLine, "ol")
+                                where { orderLine.itemId isEqualTo "im"(itemMaster.itemId) }
+                            }
                         }
+                        and { itemMaster.itemId isGreaterThan 2 }
                     }
-                    and { itemMaster.itemId isGreaterThan 2 }
                 }
                 orderBy(itemMaster.itemId)
             }
@@ -394,12 +398,14 @@ class ExistsTest {
 
             val selectStatement = select(itemMaster.allColumns()) {
                 from(itemMaster, "im")
-                where { itemMaster.itemId isEqualTo 22 }
-                or {
-                    exists {
-                        select(orderLine.allColumns()) {
-                            from(orderLine, "ol")
-                            where { orderLine.itemId isEqualTo "im"(itemMaster.itemId) }
+                where {
+                    itemMaster.itemId isEqualTo 22
+                    or {
+                        exists {
+                            select(orderLine.allColumns()) {
+                                from(orderLine, "ol")
+                                where { orderLine.itemId isEqualTo "im"(itemMaster.itemId) }
+                            }
                         }
                     }
                 }
@@ -439,15 +445,17 @@ class ExistsTest {
 
             val selectStatement = select(itemMaster.allColumns()) {
                 from(itemMaster, "im")
-                where { itemMaster.itemId isEqualTo 22 }
-                or {
-                    exists {
-                        select(orderLine.allColumns()) {
-                            from(orderLine, "ol")
-                            where { orderLine.itemId isEqualTo "im"(itemMaster.itemId) }
+                where {
+                    itemMaster.itemId isEqualTo 22
+                    or {
+                        exists {
+                            select(orderLine.allColumns()) {
+                                from(orderLine, "ol")
+                                where { orderLine.itemId isEqualTo "im"(itemMaster.itemId) }
+                            }
                         }
+                        and { itemMaster.itemId isGreaterThan 2 }
                     }
-                    and { itemMaster.itemId isGreaterThan 2 }
                 }
                 orderBy(itemMaster.itemId)
             }

--- a/src/test/kotlin/examples/kotlin/spring/canonical/CanonicalSpringKotlinTemplateDirectTest.kt
+++ b/src/test/kotlin/examples/kotlin/spring/canonical/CanonicalSpringKotlinTemplateDirectTest.kt
@@ -117,8 +117,10 @@ open class CanonicalSpringKotlinTemplateDirectTest {
     @Test
     fun testDelete2() {
         val rows = template.deleteFrom(person) {
-            where { id isLessThan 4 }
-            and { occupation.isNotNull() }
+            where {
+                id isLessThan 4
+                and { occupation.isNotNull() }
+            }
         }
 
         assertThat(rows).isEqualTo(2)
@@ -127,8 +129,10 @@ open class CanonicalSpringKotlinTemplateDirectTest {
     @Test
     fun testDelete3() {
         val rows = template.deleteFrom(person) {
-            where { id isLessThan 4 }
-            or { occupation.isNotNull() }
+            where {
+                id isLessThan 4
+                or { occupation.isNotNull() }
+            }
         }
 
         assertThat(rows).isEqualTo(5)
@@ -138,10 +142,12 @@ open class CanonicalSpringKotlinTemplateDirectTest {
     fun testDelete4() {
         val rows = template.deleteFrom(person) {
             where {
-                id isLessThan 4
-                or { occupation.isNotNull() }
+                group {
+                    id isLessThan 4
+                    or { occupation.isNotNull() }
+                }
+                and { employed isEqualTo true }
             }
-            and { employed isEqualTo true }
         }
 
         assertThat(rows).isEqualTo(4)
@@ -150,10 +156,12 @@ open class CanonicalSpringKotlinTemplateDirectTest {
     @Test
     fun testDelete5() {
         val rows = template.deleteFrom(person) {
-            where { id isLessThan 4 }
-            or {
-                occupation.isNotNull()
-                and { employed isEqualTo true }
+            where {
+                id isLessThan 4
+                or {
+                    occupation.isNotNull()
+                    and { employed isEqualTo true }
+                }
             }
         }
 
@@ -163,10 +171,12 @@ open class CanonicalSpringKotlinTemplateDirectTest {
     @Test
     fun testDelete6() {
         val rows = template.deleteFrom(person) {
-            where { id isLessThan 4 }
-            and {
-                occupation.isNotNull()
-                and { employed isEqualTo true }
+            where {
+                id isLessThan 4
+                and {
+                    occupation.isNotNull()
+                    and { employed isEqualTo true }
+                }
             }
         }
 
@@ -387,10 +397,12 @@ open class CanonicalSpringKotlinTemplateDirectTest {
         val rows = template.select(id `as` "A_ID", firstName, lastName, birthDate, employed, occupation, addressId) {
             from(person)
             where {
-                id isLessThan 4
+                group {
+                    id isLessThan 4
+                    and { occupation.isNotNull() }
+                }
                 and { occupation.isNotNull() }
             }
-            and { occupation.isNotNull() }
             orderBy(id)
             limit(3)
         }.withRowMapper(personRowMapper)
@@ -592,12 +604,14 @@ open class CanonicalSpringKotlinTemplateDirectTest {
     fun testSelectWithComplexWhere1() {
         val rows = template.select(id `as` "A_ID", firstName, lastName, birthDate, employed, occupation, addressId) {
             from(person)
-            where { id isLessThan 5 }
-            and {
-                id isLessThan 4
+            where {
+                id isLessThan 5
                 and {
-                    id isLessThan 3
-                    and { id isLessThan 2 }
+                    id isLessThan 4
+                    and {
+                        id isLessThan 3
+                        and { id isLessThan 2 }
+                    }
                 }
             }
             orderBy(id)
@@ -620,12 +634,14 @@ open class CanonicalSpringKotlinTemplateDirectTest {
     fun testSelectWithComplexWhere2() {
         val rows = template.select(id `as` "A_ID", firstName, lastName, birthDate, employed, occupation, addressId) {
             from(person)
-            where { id isEqualTo 5 }
-            or {
-                id isEqualTo 4
+            where {
+                id isEqualTo 5
                 or {
-                    id isEqualTo 3
-                    or { id isEqualTo 2 }
+                    id isEqualTo 4
+                    or {
+                        id isEqualTo 3
+                        or { id isEqualTo 2 }
+                    }
                 }
             }
             orderBy(id)
@@ -671,10 +687,12 @@ open class CanonicalSpringKotlinTemplateDirectTest {
     fun testUpdate3() {
         val rows = template.update(person) {
             set(firstName) equalTo "Sam"
-            where { firstName isEqualTo "Fred" }
-            or {
-                id isEqualTo 5
-                or { id isEqualTo 6 }
+            where {
+                firstName isEqualTo "Fred"
+                or {
+                    id isEqualTo 5
+                    or { id isEqualTo 6 }
+                }
             }
         }
 
@@ -685,10 +703,12 @@ open class CanonicalSpringKotlinTemplateDirectTest {
     fun testUpdate4() {
         val rows = template.update(person) {
             set(firstName) equalTo  "Sam"
-            where { firstName isEqualTo "Fred" }
-            and {
-                id isEqualTo 1
-                or { id isEqualTo 6 }
+            where {
+                firstName isEqualTo "Fred"
+                and {
+                    id isEqualTo 1
+                    or { id isEqualTo 6 }
+                }
             }
         }
 
@@ -699,8 +719,10 @@ open class CanonicalSpringKotlinTemplateDirectTest {
     fun testUpdate5() {
         val rows = template.update(person) {
             set(firstName) equalTo "Sam"
-            where { firstName isEqualTo "Fred" }
-            or { id isEqualTo 3 }
+            where {
+                firstName isEqualTo "Fred"
+                or { id isEqualTo 3 }
+            }
         }
 
         assertThat(rows).isEqualTo(2)

--- a/src/test/kotlin/examples/kotlin/spring/canonical/CanonicalSpringKotlinTest.kt
+++ b/src/test/kotlin/examples/kotlin/spring/canonical/CanonicalSpringKotlinTest.kt
@@ -142,8 +142,10 @@ open class CanonicalSpringKotlinTest {
     @Test
     fun testRawDelete2() {
         val deleteStatement = deleteFrom(person) {
-            where { id isLessThan 4 }
-            and { occupation.isNotNull() }
+            where {
+                id isLessThan 4
+                and { occupation.isNotNull() }
+            }
         }
 
         assertThat(deleteStatement.deleteStatement).isEqualTo(
@@ -159,8 +161,10 @@ open class CanonicalSpringKotlinTest {
     fun testRawDelete3() {
 
         val deleteStatement = deleteFrom(person) {
-            where { id isLessThan 4 }
-            or { occupation.isNotNull() }
+            where {
+                id isLessThan 4
+                or { occupation.isNotNull() }
+            }
         }
 
         assertThat(deleteStatement.deleteStatement).isEqualTo(
@@ -177,10 +181,12 @@ open class CanonicalSpringKotlinTest {
 
         val deleteStatement = deleteFrom(person) {
             where {
-                id isLessThan 4
-                or { occupation.isNotNull() }
+                group {
+                    id isLessThan 4
+                    or { occupation.isNotNull() }
+                }
+                and { employed isEqualTo true }
             }
-            and { employed isEqualTo true }
         }
 
         val expected = "delete from Person" +
@@ -199,10 +205,12 @@ open class CanonicalSpringKotlinTest {
     @Test
     fun testRawDelete5() {
         val deleteStatement = deleteFrom(person) {
-            where { id isLessThan 4 }
-            or {
-                occupation.isNotNull()
-                and { employed isEqualTo true }
+            where {
+                id isLessThan 4
+                or {
+                    occupation.isNotNull()
+                    and { employed isEqualTo true }
+                }
             }
         }
 
@@ -221,10 +229,12 @@ open class CanonicalSpringKotlinTest {
     @Test
     fun testRawDelete6() {
         val deleteStatement = deleteFrom(person) {
-            where { id isLessThan 4 }
-            and {
-                occupation.isNotNull()
-                and { employed isEqualTo true }
+            where {
+                id isLessThan 4
+                and {
+                    occupation.isNotNull()
+                    and { employed isEqualTo true }
+                }
             }
         }
 
@@ -627,10 +637,12 @@ open class CanonicalSpringKotlinTest {
         ) {
             from(person)
             where {
-                id isLessThan 4
+                group {
+                    id isLessThan 4
+                    and { occupation.isNotNull() }
+                }
                 and { occupation.isNotNull() }
             }
-            and { occupation.isNotNull() }
             orderBy(id)
             limit(3)
         }
@@ -1147,12 +1159,14 @@ open class CanonicalSpringKotlinTest {
             id `as` "A_ID", firstName, lastName, birthDate, employed, occupation, addressId
         ) {
             from(person)
-            where { id isLessThan 5 }
-            and {
-                id isLessThan 4
+            where {
+                id isLessThan 5
                 and {
-                    id isLessThan 3
-                    and { id isLessThan 2 }
+                    id isLessThan 4
+                    and {
+                        id isLessThan 3
+                        and { id isLessThan 2 }
+                    }
                 }
             }
             orderBy(id)
@@ -1188,12 +1202,14 @@ open class CanonicalSpringKotlinTest {
             id `as` "A_ID", firstName, lastName, birthDate, employed, occupation, addressId
         ) {
             from(person)
-            where { id isEqualTo 5 }
-            or {
-                id isEqualTo 4
+            where {
+                id isEqualTo 5
                 or {
-                    id isEqualTo 3
-                    or { id isEqualTo 2 }
+                    id isEqualTo 4
+                    or {
+                        id isEqualTo 3
+                        or { id isEqualTo 2 }
+                    }
                 }
             }
             orderBy(id)
@@ -1268,10 +1284,12 @@ open class CanonicalSpringKotlinTest {
     fun testRawUpdate3() {
         val updateStatement = update(person) {
             set(firstName) equalTo "Sam"
-            where { firstName isEqualTo "Fred" }
-            or {
-                id isEqualTo 5
-                or { id isEqualTo 6 }
+            where {
+                firstName isEqualTo "Fred"
+                or {
+                    id isEqualTo 5
+                    or { id isEqualTo 6 }
+                }
             }
         }
 
@@ -1291,10 +1309,12 @@ open class CanonicalSpringKotlinTest {
     fun testRawUpdate4() {
         val updateStatement = update(person) {
             set(firstName) equalTo "Sam"
-            where { firstName isEqualTo "Fred" }
-            and {
-                id isEqualTo 1
-                or { id isEqualTo 6 }
+            where {
+                firstName isEqualTo "Fred"
+                and {
+                    id isEqualTo 1
+                    or { id isEqualTo 6 }
+                }
             }
         }
 
@@ -1314,8 +1334,10 @@ open class CanonicalSpringKotlinTest {
     fun testRawUpdate5() {
         val updateStatement = update(person) {
             set(firstName) equalTo "Sam"
-            where { firstName isEqualTo "Fred" }
-            or { id isEqualTo 3 }
+            where {
+                firstName isEqualTo "Fred"
+                or { id isEqualTo 3 }
+            }
         }
 
         assertThat(updateStatement.updateStatement).isEqualTo(
@@ -1334,8 +1356,10 @@ open class CanonicalSpringKotlinTest {
     fun testRawUpdate6() {
         val updateStatement = update(person) {
             set(occupation) equalToOrNull  null
-            where { firstName isEqualTo "Fred" }
-            or { id isEqualTo 3 }
+            where {
+                firstName isEqualTo "Fred"
+                or { id isEqualTo 3 }
+            }
         }
 
         assertThat(updateStatement.updateStatement).isEqualTo(
@@ -1580,21 +1604,23 @@ open class CanonicalSpringKotlinTest {
             id, firstName, lastName, birthDate, employed, occupation, addressId
         ) {
             from(person)
-            where { id isEqualToWhenPresent search1.id }
-            and {
-                upper(firstName) (isLikeWhenPresent(search1.firstName)
+            where {
+                id isEqualToWhenPresent search1.id
+                and {
+                    upper(firstName) (isLikeWhenPresent(search1.firstName)
                         .map(String::trim)
                         .filter(String::isNotEmpty)
                         .map(String::uppercase)
                         .map { "%$it%" }
-                )
-            }
-            and {
-                upper(lastName) (isLikeWhenPresent(search1.lastName)
+                    )
+                }
+                and {
+                    upper(lastName) (isLikeWhenPresent(search1.lastName)
                         .map(String::trim)
                         .filter(String::isNotEmpty)
                         .map(String::uppercase)
                         .map { LastName("%$it%") })
+                }
             }
             orderBy(id)
             limit(3)

--- a/src/test/kotlin/examples/kotlin/spring/canonical/SpringKotlinSubQueryTest.kt
+++ b/src/test/kotlin/examples/kotlin/spring/canonical/SpringKotlinSubQueryTest.kt
@@ -53,8 +53,10 @@ open class SpringKotlinSubQueryTest {
                         orderBy(firstName.descending())
                     }
                 }
-                where { rowNum isLessThan 5 }
-                and { firstName isLike "%a%" }
+                where {
+                    rowNum isLessThan 5
+                    and { firstName isLike "%a%" }
+                }
             }
 
         assertThat(selectStatement.selectStatement).isEqualTo(
@@ -93,8 +95,10 @@ open class SpringKotlinSubQueryTest {
                     orderBy(firstName.descending())
                 }
             }
-            where { rowNum isLessThan 5 }
-            and { firstName isLike "%a%" }
+            where {
+                rowNum isLessThan 5
+                and { firstName isLike "%a%" }
+            }
         }.withRowMapper { rs, _ ->
             mapOf(
                 Pair("FIRST_NAME", rs.getString(1)),
@@ -123,8 +127,10 @@ open class SpringKotlinSubQueryTest {
                     }
                     + "b"
                 }
-                where { rowNum isLessThan 5 }
-                and { outerFirstName isLike "%a%" }
+                where {
+                    rowNum isLessThan 5
+                    and { outerFirstName isLike "%a%" }
+                }
             }
 
         assertThat(selectStatement.selectStatement).isEqualTo(


### PR DESCRIPTION
These methods always impact the where clause, but given their visibility they could be misunderstood as methods that would impact a having clause.

The replacement is to only use the and/or methods inside the where lambda.