### PR TITLE
Refactoring Slice - Empty Conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ types - which is a rare usage. Please let us know if this causes an undo hardshi
    your code accordingly. ([#662](https://github.com/mybatis/mybatis-dynamic-sql/pull/662))
 2. Added the ability to code a bound value in rendered SQL. This is similar to a constant, but the value is added to
    the parameter map and a bind parameter marker is rendered. ([#738](https://github.com/mybatis/mybatis-dynamic-sql/pull/738))
+3. Refactored the conditions to separate the concept of an empty condition from that of a renderable condition. This
+   will enable a future change where conditions could decide to allow rendering even if they are considered empty (such
+   as rendering empty lists). This change should be transparent to users unless they have implemented custom conditions.
 
 ## Release 1.5.0 - April 21, 2023
 

--- a/src/main/java/org/mybatis/dynamic/sql/AbstractListValueCondition.java
+++ b/src/main/java/org/mybatis/dynamic/sql/AbstractListValueCondition.java
@@ -35,8 +35,8 @@ public abstract class AbstractListValueCondition<T> implements VisitableConditio
     }
 
     @Override
-    public boolean shouldRender() {
-        return !values.isEmpty();
+    public boolean isEmpty() {
+        return values.isEmpty();
     }
 
     @Override
@@ -56,20 +56,20 @@ public abstract class AbstractListValueCondition<T> implements VisitableConditio
 
     protected <S extends AbstractListValueCondition<T>> S filterSupport(Predicate<? super T> predicate,
             Function<Collection<T>, S> constructor, S self, Supplier<S> emptySupplier) {
-        if (shouldRender()) {
+        if (isEmpty()) {
+            return self;
+        } else {
             Collection<T> filtered = applyFilter(predicate);
             return filtered.isEmpty() ? emptySupplier.get() : constructor.apply(filtered);
-        } else {
-            return self;
         }
     }
 
     protected <R, S extends AbstractListValueCondition<R>> S mapSupport(Function<? super T, ? extends R> mapper,
             Function<Collection<R>, S> constructor, Supplier<S> emptySupplier) {
-        if (shouldRender()) {
-            return constructor.apply(applyMapper(mapper));
-        } else {
+        if (isEmpty()) {
             return emptySupplier.get();
+        } else {
+            return constructor.apply(applyMapper(mapper));
         }
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/AbstractNoValueCondition.java
+++ b/src/main/java/org/mybatis/dynamic/sql/AbstractNoValueCondition.java
@@ -27,10 +27,10 @@ public abstract class AbstractNoValueCondition<T> implements VisitableCondition<
 
     protected <S extends AbstractNoValueCondition<?>> S filterSupport(BooleanSupplier booleanSupplier,
             Supplier<S> emptySupplier, S self) {
-        if (shouldRender()) {
-            return booleanSupplier.getAsBoolean() ? self : emptySupplier.get();
-        } else {
+        if (isEmpty()) {
             return self;
+        } else {
+            return booleanSupplier.getAsBoolean() ? self : emptySupplier.get();
         }
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/AbstractSingleValueCondition.java
+++ b/src/main/java/org/mybatis/dynamic/sql/AbstractSingleValueCondition.java
@@ -37,19 +37,19 @@ public abstract class AbstractSingleValueCondition<T> implements VisitableCondit
 
     protected <S extends AbstractSingleValueCondition<T>> S filterSupport(Predicate<? super T> predicate,
             Supplier<S> emptySupplier, S self) {
-        if (shouldRender()) {
-            return predicate.test(value) ? self : emptySupplier.get();
-        } else {
+        if (isEmpty()) {
             return self;
+        } else {
+            return predicate.test(value) ? self : emptySupplier.get();
         }
     }
 
     protected <R, S extends AbstractSingleValueCondition<R>> S mapSupport(Function<? super T, ? extends R> mapper,
             Function<R, S> constructor, Supplier<S> emptySupplier) {
-        if (shouldRender()) {
-            return constructor.apply(mapper.apply(value));
-        } else {
+        if (isEmpty()) {
             return emptySupplier.get();
+        } else {
+            return constructor.apply(mapper.apply(value));
         }
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/AbstractTwoValueCondition.java
+++ b/src/main/java/org/mybatis/dynamic/sql/AbstractTwoValueCondition.java
@@ -45,10 +45,10 @@ public abstract class AbstractTwoValueCondition<T> implements VisitableCondition
 
     protected <S extends AbstractTwoValueCondition<T>> S filterSupport(BiPredicate<? super T, ? super T> predicate,
             Supplier<S> emptySupplier, S self) {
-        if (shouldRender()) {
-            return predicate.test(value1, value2) ? self : emptySupplier.get();
-        } else {
+        if (isEmpty()) {
             return self;
+        } else {
+            return predicate.test(value1, value2) ? self : emptySupplier.get();
         }
     }
 
@@ -59,10 +59,10 @@ public abstract class AbstractTwoValueCondition<T> implements VisitableCondition
 
     protected <R, S extends AbstractTwoValueCondition<R>> S mapSupport(Function<? super T, ? extends R> mapper1,
             Function<? super T, ? extends R> mapper2, BiFunction<R, R, S> constructor, Supplier<S> emptySupplier) {
-        if (shouldRender()) {
-            return constructor.apply(mapper1.apply(value1), mapper2.apply(value2));
-        } else {
+        if (isEmpty()) {
             return emptySupplier.get();
+        } else {
+            return constructor.apply(mapper1.apply(value1), mapper2.apply(value2));
         }
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/VisitableCondition.java
+++ b/src/main/java/org/mybatis/dynamic/sql/VisitableCondition.java
@@ -15,22 +15,34 @@
  */
 package org.mybatis.dynamic.sql;
 
+import org.mybatis.dynamic.sql.render.RenderingContext;
+
 @FunctionalInterface
 public interface VisitableCondition<T> {
     <R> R accept(ConditionVisitor<T, R> visitor);
 
     /**
      * Subclasses can override this to inform the renderer if the condition should not be included
-     * in the rendered SQL.  For example, IsEqualWhenPresent will not render if the value is null.
+     * in the rendered SQL.  Typically, conditions will not render if they are empty.
      *
      * @return true if the condition should render.
      */
-    default boolean shouldRender() {
-        return true;
+    default boolean shouldRender(RenderingContext renderingContext) {
+        return !isEmpty();
     }
 
     /**
-     * This method will be called during rendering when {@link VisitableCondition#shouldRender()}
+     * Subclasses can override this to indicate whether the condition is considered empty. This is primarily used in
+     * map and filter operations - the map and filter functions will not be applied if the condition is empty.
+     *
+     * @return true if the condition is empty.
+     */
+    default boolean isEmpty() {
+        return false;
+    }
+
+    /**
+     * This method will be called during rendering when {@link VisitableCondition#shouldRender(RenderingContext)}
      * returns false.
      */
     default void renderingSkipped() {}

--- a/src/main/java/org/mybatis/dynamic/sql/select/aggregate/Sum.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/aggregate/Sum.java
@@ -36,7 +36,7 @@ public class Sum<T> extends AbstractUniTypeFunction<T, Sum<T>> {
     private Sum(BindableColumn<T> column, VisitableCondition<T> condition) {
         super(column);
         renderer = rc -> {
-            Validator.assertTrue(condition.shouldRender(), "ERROR.37", "sum"); //$NON-NLS-1$ //$NON-NLS-2$
+            Validator.assertTrue(condition.shouldRender(rc), "ERROR.37", "sum"); //$NON-NLS-1$ //$NON-NLS-2$
 
             DefaultConditionVisitor<T> visitor = new DefaultConditionVisitor.Builder<T>()
                     .withColumn(column)

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsBetween.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsBetween.java
@@ -25,8 +25,8 @@ import org.mybatis.dynamic.sql.AbstractTwoValueCondition;
 public class IsBetween<T> extends AbstractTwoValueCondition<T> {
     private static final IsBetween<?> EMPTY = new IsBetween<Object>(null, null) {
         @Override
-        public boolean shouldRender() {
-            return false;
+        public boolean isEmpty() {
+            return true;
         }
     };
 

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsEqualTo.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsEqualTo.java
@@ -24,8 +24,8 @@ public class IsEqualTo<T> extends AbstractSingleValueCondition<T> {
 
     private static final IsEqualTo<?> EMPTY = new IsEqualTo<Object>(null) {
         @Override
-        public boolean shouldRender() {
-            return false;
+        public boolean isEmpty() {
+            return true;
         }
     };
 

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThan.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThan.java
@@ -23,8 +23,8 @@ import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 public class IsGreaterThan<T> extends AbstractSingleValueCondition<T> {
     private static final IsGreaterThan<?> EMPTY = new IsGreaterThan<Object>(null) {
         @Override
-        public boolean shouldRender() {
-            return false;
+        public boolean isEmpty() {
+            return true;
         }
     };
 

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThanOrEqualTo.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThanOrEqualTo.java
@@ -23,8 +23,8 @@ import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 public class IsGreaterThanOrEqualTo<T> extends AbstractSingleValueCondition<T> {
     private static final IsGreaterThanOrEqualTo<?> EMPTY = new IsGreaterThanOrEqualTo<Object>(null) {
         @Override
-        public boolean shouldRender() {
-            return false;
+        public boolean isEmpty() {
+            return true;
         }
     };
 

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThan.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThan.java
@@ -23,8 +23,8 @@ import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 public class IsLessThan<T> extends AbstractSingleValueCondition<T> {
     private static final IsLessThan<?> EMPTY = new IsLessThan<Object>(null) {
         @Override
-        public boolean shouldRender() {
-            return false;
+        public boolean isEmpty() {
+            return true;
         }
     };
 

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThanOrEqualTo.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThanOrEqualTo.java
@@ -23,8 +23,8 @@ import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 public class IsLessThanOrEqualTo<T> extends AbstractSingleValueCondition<T> {
     private static final IsLessThanOrEqualTo<?> EMPTY = new IsLessThanOrEqualTo<Object>(null) {
         @Override
-        public boolean shouldRender() {
-            return false;
+        public boolean isEmpty() {
+            return true;
         }
     };
 

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLike.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLike.java
@@ -23,8 +23,8 @@ import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 public class IsLike<T> extends AbstractSingleValueCondition<T> {
     private static final IsLike<?> EMPTY = new IsLike<Object>(null) {
         @Override
-        public boolean shouldRender() {
-            return false;
+        public boolean isEmpty() {
+            return true;
         }
     };
 

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLikeCaseInsensitive.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLikeCaseInsensitive.java
@@ -25,8 +25,8 @@ public class IsLikeCaseInsensitive extends AbstractSingleValueCondition<String>
         implements CaseInsensitiveVisitableCondition {
     private static final IsLikeCaseInsensitive EMPTY = new IsLikeCaseInsensitive(null) {
         @Override
-        public boolean shouldRender() {
-            return false;
+        public boolean isEmpty() {
+            return true;
         }
     };
 

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotBetween.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotBetween.java
@@ -25,8 +25,8 @@ import org.mybatis.dynamic.sql.AbstractTwoValueCondition;
 public class IsNotBetween<T> extends AbstractTwoValueCondition<T> {
     private static final IsNotBetween<?> EMPTY = new IsNotBetween<Object>(null, null) {
         @Override
-        public boolean shouldRender() {
-            return false;
+        public boolean isEmpty() {
+            return true;
         }
     };
 

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotEqualTo.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotEqualTo.java
@@ -23,8 +23,8 @@ import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 public class IsNotEqualTo<T> extends AbstractSingleValueCondition<T> {
     private static final IsNotEqualTo<?> EMPTY = new IsNotEqualTo<Object>(null) {
         @Override
-        public boolean shouldRender() {
-            return false;
+        public boolean isEmpty() {
+            return true;
         }
     };
 

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotLike.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotLike.java
@@ -23,8 +23,8 @@ import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 public class IsNotLike<T> extends AbstractSingleValueCondition<T> {
     private static final IsNotLike<?> EMPTY = new IsNotLike<Object>(null) {
         @Override
-        public boolean shouldRender() {
-            return false;
+        public boolean isEmpty() {
+            return true;
         }
     };
 

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotLikeCaseInsensitive.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotLikeCaseInsensitive.java
@@ -25,8 +25,8 @@ public class IsNotLikeCaseInsensitive extends AbstractSingleValueCondition<Strin
         implements CaseInsensitiveVisitableCondition {
     private static final IsNotLikeCaseInsensitive EMPTY = new IsNotLikeCaseInsensitive(null) {
         @Override
-        public boolean shouldRender() {
-            return false;
+        public boolean isEmpty() {
+            return true;
         }
     };
 

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotNull.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotNull.java
@@ -22,8 +22,8 @@ import org.mybatis.dynamic.sql.AbstractNoValueCondition;
 public class IsNotNull<T> extends AbstractNoValueCondition<T> {
     private static final IsNotNull<?> EMPTY = new IsNotNull<Object>() {
         @Override
-        public boolean shouldRender() {
-            return false;
+        public boolean isEmpty() {
+            return true;
         }
     };
 

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNull.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNull.java
@@ -22,8 +22,8 @@ import org.mybatis.dynamic.sql.AbstractNoValueCondition;
 public class IsNull<T> extends AbstractNoValueCondition<T> {
     private static final IsNull<?> EMPTY = new IsNull<Object>() {
         @Override
-        public boolean shouldRender() {
-            return false;
+        public boolean isEmpty() {
+            return true;
         }
     };
 

--- a/src/main/java/org/mybatis/dynamic/sql/where/render/CriterionRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/render/CriterionRenderer.java
@@ -110,7 +110,7 @@ public class CriterionRenderer implements SqlCriterionVisitor<Optional<RenderedC
     }
 
     private <T> Optional<FragmentAndParameters> renderColumnAndCondition(ColumnAndConditionCriterion<T> criterion) {
-        if (criterion.condition().shouldRender()) {
+        if (criterion.condition().shouldRender(renderingContext)) {
             return Optional.of(renderCondition(criterion));
         } else {
             criterion.condition().renderingSkipped();

--- a/src/test/java/org/mybatis/dynamic/sql/where/condition/FilterAndMapTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/where/condition/FilterAndMapTest.java
@@ -30,7 +30,7 @@ class FilterAndMapTest {
     @Test
     void testTypeConversion() {
         IsEqualTo<Integer> cond = SqlBuilder.isEqualTo("1").map(Integer::parseInt);
-        assertThat(cond.shouldRender()).isTrue();
+        assertThat(cond.isEmpty()).isFalse();
         assertThat(cond.value()).isEqualTo(1);
     }
 
@@ -45,14 +45,14 @@ class FilterAndMapTest {
     @Test
     void testTypeConversionWithNullAndFilterDoesNotThrowException() {
         IsEqualTo<Integer> cond = SqlBuilder.isEqualTo((String) null).filter(Objects::nonNull).map(Integer::parseInt);
-        assertThat(cond.shouldRender()).isFalse();
+        assertThat(cond.isEmpty()).isTrue();
     }
 
     @Test
     void testIsNullRenderableTruePredicateShouldReturnSameObject() {
         IsNull<String> cond = SqlBuilder.isNull();
         IsNull<String> filtered = cond.filter(() -> true);
-        assertThat(filtered.shouldRender()).isTrue();
+        assertThat(filtered.isEmpty()).isFalse();
         assertThat(cond).isSameAs(filtered);
     }
 
@@ -60,15 +60,15 @@ class FilterAndMapTest {
     void testIsNullRenderableFalsePredicate() {
         IsNull<String> cond = SqlBuilder.isNull();
         IsNull<String> filtered = cond.filter(() -> false);
-        assertThat(cond.shouldRender()).isTrue();
-        assertThat(filtered.shouldRender()).isFalse();
+        assertThat(cond.isEmpty()).isFalse();
+        assertThat(filtered.isEmpty()).isTrue();
     }
 
     @Test
     void testIsNullFilterUnRenderableShouldReturnSameObject() {
         IsNull<String> cond = SqlBuilder.isNull().filter(() -> false);
         IsNull<String> filtered = cond.filter(() -> true);
-        assertThat(filtered.shouldRender()).isFalse();
+        assertThat(filtered.isEmpty()).isTrue();
         assertThat(cond).isSameAs(filtered);
     }
 
@@ -76,7 +76,7 @@ class FilterAndMapTest {
     void testIsNotNullRenderableTruePredicateShouldReturnSameObject() {
         IsNotNull<String> cond = SqlBuilder.isNotNull();
         IsNotNull<String> filtered = cond.filter(() -> true);
-        assertThat(filtered.shouldRender()).isTrue();
+        assertThat(filtered.isEmpty()).isFalse();
         assertThat(cond).isSameAs(filtered);
     }
 
@@ -84,15 +84,15 @@ class FilterAndMapTest {
     void testIsNotNullRenderableFalsePredicate() {
         IsNotNull<String> cond = SqlBuilder.isNotNull();
         IsNotNull<String> filtered = cond.filter(() -> false);
-        assertThat(cond.shouldRender()).isTrue();
-        assertThat(filtered.shouldRender()).isFalse();
+        assertThat(cond.isEmpty()).isFalse();
+        assertThat(filtered.isEmpty()).isTrue();
     }
 
     @Test
     void testIsNotNullFilterUnRenderableShouldReturnSameObject() {
         IsNotNull<String> cond = SqlBuilder.isNotNull().filter(() -> false);
         IsNotNull<String> filtered = cond.filter(() -> true);
-        assertThat(filtered.shouldRender()).isFalse();
+        assertThat(filtered.isEmpty()).isTrue();
         assertThat(cond).isSameAs(filtered);
     }
 
@@ -100,7 +100,7 @@ class FilterAndMapTest {
     void testIsEqualRenderableTruePredicateShouldReturnSameObject() {
         IsEqualTo<String> cond = SqlBuilder.isEqualTo("Fred");
         IsEqualTo<String> filtered = cond.filter(s -> true);
-        assertThat(filtered.shouldRender()).isTrue();
+        assertThat(filtered.isEmpty()).isFalse();
         assertThat(cond).isSameAs(filtered);
     }
 
@@ -108,15 +108,15 @@ class FilterAndMapTest {
     void testIsEqualRenderableFalsePredicate() {
         IsEqualTo<String> cond = SqlBuilder.isEqualTo("Fred");
         IsEqualTo<String> filtered = cond.filter(s -> false);
-        assertThat(cond.shouldRender()).isTrue();
-        assertThat(filtered.shouldRender()).isFalse();
+        assertThat(cond.isEmpty()).isFalse();
+        assertThat(filtered.isEmpty()).isTrue();
     }
 
     @Test
     void testIsEqualFilterUnRenderableShouldReturnSameObject() {
         IsEqualTo<String> cond = SqlBuilder.isEqualTo("Fred").filter(s -> false);
         IsEqualTo<String> filtered = cond.filter(s -> true);
-        assertThat(filtered.shouldRender()).isFalse();
+        assertThat(filtered.isEmpty()).isTrue();
         assertThat(cond).isSameAs(filtered);
     }
 
@@ -124,7 +124,7 @@ class FilterAndMapTest {
     void testIsEqualMapUnRenderableShouldNotThrowNullPointerException() {
         IsEqualTo<String> cond = SqlBuilder.isEqualTo("Fred").filter(s -> false);
         IsEqualTo<String> mapped = cond.map(String::toUpperCase);
-        assertThat(cond.shouldRender()).isFalse();
+        assertThat(cond.isEmpty()).isTrue();
         assertThat(cond.value()).isNull();
         assertThat(cond).isSameAs(mapped);
     }
@@ -133,7 +133,7 @@ class FilterAndMapTest {
     void testIsNotEqualRenderableTruePredicateShouldReturnSameObject() {
         IsNotEqualTo<String> cond = SqlBuilder.isNotEqualTo("Fred");
         IsNotEqualTo<String> filtered = cond.filter(s -> true);
-        assertThat(filtered.shouldRender()).isTrue();
+        assertThat(filtered.isEmpty()).isFalse();
         assertThat(cond).isSameAs(filtered);
     }
 
@@ -141,15 +141,15 @@ class FilterAndMapTest {
     void testIsNotEqualRenderableFalsePredicate() {
         IsNotEqualTo<String> cond = SqlBuilder.isNotEqualTo("Fred");
         IsNotEqualTo<String> filtered = cond.filter(s -> false);
-        assertThat(cond.shouldRender()).isTrue();
-        assertThat(filtered.shouldRender()).isFalse();
+        assertThat(cond.isEmpty()).isFalse();
+        assertThat(filtered.isEmpty()).isTrue();
     }
 
     @Test
     void testIsNotEqualFilterUnRenderableShouldReturnSameObject() {
         IsNotEqualTo<String> cond = SqlBuilder.isNotEqualTo("Fred").filter(s -> false);
         IsNotEqualTo<String> filtered = cond.filter(s -> true);
-        assertThat(filtered.shouldRender()).isFalse();
+        assertThat(filtered.isEmpty()).isTrue();
         assertThat(cond).isSameAs(filtered);
     }
 
@@ -157,7 +157,7 @@ class FilterAndMapTest {
     void testIsNotEqualMapUnRenderableShouldNotThrowNullPointerException() {
         IsNotEqualTo<String> cond = SqlBuilder.isNotEqualTo("Fred").filter(s -> false);
         IsNotEqualTo<String> mapped = cond.map(String::toUpperCase);
-        assertThat(cond.shouldRender()).isFalse();
+        assertThat(cond.isEmpty()).isTrue();
         assertThat(cond.value()).isNull();
         assertThat(cond).isSameAs(mapped);
     }
@@ -166,7 +166,7 @@ class FilterAndMapTest {
     void testIsLessThanRenderableTruePredicateShouldReturnSameObject() {
         IsLessThan<String> cond = SqlBuilder.isLessThan("Fred");
         IsLessThan<String> filtered = cond.filter(s -> true);
-        assertThat(filtered.shouldRender()).isTrue();
+        assertThat(filtered.isEmpty()).isFalse();
         assertThat(cond).isSameAs(filtered);
     }
 
@@ -174,15 +174,15 @@ class FilterAndMapTest {
     void testIsLessThanRenderableFalsePredicate() {
         IsLessThan<String> cond = SqlBuilder.isLessThan("Fred");
         IsLessThan<String> filtered = cond.filter(s -> false);
-        assertThat(cond.shouldRender()).isTrue();
-        assertThat(filtered.shouldRender()).isFalse();
+        assertThat(cond.isEmpty()).isFalse();
+        assertThat(filtered.isEmpty()).isTrue();
     }
 
     @Test
     void testIsLessThanFilterUnRenderableShouldReturnSameObject() {
         IsLessThan<String> cond = SqlBuilder.isLessThan("Fred").filter(s -> false);
         IsLessThan<String> filtered = cond.filter(s -> true);
-        assertThat(filtered.shouldRender()).isFalse();
+        assertThat(filtered.isEmpty()).isTrue();
         assertThat(cond).isSameAs(filtered);
     }
 
@@ -190,7 +190,7 @@ class FilterAndMapTest {
     void testIsLessThanMapUnRenderableShouldNotThrowNullPointerException() {
         IsLessThan<String> cond = SqlBuilder.isLessThan("Fred").filter(s -> false);
         IsLessThan<String> mapped = cond.map(String::toUpperCase);
-        assertThat(cond.shouldRender()).isFalse();
+        assertThat(cond.isEmpty()).isTrue();
         assertThat(cond.value()).isNull();
         assertThat(cond).isSameAs(mapped);
     }
@@ -199,7 +199,7 @@ class FilterAndMapTest {
     void testIsLessThanOrEqualRenderableTruePredicateShouldReturnSameObject() {
         IsLessThanOrEqualTo<String> cond = SqlBuilder.isLessThanOrEqualTo("Fred");
         IsLessThanOrEqualTo<String> filtered = cond.filter(s -> true);
-        assertThat(filtered.shouldRender()).isTrue();
+        assertThat(filtered.isEmpty()).isFalse();
         assertThat(cond).isSameAs(filtered);
     }
 
@@ -207,15 +207,15 @@ class FilterAndMapTest {
     void testIsLessThanOrEqualRenderableFalsePredicate() {
         IsLessThanOrEqualTo<String> cond = SqlBuilder.isLessThanOrEqualTo("Fred");
         IsLessThanOrEqualTo<String> filtered = cond.filter(s -> false);
-        assertThat(cond.shouldRender()).isTrue();
-        assertThat(filtered.shouldRender()).isFalse();
+        assertThat(cond.isEmpty()).isFalse();
+        assertThat(filtered.isEmpty()).isTrue();
     }
 
     @Test
     void testIsLessThanOrEqualFilterUnRenderableShouldReturnSameObject() {
         IsLessThanOrEqualTo<String> cond = SqlBuilder.isLessThanOrEqualTo("Fred").filter(s -> false);
         IsLessThanOrEqualTo<String> filtered = cond.filter(s -> true);
-        assertThat(filtered.shouldRender()).isFalse();
+        assertThat(filtered.isEmpty()).isTrue();
         assertThat(cond).isSameAs(filtered);
     }
 
@@ -223,7 +223,7 @@ class FilterAndMapTest {
     void testIsLessThanOrEqualMapUnRenderableShouldNotThrowNullPointerException() {
         IsLessThanOrEqualTo<String> cond = SqlBuilder.isLessThanOrEqualTo("Fred").filter(s -> false);
         IsLessThanOrEqualTo<String> mapped = cond.map(String::toUpperCase);
-        assertThat(cond.shouldRender()).isFalse();
+        assertThat(cond.isEmpty()).isTrue();
         assertThat(cond.value()).isNull();
         assertThat(cond).isSameAs(mapped);
     }
@@ -232,7 +232,7 @@ class FilterAndMapTest {
     void testIsGreaterThanRenderableTruePredicateShouldReturnSameObject() {
         IsGreaterThan<String> cond = SqlBuilder.isGreaterThan("Fred");
         IsGreaterThan<String> filtered = cond.filter(s -> true);
-        assertThat(filtered.shouldRender()).isTrue();
+        assertThat(filtered.isEmpty()).isFalse();
         assertThat(cond).isSameAs(filtered);
     }
 
@@ -240,15 +240,15 @@ class FilterAndMapTest {
     void testIsGreaterThanRenderableFalsePredicate() {
         IsGreaterThan<String> cond = SqlBuilder.isGreaterThan("Fred");
         IsGreaterThan<String> filtered = cond.filter(s -> false);
-        assertThat(cond.shouldRender()).isTrue();
-        assertThat(filtered.shouldRender()).isFalse();
+        assertThat(cond.isEmpty()).isFalse();
+        assertThat(filtered.isEmpty()).isTrue();
     }
 
     @Test
     void testIsGreaterThanFilterUnRenderableShouldReturnSameObject() {
         IsGreaterThan<String> cond = SqlBuilder.isGreaterThan("Fred").filter(s -> false);
         IsGreaterThan<String> filtered = cond.filter(s -> true);
-        assertThat(filtered.shouldRender()).isFalse();
+        assertThat(filtered.isEmpty()).isTrue();
         assertThat(cond).isSameAs(filtered);
     }
 
@@ -256,7 +256,7 @@ class FilterAndMapTest {
     void testIsGreaterThanMapUnRenderableShouldNotThrowNullPointerException() {
         IsGreaterThan<String> cond = SqlBuilder.isGreaterThan("Fred").filter(s -> false);
         IsGreaterThan<String> mapped = cond.map(String::toUpperCase);
-        assertThat(cond.shouldRender()).isFalse();
+        assertThat(cond.isEmpty()).isTrue();
         assertThat(cond.value()).isNull();
         assertThat(cond).isSameAs(mapped);
     }
@@ -265,7 +265,7 @@ class FilterAndMapTest {
     void testIsGreaterThanOrEqualRenderableTruePredicateShouldReturnSameObject() {
         IsGreaterThanOrEqualTo<String> cond = SqlBuilder.isGreaterThanOrEqualTo("Fred");
         IsGreaterThanOrEqualTo<String> filtered = cond.filter(s -> true);
-        assertThat(filtered.shouldRender()).isTrue();
+        assertThat(filtered.isEmpty()).isFalse();
         assertThat(cond).isSameAs(filtered);
     }
 
@@ -273,15 +273,15 @@ class FilterAndMapTest {
     void testIsGreaterThanOrEqualRenderableFalsePredicate() {
         IsGreaterThanOrEqualTo<String> cond = SqlBuilder.isGreaterThanOrEqualTo("Fred");
         IsGreaterThanOrEqualTo<String> filtered = cond.filter(s -> false);
-        assertThat(cond.shouldRender()).isTrue();
-        assertThat(filtered.shouldRender()).isFalse();
+        assertThat(cond.isEmpty()).isFalse();
+        assertThat(filtered.isEmpty()).isTrue();
     }
 
     @Test
     void testIsGreaterThanOrEqualFilterUnRenderableShouldReturnSameObject() {
         IsGreaterThanOrEqualTo<String> cond = SqlBuilder.isGreaterThanOrEqualTo("Fred").filter(s -> false);
         IsGreaterThanOrEqualTo<String> filtered = cond.filter(s -> true);
-        assertThat(filtered.shouldRender()).isFalse();
+        assertThat(filtered.isEmpty()).isTrue();
         assertThat(cond).isSameAs(filtered);
     }
 
@@ -289,7 +289,7 @@ class FilterAndMapTest {
     void testIsGreaterThanOrEqualMapUnRenderableShouldNotThrowNullPointerException() {
         IsGreaterThanOrEqualTo<String> cond = SqlBuilder.isGreaterThanOrEqualTo("Fred").filter(s -> false);
         IsGreaterThanOrEqualTo<String> mapped = cond.map(String::toUpperCase);
-        assertThat(cond.shouldRender()).isFalse();
+        assertThat(cond.isEmpty()).isTrue();
         assertThat(cond.value()).isNull();
         assertThat(cond).isSameAs(mapped);
     }
@@ -298,7 +298,7 @@ class FilterAndMapTest {
     void testIsLikeRenderableTruePredicateShouldReturnSameObject() {
         IsLike<String> cond = SqlBuilder.isLike("Fred");
         IsLike<String> filtered = cond.filter(s -> true);
-        assertThat(filtered.shouldRender()).isTrue();
+        assertThat(filtered.isEmpty()).isFalse();
         assertThat(cond).isSameAs(filtered);
     }
 
@@ -306,15 +306,15 @@ class FilterAndMapTest {
     void testIsLikeRenderableFalsePredicate() {
         IsLike<String> cond = SqlBuilder.isLike("Fred");
         IsLike<String> filtered = cond.filter(s -> false);
-        assertThat(cond.shouldRender()).isTrue();
-        assertThat(filtered.shouldRender()).isFalse();
+        assertThat(cond.isEmpty()).isFalse();
+        assertThat(filtered.isEmpty()).isTrue();
     }
 
     @Test
     void testIsLikeFilterUnRenderableShouldReturnSameObject() {
         IsLike<String> cond = SqlBuilder.isLike("Fred").filter(s -> false);
         IsLike<String> filtered = cond.filter(s -> true);
-        assertThat(filtered.shouldRender()).isFalse();
+        assertThat(filtered.isEmpty()).isTrue();
         assertThat(cond).isSameAs(filtered);
     }
 
@@ -322,7 +322,7 @@ class FilterAndMapTest {
     void testIsLikeMapUnRenderableShouldNotThrowNullPointerException() {
         IsLike<String> cond = SqlBuilder.isLike("Fred").filter(s -> false);
         IsLike<String> mapped = cond.map(String::toUpperCase);
-        assertThat(cond.shouldRender()).isFalse();
+        assertThat(cond.isEmpty()).isTrue();
         assertThat(cond.value()).isNull();
         assertThat(cond).isSameAs(mapped);
     }
@@ -332,7 +332,7 @@ class FilterAndMapTest {
         IsLikeCaseInsensitive cond = SqlBuilder.isLikeCaseInsensitive("Fred");
         IsLikeCaseInsensitive filtered = cond.filter(s -> true);
         assertThat(filtered.value()).isEqualTo("FRED");
-        assertThat(filtered.shouldRender()).isTrue();
+        assertThat(filtered.isEmpty()).isFalse();
         assertThat(cond).isSameAs(filtered);
     }
 
@@ -340,15 +340,15 @@ class FilterAndMapTest {
     void testIsLikeCaseInsensitiveRenderableFalsePredicate() {
         IsLikeCaseInsensitive cond = SqlBuilder.isLikeCaseInsensitive("Fred");
         IsLikeCaseInsensitive filtered = cond.filter(s -> false);
-        assertThat(cond.shouldRender()).isTrue();
-        assertThat(filtered.shouldRender()).isFalse();
+        assertThat(cond.isEmpty()).isFalse();
+        assertThat(filtered.isEmpty()).isTrue();
     }
 
     @Test
     void testIsLikeCaseInsensitiveFilterUnRenderableShouldReturnSameObject() {
         IsLikeCaseInsensitive cond = SqlBuilder.isLikeCaseInsensitive("Fred").filter(s -> false);
         IsLikeCaseInsensitive filtered = cond.filter(s -> true);
-        assertThat(filtered.shouldRender()).isFalse();
+        assertThat(filtered.isEmpty()).isTrue();
         assertThat(cond).isSameAs(filtered);
     }
 
@@ -356,7 +356,7 @@ class FilterAndMapTest {
     void testIsLikeCaseInsensitiveMapUnRenderableShouldNotThrowNullPointerException() {
         IsLikeCaseInsensitive cond = SqlBuilder.isLikeCaseInsensitive("Fred").filter(s -> false);
         IsLikeCaseInsensitive mapped = cond.map(String::toUpperCase);
-        assertThat(cond.shouldRender()).isFalse();
+        assertThat(cond.isEmpty()).isTrue();
         assertThat(cond.value()).isNull();
         assertThat(cond).isSameAs(mapped);
     }
@@ -365,7 +365,7 @@ class FilterAndMapTest {
     void testIsNotLikeRenderableTruePredicateShouldReturnSameObject() {
         IsNotLike<String> cond = SqlBuilder.isNotLike("Fred");
         IsNotLike<String> filtered = cond.filter(s -> true);
-        assertThat(filtered.shouldRender()).isTrue();
+        assertThat(filtered.isEmpty()).isFalse();
         assertThat(cond).isSameAs(filtered);
     }
 
@@ -373,15 +373,15 @@ class FilterAndMapTest {
     void testIsNotLikeRenderableFalsePredicate() {
         IsNotLike<String> cond = SqlBuilder.isNotLike("Fred");
         IsNotLike<String> filtered = cond.filter(s -> false);
-        assertThat(cond.shouldRender()).isTrue();
-        assertThat(filtered.shouldRender()).isFalse();
+        assertThat(cond.isEmpty()).isFalse();
+        assertThat(filtered.isEmpty()).isTrue();
     }
 
     @Test
     void testIsNotLikeFilterUnRenderableShouldReturnSameObject() {
         IsNotLike<String> cond = SqlBuilder.isNotLike("Fred").filter(s -> false);
         IsNotLike<String> filtered = cond.filter(s -> true);
-        assertThat(filtered.shouldRender()).isFalse();
+        assertThat(filtered.isEmpty()).isTrue();
         assertThat(cond).isSameAs(filtered);
     }
 
@@ -389,7 +389,7 @@ class FilterAndMapTest {
     void testIsNotLikeMapUnRenderableShouldNotThrowNullPointerException() {
         IsNotLike<String> cond = SqlBuilder.isNotLike("Fred").filter(s -> false);
         IsNotLike<String> mapped = cond.map(String::toUpperCase);
-        assertThat(cond.shouldRender()).isFalse();
+        assertThat(cond.isEmpty()).isTrue();
         assertThat(cond.value()).isNull();
         assertThat(cond).isSameAs(mapped);
     }
@@ -399,7 +399,7 @@ class FilterAndMapTest {
         IsNotLikeCaseInsensitive cond = SqlBuilder.isNotLikeCaseInsensitive("Fred");
         IsNotLikeCaseInsensitive filtered = cond.filter(s -> true);
         assertThat(filtered.value()).isEqualTo("FRED");
-        assertThat(filtered.shouldRender()).isTrue();
+        assertThat(filtered.isEmpty()).isFalse();
         assertThat(cond).isSameAs(filtered);
     }
 
@@ -407,15 +407,15 @@ class FilterAndMapTest {
     void testIsNotLikeCaseInsensitiveRenderableFalsePredicate() {
         IsNotLikeCaseInsensitive cond = SqlBuilder.isNotLikeCaseInsensitive("Fred");
         IsNotLikeCaseInsensitive filtered = cond.filter(s -> false);
-        assertThat(cond.shouldRender()).isTrue();
-        assertThat(filtered.shouldRender()).isFalse();
+        assertThat(cond.isEmpty()).isFalse();
+        assertThat(filtered.isEmpty()).isTrue();
     }
 
     @Test
     void testIsNotLikeCaseInsensitiveFilterUnRenderableShouldReturnSameObject() {
         IsNotLikeCaseInsensitive cond = SqlBuilder.isNotLikeCaseInsensitive("Fred").filter(s -> false);
         IsNotLikeCaseInsensitive filtered = cond.filter(s -> true);
-        assertThat(filtered.shouldRender()).isFalse();
+        assertThat(filtered.isEmpty()).isTrue();
         assertThat(cond).isSameAs(filtered);
     }
 
@@ -423,7 +423,7 @@ class FilterAndMapTest {
     void testIsNotLikeCaseInsensitiveMapUnRenderableShouldNotThrowNullPointerException() {
         IsNotLikeCaseInsensitive cond = SqlBuilder.isNotLikeCaseInsensitive("Fred").filter(s -> false);
         IsNotLikeCaseInsensitive mapped = cond.map(String::toUpperCase);
-        assertThat(cond.shouldRender()).isFalse();
+        assertThat(cond.isEmpty()).isTrue();
         assertThat(cond.value()).isNull();
         assertThat(cond).isSameAs(mapped);
     }
@@ -431,7 +431,7 @@ class FilterAndMapTest {
     @Test
     void testIsInRenderableMapShouldReturnMappedObject() {
         IsIn<String> cond = SqlBuilder.isIn("Fred", "Wilma");
-        assertThat(cond.shouldRender()).isTrue();
+        assertThat(cond.isEmpty()).isFalse();
         IsIn<String> mapped = cond.map(String::toUpperCase);
         List<String> mappedValues = mapped.mapValues(Function.identity()).collect(Collectors.toList());
         assertThat(mappedValues).containsExactly("FRED", "WILMA");
@@ -440,7 +440,7 @@ class FilterAndMapTest {
     @Test
     void testIsNotInRenderableMapShouldReturnMappedObject() {
         IsNotIn<String> cond = SqlBuilder.isNotIn("Fred", "Wilma");
-        assertThat(cond.shouldRender()).isTrue();
+        assertThat(cond.isEmpty()).isFalse();
         IsNotIn<String> mapped = cond.map(String::toUpperCase);
         List<String> mappedValues = mapped.mapValues(Function.identity()).collect(Collectors.toList());
         assertThat(mappedValues).containsExactly("FRED", "WILMA");
@@ -451,7 +451,7 @@ class FilterAndMapTest {
         IsNotInCaseInsensitive cond = SqlBuilder.isNotInCaseInsensitive("Fred  ", "Wilma  ");
         List<String> values = cond.mapValues(Function.identity()).collect(Collectors.toList());
         assertThat(values).containsExactly("FRED  ", "WILMA  ");
-        assertThat(cond.shouldRender()).isTrue();
+        assertThat(cond.isEmpty()).isFalse();
 
         IsNotInCaseInsensitive mapped = cond.map(String::trim);
         List<String> mappedValues = mapped.mapValues(Function.identity()).collect(Collectors.toList());
@@ -463,7 +463,7 @@ class FilterAndMapTest {
         IsInCaseInsensitive cond = SqlBuilder.isInCaseInsensitive("Fred  ", "Wilma  ");
         List<String> values = cond.mapValues(Function.identity()).collect(Collectors.toList());
         assertThat(values).containsExactly("FRED  ", "WILMA  ");
-        assertThat(cond.shouldRender()).isTrue();
+        assertThat(cond.isEmpty()).isFalse();
 
         IsInCaseInsensitive mapped = cond.map(String::trim);
         List<String> mappedValues = mapped.mapValues(Function.identity()).collect(Collectors.toList());
@@ -473,7 +473,7 @@ class FilterAndMapTest {
     @Test
     void testBetweenUnRenderableFilterShouldReturnSameObject() {
         IsBetween<Integer> cond = SqlBuilder.isBetween(3).and(4).filter((i1, i2) -> false);
-        assertThat(cond.shouldRender()).isFalse();
+        assertThat(cond.isEmpty()).isTrue();
         IsBetween<Integer> filtered = cond.filter((v1, v2) -> true);
         assertThat(cond).isSameAs(filtered);
     }
@@ -481,7 +481,7 @@ class FilterAndMapTest {
     @Test
     void testBetweenUnRenderableFirstNullFilterShouldReturnSameObject() {
         IsBetween<Integer> cond = SqlBuilder.isBetween((Integer) null).and(4).filter(Objects::nonNull);
-        assertThat(cond.shouldRender()).isFalse();
+        assertThat(cond.isEmpty()).isTrue();
         IsBetween<Integer> filtered = cond.filter(v -> true);
         assertThat(cond).isSameAs(filtered);
     }
@@ -489,7 +489,7 @@ class FilterAndMapTest {
     @Test
     void testBetweenUnRenderableSecondNullFilterShouldReturnSameObject() {
         IsBetween<Integer> cond = SqlBuilder.isBetween(3).and((Integer) null).filter(Objects::nonNull);
-        assertThat(cond.shouldRender()).isFalse();
+        assertThat(cond.isEmpty()).isTrue();
         IsBetween<Integer> filtered = cond.filter(v -> true);
         assertThat(cond).isSameAs(filtered);
     }
@@ -497,7 +497,7 @@ class FilterAndMapTest {
     @Test
     void testBetweenMapWithSingleMapper() {
         IsBetween<Integer> cond = SqlBuilder.isBetween("3").and("4").map(Integer::parseInt);
-        assertThat(cond.shouldRender()).isTrue();
+        assertThat(cond.isEmpty()).isFalse();
         assertThat(cond.value1()).isEqualTo(3);
         assertThat(cond.value2()).isEqualTo(4);
     }
@@ -505,7 +505,7 @@ class FilterAndMapTest {
     @Test
     void testNotBetweenUnRenderableFilterShouldReturnSameObject() {
         IsNotBetween<Integer> cond = SqlBuilder.isNotBetween(3).and(4).filter((i1, i2) -> false);
-        assertThat(cond.shouldRender()).isFalse();
+        assertThat(cond.isEmpty()).isTrue();
         IsNotBetween<Integer> filtered = cond.filter((v1, v2) -> true);
         assertThat(cond).isSameAs(filtered);
     }
@@ -513,7 +513,7 @@ class FilterAndMapTest {
     @Test
     void testNotBetweenUnRenderableFirstNullFilterShouldReturnSameObject() {
         IsNotBetween<Integer> cond = SqlBuilder.isNotBetween((Integer) null).and(4).filter(Objects::nonNull);
-        assertThat(cond.shouldRender()).isFalse();
+        assertThat(cond.isEmpty()).isTrue();
         IsNotBetween<Integer> filtered = cond.filter(v -> true);
         assertThat(cond).isSameAs(filtered);
     }
@@ -521,7 +521,7 @@ class FilterAndMapTest {
     @Test
     void testNotBetweenUnRenderableSecondNullFilterShouldReturnSameObject() {
         IsNotBetween<Integer> cond = SqlBuilder.isNotBetween(3).and((Integer) null).filter(Objects::nonNull);
-        assertThat(cond.shouldRender()).isFalse();
+        assertThat(cond.isEmpty()).isTrue();
         IsNotBetween<Integer> filtered = cond.filter(v -> true);
         assertThat(cond).isSameAs(filtered);
     }
@@ -529,7 +529,7 @@ class FilterAndMapTest {
     @Test
     void testNotBetweenMapWithSingleMapper() {
         IsNotBetween<Integer> cond = SqlBuilder.isNotBetween("3").and("4").map(Integer::parseInt);
-        assertThat(cond.shouldRender()).isTrue();
+        assertThat(cond.isEmpty()).isFalse();
         assertThat(cond.value1()).isEqualTo(3);
         assertThat(cond.value2()).isEqualTo(4);
     }

--- a/src/test/java/org/mybatis/dynamic/sql/where/condition/SupplierTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/where/condition/SupplierTest.java
@@ -28,7 +28,7 @@ class SupplierTest {
         IsBetween<Integer> cond = SqlBuilder.isBetween(() -> 3).and(() -> 4);
         assertThat(cond.value1()).isEqualTo(3);
         assertThat(cond.value2()).isEqualTo(4);
-        assertThat(cond.shouldRender()).isTrue();
+        assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
@@ -36,7 +36,7 @@ class SupplierTest {
         IsBetween<Integer> cond = SqlBuilder.isBetween(() -> (Integer) null).and(() -> null);
         assertThat(cond.value1()).isNull();
         assertThat(cond.value2()).isNull();
-        assertThat(cond.shouldRender()).isTrue();
+        assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
@@ -44,7 +44,7 @@ class SupplierTest {
         IsBetween<Integer> cond = SqlBuilder.isBetweenWhenPresent(() -> 3).and(() -> 4);
         assertThat(cond.value1()).isEqualTo(3);
         assertThat(cond.value2()).isEqualTo(4);
-        assertThat(cond.shouldRender()).isTrue();
+        assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
@@ -52,7 +52,7 @@ class SupplierTest {
         IsBetween<Integer> cond = SqlBuilder.isBetweenWhenPresent(() -> (Integer) null).and(() -> null);
         assertThat(cond.value1()).isNull();
         assertThat(cond.value2()).isNull();
-        assertThat(cond.shouldRender()).isFalse();
+        assertThat(cond.isEmpty()).isTrue();
     }
 
     @Test
@@ -60,7 +60,7 @@ class SupplierTest {
         IsNotBetween<Integer> cond = SqlBuilder.isNotBetween(() -> 3).and(() -> 4);
         assertThat(cond.value1()).isEqualTo(3);
         assertThat(cond.value2()).isEqualTo(4);
-        assertThat(cond.shouldRender()).isTrue();
+        assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
@@ -68,7 +68,7 @@ class SupplierTest {
         IsNotBetween<Integer> cond = SqlBuilder.isNotBetween(() -> (Integer) null).and(() -> null);
         assertThat(cond.value1()).isNull();
         assertThat(cond.value2()).isNull();
-        assertThat(cond.shouldRender()).isTrue();
+        assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
@@ -76,7 +76,7 @@ class SupplierTest {
         IsNotBetween<Integer> cond = SqlBuilder.isNotBetweenWhenPresent(() -> 3).and(() -> 4);
         assertThat(cond.value1()).isEqualTo(3);
         assertThat(cond.value2()).isEqualTo(4);
-        assertThat(cond.shouldRender()).isTrue();
+        assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
@@ -84,272 +84,272 @@ class SupplierTest {
         IsNotBetween<Integer> cond = SqlBuilder.isNotBetweenWhenPresent(() -> (Integer) null).and(() -> null);
         assertThat(cond.value1()).isNull();
         assertThat(cond.value2()).isNull();
-        assertThat(cond.shouldRender()).isFalse();
+        assertThat(cond.isEmpty()).isTrue();
     }
 
     @Test
     void testIsEqualToWhenPresent() {
         IsEqualTo<Integer> cond = SqlBuilder.isEqualToWhenPresent(() -> 3);
         assertThat(cond.value()).isEqualTo(3);
-        assertThat(cond.shouldRender()).isTrue();
+        assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsEqualToWhenPresentNull() {
         IsEqualTo<Integer> cond = SqlBuilder.isEqualToWhenPresent(() -> null);
         assertThat(cond.value()).isNull();
-        assertThat(cond.shouldRender()).isFalse();
+        assertThat(cond.isEmpty()).isTrue();
     }
 
     @Test
     void testIsNotEqualTo() {
         IsNotEqualTo<Integer> cond = SqlBuilder.isNotEqualTo(() -> 3);
         assertThat(cond.value()).isEqualTo(3);
-        assertThat(cond.shouldRender()).isTrue();
+        assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsNotEqualToNull() {
         IsNotEqualTo<Integer> cond = SqlBuilder.isNotEqualTo(() -> (Integer) null);
         assertThat(cond.value()).isNull();
-        assertThat(cond.shouldRender()).isTrue();
+        assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsNotEqualToWhenPresent() {
         IsNotEqualTo<Integer> cond = SqlBuilder.isNotEqualToWhenPresent(() -> 3);
         assertThat(cond.value()).isEqualTo(3);
-        assertThat(cond.shouldRender()).isTrue();
+        assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsNotEqualToWhenPresentNull() {
         IsNotEqualTo<Integer> cond = SqlBuilder.isNotEqualToWhenPresent(() -> null);
         assertThat(cond.value()).isNull();
-        assertThat(cond.shouldRender()).isFalse();
+        assertThat(cond.isEmpty()).isTrue();
     }
 
     @Test
     void testIsGreaterThan() {
         IsGreaterThan<Integer> cond = SqlBuilder.isGreaterThan(() -> 3);
         assertThat(cond.value()).isEqualTo(3);
-        assertThat(cond.shouldRender()).isTrue();
+        assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsGreaterThanNull() {
         IsGreaterThan<Integer> cond = SqlBuilder.isGreaterThan(() -> (Integer) null);
         assertThat(cond.value()).isNull();
-        assertThat(cond.shouldRender()).isTrue();
+        assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsGreaterThanWhenPresent() {
         IsGreaterThan<Integer> cond = SqlBuilder.isGreaterThanWhenPresent(() -> 3);
         assertThat(cond.value()).isEqualTo(3);
-        assertThat(cond.shouldRender()).isTrue();
+        assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsGreaterThanWhenPresentNull() {
         IsGreaterThan<Integer> cond = SqlBuilder.isGreaterThanWhenPresent(() -> null);
         assertThat(cond.value()).isNull();
-        assertThat(cond.shouldRender()).isFalse();
+        assertThat(cond.isEmpty()).isTrue();
     }
 
     @Test
     void testIsGreaterThanOrEqualTo() {
         IsGreaterThanOrEqualTo<Integer> cond = SqlBuilder.isGreaterThanOrEqualTo(() -> 3);
         assertThat(cond.value()).isEqualTo(3);
-        assertThat(cond.shouldRender()).isTrue();
+        assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsGreaterThanOrEqualToNull() {
         IsGreaterThanOrEqualTo<Integer> cond = SqlBuilder.isGreaterThanOrEqualTo(() -> (Integer) null);
         assertThat(cond.value()).isNull();
-        assertThat(cond.shouldRender()).isTrue();
+        assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsGreaterThanOrEqualToWhenPresent() {
         IsGreaterThanOrEqualTo<Integer> cond = SqlBuilder.isGreaterThanOrEqualToWhenPresent(() -> 3);
         assertThat(cond.value()).isEqualTo(3);
-        assertThat(cond.shouldRender()).isTrue();
+        assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsGreaterThanOrEqualToWhenPresentNull() {
         IsGreaterThanOrEqualTo<Integer> cond = SqlBuilder.isGreaterThanOrEqualToWhenPresent(() -> null);
         assertThat(cond.value()).isNull();
-        assertThat(cond.shouldRender()).isFalse();
+        assertThat(cond.isEmpty()).isTrue();
     }
 
     @Test
     void testIsLessThan() {
         IsLessThan<Integer> cond = SqlBuilder.isLessThan(() -> 3);
         assertThat(cond.value()).isEqualTo(3);
-        assertThat(cond.shouldRender()).isTrue();
+        assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsLessThanNull() {
         IsLessThan<Integer> cond = SqlBuilder.isLessThan(() -> (Integer) null);
         assertThat(cond.value()).isNull();
-        assertThat(cond.shouldRender()).isTrue();
+        assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsLessThanWhenPresent() {
         IsLessThan<Integer> cond = SqlBuilder.isLessThanWhenPresent(() -> 3);
         assertThat(cond.value()).isEqualTo(3);
-        assertThat(cond.shouldRender()).isTrue();
+        assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsLessThanWhenPresentNull() {
         IsLessThan<Integer> cond = SqlBuilder.isLessThanWhenPresent(() -> null);
         assertThat(cond.value()).isNull();
-        assertThat(cond.shouldRender()).isFalse();
+        assertThat(cond.isEmpty()).isTrue();
     }
 
     @Test
     void testIsLessThanOrEqualTo() {
         IsLessThanOrEqualTo<Integer> cond = SqlBuilder.isLessThanOrEqualTo(() -> 3);
         assertThat(cond.value()).isEqualTo(3);
-        assertThat(cond.shouldRender()).isTrue();
+        assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsLessThanOrEqualToNull() {
         IsLessThanOrEqualTo<Integer> cond = SqlBuilder.isLessThanOrEqualTo(() -> (Integer) null);
         assertThat(cond.value()).isNull();
-        assertThat(cond.shouldRender()).isTrue();
+        assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsLessThanOrEqualToWhenPresent() {
         IsLessThanOrEqualTo<Integer> cond = SqlBuilder.isLessThanOrEqualToWhenPresent(() -> 3);
         assertThat(cond.value()).isEqualTo(3);
-        assertThat(cond.shouldRender()).isTrue();
+        assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsLessThanOrEqualToWhenPresentNull() {
         IsLessThanOrEqualTo<Integer> cond = SqlBuilder.isLessThanOrEqualToWhenPresent(() -> null);
         assertThat(cond.value()).isNull();
-        assertThat(cond.shouldRender()).isFalse();
+        assertThat(cond.isEmpty()).isTrue();
     }
 
     @Test
     void testIsLike() {
         IsLike<String> cond = SqlBuilder.isLike(() -> "%F%");
         assertThat(cond.value()).isEqualTo("%F%");
-        assertThat(cond.shouldRender()).isTrue();
+        assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsLikeNull() {
         IsLike<String> cond = SqlBuilder.isLike(() -> null);
         assertThat(cond.value()).isNull();
-        assertThat(cond.shouldRender()).isTrue();
+        assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsLikeCaseInsensitive() {
         IsLikeCaseInsensitive cond = SqlBuilder.isLikeCaseInsensitive(() -> "%f%");
         assertThat(cond.value()).isEqualTo("%F%");
-        assertThat(cond.shouldRender()).isTrue();
+        assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsLikeCaseInsensitiveNull() {
         IsLikeCaseInsensitive cond = SqlBuilder.isLikeCaseInsensitive(() -> null);
         assertThat(cond.value()).isNull();
-        assertThat(cond.shouldRender()).isTrue();
+        assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsLikeCaseInsensitiveWhenPresent() {
         IsLikeCaseInsensitive cond = SqlBuilder.isLikeCaseInsensitiveWhenPresent(() -> "%f%");
         assertThat(cond.value()).isEqualTo("%F%");
-        assertThat(cond.shouldRender()).isTrue();
+        assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsLikeCaseInsensitiveWhenPresentNull() {
         IsLikeCaseInsensitive cond = SqlBuilder.isLikeCaseInsensitiveWhenPresent(() -> null);
         assertThat(cond.value()).isNull();
-        assertThat(cond.shouldRender()).isFalse();
+        assertThat(cond.isEmpty()).isTrue();
     }
 
     @Test
     void testIsLikeWhenPresent() {
         IsLike<String> cond = SqlBuilder.isLikeWhenPresent(() -> "%F%");
         assertThat(cond.value()).isEqualTo("%F%");
-        assertThat(cond.shouldRender()).isTrue();
+        assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsLikeWhenPresentNull() {
         IsLike<String> cond = SqlBuilder.isLikeWhenPresent(() -> null);
         assertThat(cond.value()).isNull();
-        assertThat(cond.shouldRender()).isFalse();
+        assertThat(cond.isEmpty()).isTrue();
     }
 
     @Test
     void testIsNotLike() {
         IsNotLike<String> cond = SqlBuilder.isNotLike(() -> "%F%");
         assertThat(cond.value()).isEqualTo("%F%");
-        assertThat(cond.shouldRender()).isTrue();
+        assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsNotLikeNull() {
         IsNotLike<String> cond = SqlBuilder.isNotLike(() -> null);
         assertThat(cond.value()).isNull();
-        assertThat(cond.shouldRender()).isTrue();
+        assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsNotLikeWhenPresent() {
         IsNotLike<String> cond = SqlBuilder.isNotLikeWhenPresent(() -> "%F%");
         assertThat(cond.value()).isEqualTo("%F%");
-        assertThat(cond.shouldRender()).isTrue();
+        assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsNotLikeWhenPresentNull() {
         IsNotLike<String> cond = SqlBuilder.isNotLikeWhenPresent(() -> null);
         assertThat(cond.value()).isNull();
-        assertThat(cond.shouldRender()).isFalse();
+        assertThat(cond.isEmpty()).isTrue();
     }
 
     @Test
     void testIsNotLikeCaseInsensitive() {
         IsNotLikeCaseInsensitive cond = SqlBuilder.isNotLikeCaseInsensitive(() -> "%f%");
         assertThat(cond.value()).isEqualTo("%F%");
-        assertThat(cond.shouldRender()).isTrue();
+        assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsNotLikeCaseInsensitiveNull() {
         IsNotLikeCaseInsensitive cond = SqlBuilder.isNotLikeCaseInsensitive(() -> null);
         assertThat(cond.value()).isNull();
-        assertThat(cond.shouldRender()).isTrue();
+        assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsNotLikeCaseInsensitiveWhenPresent() {
         IsNotLikeCaseInsensitive cond = SqlBuilder.isNotLikeCaseInsensitiveWhenPresent(() -> "%f%");
         assertThat(cond.value()).isEqualTo("%F%");
-        assertThat(cond.shouldRender()).isTrue();
+        assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsNotLikeCaseInsensitiveWhenPresentNull() {
         IsNotLikeCaseInsensitive cond = SqlBuilder.isNotLikeCaseInsensitiveWhenPresent(() -> null);
         assertThat(cond.value()).isNull();
-        assertThat(cond.shouldRender()).isFalse();
+        assertThat(cond.isEmpty()).isTrue();
     }
 }


### PR DESCRIPTION
This change separates the concept of an empty condition from that of a renderable condition. This will enable a future change where conditions could decide to allow rendering even if they are considered empty (such as rendering empty lists). This change should be transparent to users unless they have implemented custom conditions.

This is a refactoring slice that will enable a simpler change for #752 
