### PR TITLE
Change AlisableSqlTable rather than SqlTable

### DIFF
--- a/src/site/markdown/docs/databaseObjects.md
+++ b/src/site/markdown/docs/databaseObjects.md
@@ -100,7 +100,7 @@ In this query it is not clear which instance of the `user` table is used for eac
 HashMap for the `user` table - so only one of the aliases specified in the select statement will be in effect.
 There are two ways to deal with this problem.
 
-The first is to simply create another instance of the User SqlTable object. With this method it is very clear which column
+The first is to simply create another instance of the User `SqlTable` object. With this method it is very clear which column
 belongs to which instance of the table and the library can easily calculate aliases:
 
 ```java

--- a/src/site/markdown/docs/kotlinMyBatis3.md
+++ b/src/site/markdown/docs/kotlinMyBatis3.md
@@ -37,7 +37,7 @@ The pattern for the meta-model is the same as shown on the Kotlin overview page.
 specifics for MyBatis3.
 
 ```kotlin
-import org.mybatis.dynamic.sql.SqlTable
+import org.mybatis.dynamic.sql.AlisableSqlTable
 import org.mybatis.dynamic.sql.util.kotlin.elements.column
 import java.sql.JDBCType
 import java.util.Date
@@ -52,7 +52,7 @@ object PersonDynamicSqlSupport {
     val occupation = person.occupation
     val addressId = person.addressId
 
-    class Person : SqlTable("Person") {
+    class Person : AlisableSqlTable<Person>("Person", ::Person) {
         val id = column<Int>(name = "id", jdbcType = JDBCType.INTEGER)
         val firstName = column<String>(name = "first_name", jdbcType = JDBCType.VARCHAR)
         val lastName = column(

--- a/src/site/markdown/docs/kotlinOverview.md
+++ b/src/site/markdown/docs/kotlinOverview.md
@@ -82,7 +82,7 @@ in a "qualified" or "un-qualified" manner that looks like natural SQL. For examp
 following a column could be referred to as `firstName` or `person.firstName`.
 
 ```kotlin
-import org.mybatis.dynamic.sql.SqlTable
+import org.mybatis.dynamic.sql.AlisableSqlTable
 import org.mybatis.dynamic.sql.util.kotlin.elements.column
 import java.util.Date
 
@@ -95,7 +95,7 @@ object PersonDynamicSqlSupport {
     val employed = person.employed
     val occupation = person.occupation
    
-    class Person : SqlTable("Person") {
+    class Person : AlisableSqlTable<Person>("Person", ::Person) {
         val id = column<Int>(name = "id", jdbcType = JDBCType.INTEGER)
         val firstName = column<String>(name = "first_name", jdbcType = JDBCType.VARCHAR)
         val lastName = column<String>(name = "last_name", jdbcType = JDBCType.VARCHAR)
@@ -113,8 +113,8 @@ object PersonDynamicSqlSupport {
 
 Notes:
 
-1. The outer object is a singleton containing the `SqlTable` and `SqlColumn` objects that map to the database table.
-2. The inner `SqlTable` is declared as a `class` rather than an `object` - this allows you to create additional
+1. The outer object is a singleton containing the `AlisableSqlTable` and `SqlColumn` objects that map to the database table.
+2. The inner `AlisableSqlTable` is declared as a `class` rather than an `object` - this allows you to create additional
    instances for use in self-joins.
 3. Note the use of the `column` extension function. This function accepts different
    parameters for the different attributes that can be assigned to a column (such as a MyBatis3 type handler, or a

--- a/src/site/markdown/docs/kotlinSpring.md
+++ b/src/site/markdown/docs/kotlinSpring.md
@@ -34,7 +34,7 @@ The pattern for the metamodel is the same as shown on the Kotlin overview page. 
 specifics for Spring.
 
 ```kotlin
-import org.mybatis.dynamic.sql.SqlTable
+import org.mybatis.dynamic.sql.AlisableSqlTable
 import org.mybatis.dynamic.sql.util.kotlin.elements.column
 import java.util.Date
 
@@ -48,7 +48,7 @@ object PersonDynamicSqlSupport {
     val occupation = person.occupation
     val addressId = person.addressId
 
-    class Person : SqlTable("Person") {
+    class Person : AlisableSqlTable<Person>("Person", ::Person) {
         val id = column<Int>(name = "id")
         val firstName = column<String>(name = "first_name")
         val lastName = column(

--- a/src/site/markdown/docs/quickStart.md
+++ b/src/site/markdown/docs/quickStart.md
@@ -48,7 +48,7 @@ the actual name of the table (including schema or catalog if appropriate). A tab
 select statement if desired.  Your table should be defined by extending the `AlisableSqlTable<T>` class.
 
 The class `org.mybatis.dynamic.sql.SqlColumn` is used to define columns for use in the library.
-SqlColumns should be created using the builder methods in SqlTable.
+SqlColumns should be created using the builder methods in `SqlTable`.
 A column definition includes:
 
 1. The Java type

--- a/src/site/markdown/docs/quickStart.md
+++ b/src/site/markdown/docs/quickStart.md
@@ -43,9 +43,9 @@ public class PersonRecord {
 
 ## Defining Tables and Columns
 
-The class `org.mybatis.dynamic.sql.SqlTable` is used to define a table. A table definition includes
+The class `org.mybatis.dynamic.sql.AlisableSqlTable` is used to define a table. A table definition includes
 the actual name of the table (including schema or catalog if appropriate). A table alias can be applied in a
-select statement if desired.  Your table should be defined by extending the `SqlTable` class.
+select statement if desired.  Your table should be defined by extending the `AlisableSqlTable<T>` class.
 
 The class `org.mybatis.dynamic.sql.SqlColumn` is used to define columns for use in the library.
 SqlColumns should be created using the builder methods in SqlTable.
@@ -67,7 +67,7 @@ import java.sql.JDBCType;
 import java.util.Date;
 
 import org.mybatis.dynamic.sql.SqlColumn;
-import org.mybatis.dynamic.sql.SqlTable;
+import org.mybatis.dynamic.sql.AliasableSqlTable;
 
 public final class PersonDynamicSqlSupport {
     public static final Person person = new Person();
@@ -79,7 +79,7 @@ public final class PersonDynamicSqlSupport {
     public static final SqlColumn<String> occupation = person.occupation;
     public static final SqlColumn<Integer> addressId = person.addressId;
 
-    public static final class Person extends SqlTable {
+    public static final class Person extends AliasableSqlTable<Person> {
         public final SqlColumn<Integer> id = column("id", JDBCType.INTEGER);
         public final SqlColumn<String> firstName = column("first_name", JDBCType.VARCHAR);
         public final SqlColumn<LastName> lastName = column("last_name", JDBCType.VARCHAR, "examples.simple.LastNameTypeHandler");
@@ -89,7 +89,7 @@ public final class PersonDynamicSqlSupport {
         public final SqlColumn<Integer> addressId = column("address_id", JDBCType.INTEGER);
 
         public Person() {
-            super("Person");
+            super("Person", Person::new);
         }
     }
 }


### PR DESCRIPTION
You've mentioned `AlisableSqlTable` is preferable to `SqlTable` in [Modeling Database Objects](https://mybatis.org/mybatis-dynamic-sql/docs/databaseObjects.html).

But other documents are still using `SqlTable`. this may lead confused for other new users in this library.

So, this PR change All the `SqlTable` implementation to `AlisableSqlTable`