### PR TITLE
Refactoring Slice - Add Statement Configuration to Rendering Context

### DIFF
--- a/src/main/java/org/mybatis/dynamic/sql/StringConstant.java
+++ b/src/main/java/org/mybatis/dynamic/sql/StringConstant.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 
 import org.mybatis.dynamic.sql.render.RenderingContext;
 import org.mybatis.dynamic.sql.util.FragmentAndParameters;
+import org.mybatis.dynamic.sql.util.StringUtilities;
 
 public class StringConstant implements BindableColumn<String> {
 
@@ -42,8 +43,7 @@ public class StringConstant implements BindableColumn<String> {
 
     @Override
     public FragmentAndParameters render(RenderingContext renderingContext) {
-        String escaped = value.replace("'", "''"); //$NON-NLS-1$ //$NON-NLS-2$
-        return FragmentAndParameters.fromFragment("'" + escaped + "'"); //$NON-NLS-1$ //$NON-NLS-2$
+        return FragmentAndParameters.fromFragment(StringUtilities.formatConstantForSQL(value));
     }
 
     @Override

--- a/src/main/java/org/mybatis/dynamic/sql/common/AbstractBooleanExpressionModel.java
+++ b/src/main/java/org/mybatis/dynamic/sql/common/AbstractBooleanExpressionModel.java
@@ -25,11 +25,11 @@ import org.mybatis.dynamic.sql.SqlCriterion;
 
 public abstract class AbstractBooleanExpressionModel {
     private final SqlCriterion initialCriterion;
-    private final List<AndOrCriteriaGroup> subCriteria = new ArrayList<>();
+    private final List<AndOrCriteriaGroup> subCriteria ;
 
-    protected AbstractBooleanExpressionModel(SqlCriterion initialCriterion, List<AndOrCriteriaGroup> subCriteria) {
-        this.initialCriterion = initialCriterion;
-        this.subCriteria.addAll(subCriteria);
+    protected AbstractBooleanExpressionModel(AbstractBuilder<?> builder) {
+        initialCriterion = builder.initialCriterion;
+        subCriteria = builder.subCriteria;
     }
 
     public Optional<SqlCriterion> initialCriterion() {
@@ -38,5 +38,22 @@ public abstract class AbstractBooleanExpressionModel {
 
     public List<AndOrCriteriaGroup> subCriteria() {
         return Collections.unmodifiableList(subCriteria);
+    }
+
+    public abstract static class AbstractBuilder<T extends AbstractBuilder<T>> {
+        private SqlCriterion initialCriterion;
+        private final List<AndOrCriteriaGroup> subCriteria = new ArrayList<>();
+
+        public T withInitialCriterion(SqlCriterion initialCriterion) {
+            this.initialCriterion = initialCriterion;
+            return getThis();
+        }
+
+        public T withSubCriteria(List<AndOrCriteriaGroup> subCriteria) {
+            this.subCriteria.addAll(subCriteria);
+            return getThis();
+        }
+
+        protected abstract T getThis();
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/common/AbstractBooleanExpressionRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/common/AbstractBooleanExpressionRenderer.java
@@ -32,11 +32,13 @@ public abstract class AbstractBooleanExpressionRenderer<M extends AbstractBoolea
     protected final M model;
     private final String prefix;
     private final CriterionRenderer criterionRenderer;
+    protected final RenderingContext renderingContext;
 
     protected AbstractBooleanExpressionRenderer(String prefix, AbstractBuilder<M, ?> builder) {
         model = Objects.requireNonNull(builder.model);
         this.prefix = Objects.requireNonNull(prefix);
-        criterionRenderer = new CriterionRenderer(builder.renderingContext);
+        renderingContext = Objects.requireNonNull(builder.renderingContext);
+        criterionRenderer = new CriterionRenderer(renderingContext);
     }
 
     public Optional<FragmentAndParameters> render() {

--- a/src/main/java/org/mybatis/dynamic/sql/common/AbstractBooleanExpressionRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/common/AbstractBooleanExpressionRenderer.java
@@ -28,13 +28,13 @@ import org.mybatis.dynamic.sql.util.FragmentCollector;
 import org.mybatis.dynamic.sql.where.render.CriterionRenderer;
 import org.mybatis.dynamic.sql.where.render.RenderedCriterion;
 
-public abstract class AbstractBooleanExpressionRenderer<M extends AbstractBooleanExpressionModel> {
-    protected final M model;
+public abstract class AbstractBooleanExpressionRenderer {
+    protected final AbstractBooleanExpressionModel model;
     private final String prefix;
     private final CriterionRenderer criterionRenderer;
     protected final RenderingContext renderingContext;
 
-    protected AbstractBooleanExpressionRenderer(String prefix, AbstractBuilder<M, ?> builder) {
+    protected AbstractBooleanExpressionRenderer(String prefix, AbstractBuilder<?> builder) {
         model = Objects.requireNonNull(builder.model);
         this.prefix = Objects.requireNonNull(prefix);
         renderingContext = Objects.requireNonNull(builder.renderingContext);
@@ -82,11 +82,11 @@ public abstract class AbstractBooleanExpressionRenderer<M extends AbstractBoolea
         return spaceAfter(prefix) + fragment;
     }
 
-    public abstract static class AbstractBuilder<M, B extends AbstractBuilder<M, B>> {
-        private final M model;
+    public abstract static class AbstractBuilder<B extends AbstractBuilder<B>> {
+        private final AbstractBooleanExpressionModel model;
         private RenderingContext renderingContext;
 
-        protected AbstractBuilder(M model) {
+        protected AbstractBuilder(AbstractBooleanExpressionModel model) {
             this.model = model;
         }
 

--- a/src/main/java/org/mybatis/dynamic/sql/common/CommonBuilder.java
+++ b/src/main/java/org/mybatis/dynamic/sql/common/CommonBuilder.java
@@ -17,7 +17,7 @@ package org.mybatis.dynamic.sql.common;
 
 import org.mybatis.dynamic.sql.SqlTable;
 import org.mybatis.dynamic.sql.configuration.StatementConfiguration;
-import org.mybatis.dynamic.sql.where.WhereModel;
+import org.mybatis.dynamic.sql.where.EmbeddedWhereModel;
 
 /**
  * Builder class shared between the delete and update model builders.
@@ -27,7 +27,7 @@ import org.mybatis.dynamic.sql.where.WhereModel;
 public abstract class CommonBuilder<T extends CommonBuilder<T>> {
     private SqlTable table;
     private String tableAlias;
-    private WhereModel whereModel;
+    private EmbeddedWhereModel whereModel;
     private Long limit;
     private OrderByModel orderByModel;
     private StatementConfiguration statementConfiguration;
@@ -40,7 +40,7 @@ public abstract class CommonBuilder<T extends CommonBuilder<T>> {
         return tableAlias;
     }
 
-    public WhereModel whereModel() {
+    public EmbeddedWhereModel whereModel() {
         return whereModel;
     }
 
@@ -66,7 +66,7 @@ public abstract class CommonBuilder<T extends CommonBuilder<T>> {
         return getThis();
     }
 
-    public T withWhereModel(WhereModel whereModel) {
+    public T withWhereModel(EmbeddedWhereModel whereModel) {
         this.whereModel = whereModel;
         return getThis();
     }

--- a/src/main/java/org/mybatis/dynamic/sql/common/CommonBuilder.java
+++ b/src/main/java/org/mybatis/dynamic/sql/common/CommonBuilder.java
@@ -16,6 +16,7 @@
 package org.mybatis.dynamic.sql.common;
 
 import org.mybatis.dynamic.sql.SqlTable;
+import org.mybatis.dynamic.sql.configuration.StatementConfiguration;
 import org.mybatis.dynamic.sql.where.WhereModel;
 
 /**
@@ -29,6 +30,7 @@ public abstract class CommonBuilder<T extends CommonBuilder<T>> {
     private WhereModel whereModel;
     private Long limit;
     private OrderByModel orderByModel;
+    private StatementConfiguration statementConfiguration;
 
     public SqlTable table() {
         return table;
@@ -48,6 +50,10 @@ public abstract class CommonBuilder<T extends CommonBuilder<T>> {
 
     public OrderByModel orderByModel() {
         return orderByModel;
+    }
+
+    public StatementConfiguration statementConfiguration() {
+        return statementConfiguration;
     }
 
     public T withTable(SqlTable table) {
@@ -72,6 +78,11 @@ public abstract class CommonBuilder<T extends CommonBuilder<T>> {
 
     public T withOrderByModel(OrderByModel orderByModel) {
         this.orderByModel = orderByModel;
+        return getThis();
+    }
+
+    public T withStatementConfiguration(StatementConfiguration statementConfiguration) {
+        this.statementConfiguration = statementConfiguration;
         return getThis();
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/delete/DeleteDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/delete/DeleteDSL.java
@@ -30,7 +30,7 @@ import org.mybatis.dynamic.sql.util.Buildable;
 import org.mybatis.dynamic.sql.util.Utilities;
 import org.mybatis.dynamic.sql.where.AbstractWhereFinisher;
 import org.mybatis.dynamic.sql.where.AbstractWhereStarter;
-import org.mybatis.dynamic.sql.where.WhereModel;
+import org.mybatis.dynamic.sql.where.EmbeddedWhereModel;
 
 public class DeleteDSL<R> extends AbstractWhereStarter<DeleteDSL<R>.DeleteWhereBuilder, DeleteDSL<R>>
         implements Buildable<R> {
@@ -111,7 +111,7 @@ public class DeleteDSL<R> extends AbstractWhereStarter<DeleteDSL<R>.DeleteWhereB
     public class DeleteWhereBuilder extends AbstractWhereFinisher<DeleteWhereBuilder> implements Buildable<R> {
 
         private DeleteWhereBuilder() {
-            super(statementConfiguration);
+            super(DeleteDSL.this);
         }
 
         public DeleteDSL<R> limit(long limit) {
@@ -138,7 +138,7 @@ public class DeleteDSL<R> extends AbstractWhereStarter<DeleteDSL<R>.DeleteWhereB
             return this;
         }
 
-        protected WhereModel buildWhereModel() {
+        protected EmbeddedWhereModel buildWhereModel() {
             return buildModel();
         }
     }

--- a/src/main/java/org/mybatis/dynamic/sql/delete/DeleteDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/delete/DeleteDSL.java
@@ -83,6 +83,7 @@ public class DeleteDSL<R> extends AbstractWhereStarter<DeleteDSL<R>.DeleteWhereB
                 .withLimit(limit)
                 .withOrderByModel(orderByModel)
                 .withWhereModel(whereBuilder == null ? null : whereBuilder.buildWhereModel())
+                .withStatementConfiguration(statementConfiguration)
                 .build();
 
         return adapterFunction.apply(deleteModel);

--- a/src/main/java/org/mybatis/dynamic/sql/delete/DeleteModel.java
+++ b/src/main/java/org/mybatis/dynamic/sql/delete/DeleteModel.java
@@ -22,6 +22,7 @@ import org.jetbrains.annotations.NotNull;
 import org.mybatis.dynamic.sql.SqlTable;
 import org.mybatis.dynamic.sql.common.CommonBuilder;
 import org.mybatis.dynamic.sql.common.OrderByModel;
+import org.mybatis.dynamic.sql.configuration.StatementConfiguration;
 import org.mybatis.dynamic.sql.delete.render.DeleteRenderer;
 import org.mybatis.dynamic.sql.delete.render.DeleteStatementProvider;
 import org.mybatis.dynamic.sql.render.RenderingStrategy;
@@ -33,6 +34,7 @@ public class DeleteModel {
     private final WhereModel whereModel;
     private final Long limit;
     private final OrderByModel orderByModel;
+    private final StatementConfiguration statementConfiguration;
 
     private DeleteModel(Builder builder) {
         table = Objects.requireNonNull(builder.table());
@@ -40,6 +42,7 @@ public class DeleteModel {
         tableAlias = builder.tableAlias();
         limit = builder.limit();
         orderByModel = builder.orderByModel();
+        statementConfiguration = Objects.requireNonNull(builder.statementConfiguration());
     }
 
     public SqlTable table() {
@@ -66,6 +69,7 @@ public class DeleteModel {
     public DeleteStatementProvider render(RenderingStrategy renderingStrategy) {
         return DeleteRenderer.withDeleteModel(this)
                 .withRenderingStrategy(renderingStrategy)
+                .withStatementConfiguration(statementConfiguration)
                 .build()
                 .render();
     }

--- a/src/main/java/org/mybatis/dynamic/sql/delete/DeleteModel.java
+++ b/src/main/java/org/mybatis/dynamic/sql/delete/DeleteModel.java
@@ -26,12 +26,12 @@ import org.mybatis.dynamic.sql.configuration.StatementConfiguration;
 import org.mybatis.dynamic.sql.delete.render.DeleteRenderer;
 import org.mybatis.dynamic.sql.delete.render.DeleteStatementProvider;
 import org.mybatis.dynamic.sql.render.RenderingStrategy;
-import org.mybatis.dynamic.sql.where.WhereModel;
+import org.mybatis.dynamic.sql.where.EmbeddedWhereModel;
 
 public class DeleteModel {
     private final SqlTable table;
     private final String tableAlias;
-    private final WhereModel whereModel;
+    private final EmbeddedWhereModel whereModel;
     private final Long limit;
     private final OrderByModel orderByModel;
     private final StatementConfiguration statementConfiguration;
@@ -53,7 +53,7 @@ public class DeleteModel {
         return Optional.ofNullable(tableAlias);
     }
 
-    public Optional<WhereModel> whereModel() {
+    public Optional<EmbeddedWhereModel> whereModel() {
         return Optional.ofNullable(whereModel);
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/delete/render/DeleteRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/delete/render/DeleteRenderer.java
@@ -41,11 +41,10 @@ public class DeleteRenderer {
         TableAliasCalculator tableAliasCalculator = builder.deleteModel.tableAlias()
                 .map(a -> ExplicitTableAliasCalculator.of(deleteModel.table(), a))
                 .orElseGet(TableAliasCalculator::empty);
-        // TODO - Add configuration to RenderingContext
-        Objects.requireNonNull(builder.statementConfiguration);
         renderingContext = RenderingContext
                 .withRenderingStrategy(Objects.requireNonNull(builder.renderingStrategy))
                 .withTableAliasCalculator(tableAliasCalculator)
+                .withStatementConfiguration(builder.statementConfiguration)
                 .build();
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/delete/render/DeleteRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/delete/render/DeleteRenderer.java
@@ -31,7 +31,6 @@ import org.mybatis.dynamic.sql.render.TableAliasCalculator;
 import org.mybatis.dynamic.sql.util.FragmentAndParameters;
 import org.mybatis.dynamic.sql.util.FragmentCollector;
 import org.mybatis.dynamic.sql.where.WhereModel;
-import org.mybatis.dynamic.sql.where.render.WhereRenderer;
 
 public class DeleteRenderer {
     private final DeleteModel deleteModel;
@@ -78,10 +77,7 @@ public class DeleteRenderer {
     }
 
     private Optional<FragmentAndParameters> renderWhereClause(WhereModel whereModel) {
-        return WhereRenderer.withWhereModel(whereModel)
-                .withRenderingContext(renderingContext)
-                .build()
-                .render();
+        return whereModel.render(renderingContext);
     }
 
     private Optional<FragmentAndParameters> calculateLimitClause() {

--- a/src/main/java/org/mybatis/dynamic/sql/delete/render/DeleteRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/delete/render/DeleteRenderer.java
@@ -21,6 +21,7 @@ import java.util.stream.Collectors;
 
 import org.mybatis.dynamic.sql.common.OrderByModel;
 import org.mybatis.dynamic.sql.common.OrderByRenderer;
+import org.mybatis.dynamic.sql.configuration.StatementConfiguration;
 import org.mybatis.dynamic.sql.delete.DeleteModel;
 import org.mybatis.dynamic.sql.render.ExplicitTableAliasCalculator;
 import org.mybatis.dynamic.sql.render.RenderedParameterInfo;
@@ -41,6 +42,8 @@ public class DeleteRenderer {
         TableAliasCalculator tableAliasCalculator = builder.deleteModel.tableAlias()
                 .map(a -> ExplicitTableAliasCalculator.of(deleteModel.table(), a))
                 .orElseGet(TableAliasCalculator::empty);
+        // TODO - Add configuration to RenderingContext
+        Objects.requireNonNull(builder.statementConfiguration);
         renderingContext = RenderingContext
                 .withRenderingStrategy(Objects.requireNonNull(builder.renderingStrategy))
                 .withTableAliasCalculator(tableAliasCalculator)
@@ -108,6 +111,7 @@ public class DeleteRenderer {
     public static class Builder {
         private DeleteModel deleteModel;
         private RenderingStrategy renderingStrategy;
+        private StatementConfiguration statementConfiguration;
 
         public Builder withDeleteModel(DeleteModel deleteModel) {
             this.deleteModel = deleteModel;
@@ -116,6 +120,11 @@ public class DeleteRenderer {
 
         public Builder withRenderingStrategy(RenderingStrategy renderingStrategy) {
             this.renderingStrategy = renderingStrategy;
+            return this;
+        }
+
+        public Builder withStatementConfiguration(StatementConfiguration statementConfiguration) {
+            this.statementConfiguration = statementConfiguration;
             return this;
         }
 

--- a/src/main/java/org/mybatis/dynamic/sql/delete/render/DeleteRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/delete/render/DeleteRenderer.java
@@ -30,7 +30,7 @@ import org.mybatis.dynamic.sql.render.RenderingStrategy;
 import org.mybatis.dynamic.sql.render.TableAliasCalculator;
 import org.mybatis.dynamic.sql.util.FragmentAndParameters;
 import org.mybatis.dynamic.sql.util.FragmentCollector;
-import org.mybatis.dynamic.sql.where.WhereModel;
+import org.mybatis.dynamic.sql.where.EmbeddedWhereModel;
 
 public class DeleteRenderer {
     private final DeleteModel deleteModel;
@@ -75,7 +75,7 @@ public class DeleteRenderer {
         return deleteModel.whereModel().flatMap(this::renderWhereClause);
     }
 
-    private Optional<FragmentAndParameters> renderWhereClause(WhereModel whereModel) {
+    private Optional<FragmentAndParameters> renderWhereClause(EmbeddedWhereModel whereModel) {
         return whereModel.render(renderingContext);
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/insert/GeneralInsertDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/GeneralInsertDSL.java
@@ -19,13 +19,16 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import org.jetbrains.annotations.NotNull;
 import org.mybatis.dynamic.sql.SqlColumn;
 import org.mybatis.dynamic.sql.SqlTable;
+import org.mybatis.dynamic.sql.configuration.StatementConfiguration;
 import org.mybatis.dynamic.sql.util.AbstractColumnMapping;
 import org.mybatis.dynamic.sql.util.Buildable;
+import org.mybatis.dynamic.sql.util.ConfigurableStatement;
 import org.mybatis.dynamic.sql.util.ConstantMapping;
 import org.mybatis.dynamic.sql.util.NullMapping;
 import org.mybatis.dynamic.sql.util.StringConstantMapping;
@@ -33,9 +36,10 @@ import org.mybatis.dynamic.sql.util.ValueMapping;
 import org.mybatis.dynamic.sql.util.ValueOrNullMapping;
 import org.mybatis.dynamic.sql.util.ValueWhenPresentMapping;
 
-public class GeneralInsertDSL implements Buildable<GeneralInsertModel> {
+public class GeneralInsertDSL implements Buildable<GeneralInsertModel>, ConfigurableStatement<GeneralInsertDSL> {
     private final List<AbstractColumnMapping> columnMappings;
     private final SqlTable table;
+    private final StatementConfiguration statementConfiguration = new StatementConfiguration();
 
     private GeneralInsertDSL(Builder builder) {
         table = Objects.requireNonNull(builder.table);
@@ -52,11 +56,18 @@ public class GeneralInsertDSL implements Buildable<GeneralInsertModel> {
         return new GeneralInsertModel.Builder()
                 .withTable(table)
                 .withInsertMappings(columnMappings)
+                .withStatementConfiguration(statementConfiguration)
                 .build();
     }
 
     public static GeneralInsertDSL insertInto(SqlTable table) {
         return new GeneralInsertDSL.Builder().withTable(table).build();
+    }
+
+    @Override
+    public GeneralInsertDSL configureStatement(Consumer<StatementConfiguration> consumer) {
+        consumer.accept(statementConfiguration);
+        return this;
     }
 
     public class SetClauseFinisher<T> {

--- a/src/main/java/org/mybatis/dynamic/sql/insert/GeneralInsertDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/GeneralInsertDSL.java
@@ -19,7 +19,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import org.jetbrains.annotations.NotNull;
@@ -28,7 +27,6 @@ import org.mybatis.dynamic.sql.SqlTable;
 import org.mybatis.dynamic.sql.configuration.StatementConfiguration;
 import org.mybatis.dynamic.sql.util.AbstractColumnMapping;
 import org.mybatis.dynamic.sql.util.Buildable;
-import org.mybatis.dynamic.sql.util.ConfigurableStatement;
 import org.mybatis.dynamic.sql.util.ConstantMapping;
 import org.mybatis.dynamic.sql.util.NullMapping;
 import org.mybatis.dynamic.sql.util.StringConstantMapping;
@@ -36,10 +34,9 @@ import org.mybatis.dynamic.sql.util.ValueMapping;
 import org.mybatis.dynamic.sql.util.ValueOrNullMapping;
 import org.mybatis.dynamic.sql.util.ValueWhenPresentMapping;
 
-public class GeneralInsertDSL implements Buildable<GeneralInsertModel>, ConfigurableStatement<GeneralInsertDSL> {
+public class GeneralInsertDSL implements Buildable<GeneralInsertModel> {
     private final List<AbstractColumnMapping> columnMappings;
     private final SqlTable table;
-    private final StatementConfiguration statementConfiguration = new StatementConfiguration();
 
     private GeneralInsertDSL(Builder builder) {
         table = Objects.requireNonNull(builder.table);
@@ -56,18 +53,12 @@ public class GeneralInsertDSL implements Buildable<GeneralInsertModel>, Configur
         return new GeneralInsertModel.Builder()
                 .withTable(table)
                 .withInsertMappings(columnMappings)
-                .withStatementConfiguration(statementConfiguration)
+                .withStatementConfiguration(new StatementConfiguration()) // nothing configurable in this statement yet
                 .build();
     }
 
     public static GeneralInsertDSL insertInto(SqlTable table) {
         return new GeneralInsertDSL.Builder().withTable(table).build();
-    }
-
-    @Override
-    public GeneralInsertDSL configureStatement(Consumer<StatementConfiguration> consumer) {
-        consumer.accept(statementConfiguration);
-        return this;
     }
 
     public class SetClauseFinisher<T> {

--- a/src/main/java/org/mybatis/dynamic/sql/insert/GeneralInsertModel.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/GeneralInsertModel.java
@@ -23,6 +23,7 @@ import java.util.stream.Stream;
 
 import org.jetbrains.annotations.NotNull;
 import org.mybatis.dynamic.sql.SqlTable;
+import org.mybatis.dynamic.sql.configuration.StatementConfiguration;
 import org.mybatis.dynamic.sql.insert.render.GeneralInsertRenderer;
 import org.mybatis.dynamic.sql.insert.render.GeneralInsertStatementProvider;
 import org.mybatis.dynamic.sql.render.RenderingStrategy;
@@ -33,11 +34,13 @@ public class GeneralInsertModel {
 
     private final SqlTable table;
     private final List<AbstractColumnMapping> insertMappings;
+    private final StatementConfiguration statementConfiguration;
 
     private GeneralInsertModel(Builder builder) {
         table = Objects.requireNonNull(builder.table);
         Validator.assertNotEmpty(builder.insertMappings, "ERROR.6"); //$NON-NLS-1$
         insertMappings = builder.insertMappings;
+        statementConfiguration = Objects.requireNonNull(builder.statementConfiguration);
     }
 
     public <R> Stream<R> mapColumnMappings(Function<AbstractColumnMapping, R> mapper) {
@@ -52,6 +55,7 @@ public class GeneralInsertModel {
     public GeneralInsertStatementProvider render(RenderingStrategy renderingStrategy) {
         return GeneralInsertRenderer.withInsertModel(this)
                 .withRenderingStrategy(renderingStrategy)
+                .withStatementConfiguration(statementConfiguration)
                 .build()
                 .render();
     }
@@ -59,6 +63,7 @@ public class GeneralInsertModel {
     public static class Builder {
         private SqlTable table;
         private final List<AbstractColumnMapping> insertMappings = new ArrayList<>();
+        private StatementConfiguration statementConfiguration;
 
         public Builder withTable(SqlTable table) {
             this.table = table;
@@ -67,6 +72,11 @@ public class GeneralInsertModel {
 
         public Builder withInsertMappings(List<? extends AbstractColumnMapping> insertMappings) {
             this.insertMappings.addAll(insertMappings);
+            return this;
+        }
+
+        public Builder withStatementConfiguration(StatementConfiguration statementConfiguration) {
+            this.statementConfiguration = statementConfiguration;
             return this;
         }
 

--- a/src/main/java/org/mybatis/dynamic/sql/insert/InsertSelectDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/InsertSelectDSL.java
@@ -18,18 +18,22 @@ package org.mybatis.dynamic.sql.insert;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Consumer;
 
 import org.jetbrains.annotations.NotNull;
 import org.mybatis.dynamic.sql.SqlColumn;
 import org.mybatis.dynamic.sql.SqlTable;
+import org.mybatis.dynamic.sql.configuration.StatementConfiguration;
 import org.mybatis.dynamic.sql.select.SelectModel;
 import org.mybatis.dynamic.sql.util.Buildable;
+import org.mybatis.dynamic.sql.util.ConfigurableStatement;
 
-public class InsertSelectDSL implements Buildable<InsertSelectModel> {
+public class InsertSelectDSL implements Buildable<InsertSelectModel>, ConfigurableStatement<InsertSelectDSL> {
 
     private final SqlTable table;
     private final InsertColumnListModel columnList;
     private final SelectModel selectModel;
+    private final StatementConfiguration statementConfiguration = new StatementConfiguration();
 
     private InsertSelectDSL(SqlTable table, InsertColumnListModel columnList, SelectModel selectModel) {
         this.table = Objects.requireNonNull(table);
@@ -49,11 +53,18 @@ public class InsertSelectDSL implements Buildable<InsertSelectModel> {
         return InsertSelectModel.withTable(table)
                 .withColumnList(columnList)
                 .withSelectModel(selectModel)
+                .withStatementConfiguration(statementConfiguration)
                 .build();
     }
 
     public static InsertColumnGatherer insertInto(SqlTable table) {
         return new InsertColumnGatherer(table);
+    }
+
+    @Override
+    public InsertSelectDSL configureStatement(Consumer<StatementConfiguration> consumer) {
+        consumer.accept(statementConfiguration);
+        return this;
     }
 
     public static class InsertColumnGatherer {

--- a/src/main/java/org/mybatis/dynamic/sql/insert/InsertSelectModel.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/InsertSelectModel.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 
 import org.jetbrains.annotations.NotNull;
 import org.mybatis.dynamic.sql.SqlTable;
+import org.mybatis.dynamic.sql.configuration.StatementConfiguration;
 import org.mybatis.dynamic.sql.insert.render.InsertSelectRenderer;
 import org.mybatis.dynamic.sql.insert.render.InsertSelectStatementProvider;
 import org.mybatis.dynamic.sql.render.RenderingStrategy;
@@ -29,11 +30,13 @@ public class InsertSelectModel {
     private final SqlTable table;
     private final InsertColumnListModel columnList;
     private final SelectModel selectModel;
+    private final StatementConfiguration statementConfiguration;
 
     private InsertSelectModel(Builder builder) {
         table = Objects.requireNonNull(builder.table);
         columnList = builder.columnList;
         selectModel = Objects.requireNonNull(builder.selectModel);
+        statementConfiguration = Objects.requireNonNull(builder.statementConfiguration);
     }
 
     public SqlTable table() {
@@ -52,6 +55,7 @@ public class InsertSelectModel {
     public InsertSelectStatementProvider render(RenderingStrategy renderingStrategy) {
         return InsertSelectRenderer.withInsertSelectModel(this)
                 .withRenderingStrategy(renderingStrategy)
+                .withStatementConfiguration(statementConfiguration)
                 .build()
                 .render();
     }
@@ -64,6 +68,7 @@ public class InsertSelectModel {
         private SqlTable table;
         private InsertColumnListModel columnList;
         private SelectModel selectModel;
+        private StatementConfiguration statementConfiguration;
 
         public Builder withTable(SqlTable table) {
             this.table = table;
@@ -77,6 +82,11 @@ public class InsertSelectModel {
 
         public Builder withSelectModel(SelectModel selectModel) {
             this.selectModel = selectModel;
+            return this;
+        }
+
+        public Builder withStatementConfiguration(StatementConfiguration statementConfiguration) {
+            this.statementConfiguration = statementConfiguration;
             return this;
         }
 

--- a/src/main/java/org/mybatis/dynamic/sql/insert/render/GeneralInsertRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/render/GeneralInsertRenderer.java
@@ -18,6 +18,7 @@ package org.mybatis.dynamic.sql.insert.render;
 import java.util.Objects;
 import java.util.Optional;
 
+import org.mybatis.dynamic.sql.configuration.StatementConfiguration;
 import org.mybatis.dynamic.sql.insert.GeneralInsertModel;
 import org.mybatis.dynamic.sql.render.RenderingContext;
 import org.mybatis.dynamic.sql.render.RenderingStrategy;
@@ -26,16 +27,16 @@ import org.mybatis.dynamic.sql.util.Validator;
 public class GeneralInsertRenderer {
 
     private final GeneralInsertModel model;
-    private final RenderingStrategy renderingStrategy;
+    private final RenderingContext renderingContext;
 
     private GeneralInsertRenderer(Builder builder) {
         model = Objects.requireNonNull(builder.model);
-        renderingStrategy = Objects.requireNonNull(builder.renderingStrategy);
+        renderingContext = RenderingContext.withRenderingStrategy(builder.renderingStrategy)
+                .withStatementConfiguration(builder.statementConfiguration)
+                .build();
     }
 
     public GeneralInsertStatementProvider render() {
-        RenderingContext renderingContext = RenderingContext.withRenderingStrategy(renderingStrategy).build();
-
         GeneralInsertValuePhraseVisitor visitor = new GeneralInsertValuePhraseVisitor(renderingContext);
         FieldAndValueCollector collector = model.mapColumnMappings(m -> m.accept(visitor))
                 .filter(Optional::isPresent)
@@ -58,6 +59,7 @@ public class GeneralInsertRenderer {
     public static class Builder {
         private GeneralInsertModel model;
         private RenderingStrategy renderingStrategy;
+        private StatementConfiguration statementConfiguration;
 
         public Builder withInsertModel(GeneralInsertModel model) {
             this.model = model;
@@ -66,6 +68,11 @@ public class GeneralInsertRenderer {
 
         public Builder withRenderingStrategy(RenderingStrategy renderingStrategy) {
             this.renderingStrategy = renderingStrategy;
+            return this;
+        }
+
+        public Builder withStatementConfiguration(StatementConfiguration statementConfiguration) {
+            this.statementConfiguration = statementConfiguration;
             return this;
         }
 

--- a/src/main/java/org/mybatis/dynamic/sql/insert/render/GeneralInsertValuePhraseVisitor.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/render/GeneralInsertValuePhraseVisitor.java
@@ -25,6 +25,7 @@ import org.mybatis.dynamic.sql.util.ConstantMapping;
 import org.mybatis.dynamic.sql.util.GeneralInsertMappingVisitor;
 import org.mybatis.dynamic.sql.util.NullMapping;
 import org.mybatis.dynamic.sql.util.StringConstantMapping;
+import org.mybatis.dynamic.sql.util.StringUtilities;
 import org.mybatis.dynamic.sql.util.ValueMapping;
 import org.mybatis.dynamic.sql.util.ValueOrNullMapping;
 import org.mybatis.dynamic.sql.util.ValueWhenPresentMapping;
@@ -52,7 +53,7 @@ public class GeneralInsertValuePhraseVisitor extends GeneralInsertMappingVisitor
     @Override
     public Optional<FieldAndValueAndParameters> visit(StringConstantMapping mapping) {
         return FieldAndValueAndParameters.withFieldName(mapping.columnName())
-                .withValuePhrase("'" + mapping.constant() + "'") //$NON-NLS-1$ //$NON-NLS-2$
+                .withValuePhrase(StringUtilities.formatConstantForSQL(mapping.constant()))
                 .buildOptional();
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/insert/render/InsertSelectRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/render/InsertSelectRenderer.java
@@ -22,8 +22,10 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.mybatis.dynamic.sql.SqlColumn;
+import org.mybatis.dynamic.sql.configuration.StatementConfiguration;
 import org.mybatis.dynamic.sql.insert.InsertColumnListModel;
 import org.mybatis.dynamic.sql.insert.InsertSelectModel;
+import org.mybatis.dynamic.sql.render.RenderingContext;
 import org.mybatis.dynamic.sql.render.RenderingStrategy;
 import org.mybatis.dynamic.sql.select.render.SelectStatementProvider;
 import org.mybatis.dynamic.sql.util.StringUtilities;
@@ -31,15 +33,17 @@ import org.mybatis.dynamic.sql.util.StringUtilities;
 public class InsertSelectRenderer {
 
     private final InsertSelectModel model;
-    private final RenderingStrategy renderingStrategy;
+    private final RenderingContext renderingContext;
 
     private InsertSelectRenderer(Builder builder) {
         model = Objects.requireNonNull(builder.model);
-        renderingStrategy = Objects.requireNonNull(builder.renderingStrategy);
+        renderingContext = RenderingContext.withRenderingStrategy(builder.renderingStrategy)
+                .withStatementConfiguration(builder.statementConfiguration)
+                .build();
     }
 
     public InsertSelectStatementProvider render() {
-        SelectStatementProvider selectStatement = model.selectModel().render(renderingStrategy);
+        SelectStatementProvider selectStatement = model.selectModel().render(renderingContext);
 
         String statementStart = InsertRenderingUtilities.calculateInsertStatementStart(model.table());
         Optional<String> columnsPhrase = calculateColumnsPhrase();
@@ -70,6 +74,7 @@ public class InsertSelectRenderer {
     public static class Builder {
         private InsertSelectModel model;
         private RenderingStrategy renderingStrategy;
+        private StatementConfiguration statementConfiguration;
 
         public Builder withInsertSelectModel(InsertSelectModel model) {
             this.model = model;
@@ -78,6 +83,11 @@ public class InsertSelectRenderer {
 
         public Builder withRenderingStrategy(RenderingStrategy renderingStrategy) {
             this.renderingStrategy = renderingStrategy;
+            return this;
+        }
+
+        public Builder withStatementConfiguration(StatementConfiguration statementConfiguration) {
+            this.statementConfiguration = statementConfiguration;
             return this;
         }
 

--- a/src/main/java/org/mybatis/dynamic/sql/insert/render/MultiRowValuePhraseVisitor.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/render/MultiRowValuePhraseVisitor.java
@@ -23,6 +23,7 @@ import org.mybatis.dynamic.sql.util.NullMapping;
 import org.mybatis.dynamic.sql.util.PropertyMapping;
 import org.mybatis.dynamic.sql.util.RowMapping;
 import org.mybatis.dynamic.sql.util.StringConstantMapping;
+import org.mybatis.dynamic.sql.util.StringUtilities;
 
 public class MultiRowValuePhraseVisitor extends MultiRowInsertMappingVisitor<FieldAndValueAndParameters> {
     protected final RenderingStrategy renderingStrategy;
@@ -50,7 +51,7 @@ public class MultiRowValuePhraseVisitor extends MultiRowInsertMappingVisitor<Fie
     @Override
     public FieldAndValueAndParameters visit(StringConstantMapping mapping) {
         return FieldAndValueAndParameters.withFieldName(mapping.columnName())
-                .withValuePhrase("'" + mapping.constant() + "'") //$NON-NLS-1$ //$NON-NLS-2$
+                .withValuePhrase(StringUtilities.formatConstantForSQL(mapping.constant()))
                 .build();
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/insert/render/ValuePhraseVisitor.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/render/ValuePhraseVisitor.java
@@ -26,6 +26,7 @@ import org.mybatis.dynamic.sql.util.PropertyMapping;
 import org.mybatis.dynamic.sql.util.PropertyWhenPresentMapping;
 import org.mybatis.dynamic.sql.util.RowMapping;
 import org.mybatis.dynamic.sql.util.StringConstantMapping;
+import org.mybatis.dynamic.sql.util.StringUtilities;
 
 public class ValuePhraseVisitor extends InsertMappingVisitor<Optional<FieldAndValueAndParameters>> {
 
@@ -52,7 +53,7 @@ public class ValuePhraseVisitor extends InsertMappingVisitor<Optional<FieldAndVa
     @Override
     public Optional<FieldAndValueAndParameters> visit(StringConstantMapping mapping) {
         return FieldAndValueAndParameters.withFieldName(mapping.columnName())
-                .withValuePhrase("'" + mapping.constant() + "'") //$NON-NLS-1$ //$NON-NLS-2$
+                .withValuePhrase(StringUtilities.formatConstantForSQL(mapping.constant()))
                 .buildOptional();
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/render/RenderingContext.java
+++ b/src/main/java/org/mybatis/dynamic/sql/render/RenderingContext.java
@@ -97,6 +97,10 @@ public class RenderingContext {
                 .orElseGet(table::tableNameAtRuntime);
     }
 
+    public boolean isNonRenderingClauseAllowed() {
+        return statementConfiguration.isNonRenderingWhereClauseAllowed();
+    }
+
     /**
      * Create a new rendering context based on this, with the table alias calculator modified to include the
      * specified child table alias calculator. This is used by the query expression renderer when the alias calculator

--- a/src/main/java/org/mybatis/dynamic/sql/render/RenderingContext.java
+++ b/src/main/java/org/mybatis/dynamic/sql/render/RenderingContext.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.mybatis.dynamic.sql.BindableColumn;
 import org.mybatis.dynamic.sql.SqlColumn;
 import org.mybatis.dynamic.sql.SqlTable;
+import org.mybatis.dynamic.sql.configuration.StatementConfiguration;
 
 /**
  * This class encapsulates all the supporting items related to rendering, and contains many utility methods
@@ -38,11 +39,13 @@ public class RenderingContext {
     private final TableAliasCalculator tableAliasCalculator;
     private final String configuredParameterName;
     private final String calculatedParameterName;
+    private final StatementConfiguration statementConfiguration;
 
     private RenderingContext(Builder builder) {
         renderingStrategy = Objects.requireNonNull(builder.renderingStrategy);
         configuredParameterName = builder.parameterName;
         tableAliasCalculator = Objects.requireNonNull(builder.tableAliasCalculator);
+        statementConfiguration = Objects.requireNonNull(builder.statementConfiguration);
 
         // reasonable defaults
         sequence = builder.sequence == null ? new AtomicInteger(1) : builder.sequence;
@@ -114,6 +117,7 @@ public class RenderingContext {
                 .withSequence(this.sequence)
                 .withParameterName(this.configuredParameterName)
                 .withTableAliasCalculator(tac)
+                .withStatementConfiguration(statementConfiguration)
                 .build();
     }
 
@@ -126,6 +130,7 @@ public class RenderingContext {
         private AtomicInteger sequence;
         private TableAliasCalculator tableAliasCalculator = TableAliasCalculator.empty();
         private String parameterName;
+        private StatementConfiguration statementConfiguration;
 
         public Builder withRenderingStrategy(RenderingStrategy renderingStrategy) {
             this.renderingStrategy = renderingStrategy;
@@ -144,6 +149,11 @@ public class RenderingContext {
 
         public Builder withParameterName(String parameterName) {
             this.parameterName = parameterName;
+            return this;
+        }
+
+        public Builder withStatementConfiguration(StatementConfiguration statementConfiguration) {
+            this.statementConfiguration = statementConfiguration;
             return this;
         }
 

--- a/src/main/java/org/mybatis/dynamic/sql/select/AbstractHavingFinisher.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/AbstractHavingFinisher.java
@@ -33,6 +33,9 @@ public abstract class AbstractHavingFinisher<T extends AbstractHavingFinisher<T>
     }
 
     protected HavingModel buildModel() {
-        return new HavingModel(getInitialCriterion(), subCriteria);
+        return new HavingModel.Builder()
+                .withInitialCriterion(getInitialCriterion())
+                .withSubCriteria(subCriteria)
+                .build();
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/select/CountDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/CountDSL.java
@@ -27,7 +27,7 @@ import org.mybatis.dynamic.sql.configuration.StatementConfiguration;
 import org.mybatis.dynamic.sql.util.Buildable;
 import org.mybatis.dynamic.sql.util.Utilities;
 import org.mybatis.dynamic.sql.where.AbstractWhereFinisher;
-import org.mybatis.dynamic.sql.where.WhereModel;
+import org.mybatis.dynamic.sql.where.EmbeddedWhereModel;
 
 /**
  * DSL for building count queries. Count queries are specializations of select queries. They have joins and where
@@ -131,7 +131,7 @@ public class CountDSL<R> extends AbstractQueryExpressionDSL<CountDSL<R>.CountWhe
     public class CountWhereBuilder extends AbstractWhereFinisher<CountWhereBuilder>
             implements Buildable<R> {
         private CountWhereBuilder() {
-            super(statementConfiguration);
+            super(CountDSL.this);
         }
 
         @NotNull
@@ -145,7 +145,7 @@ public class CountDSL<R> extends AbstractQueryExpressionDSL<CountDSL<R>.CountWhe
             return this;
         }
 
-        protected WhereModel buildWhereModel() {
+        protected EmbeddedWhereModel buildWhereModel() {
             return super.buildModel();
         }
     }

--- a/src/main/java/org/mybatis/dynamic/sql/select/CountDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/CountDSL.java
@@ -81,6 +81,7 @@ public class CountDSL<R> extends AbstractQueryExpressionDSL<CountDSL<R>.CountWhe
 
         return new SelectModel.Builder()
                 .withQueryExpression(queryExpressionModel)
+                .withStatementConfiguration(statementConfiguration)
                 .build();
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/select/MultiSelectDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/MultiSelectDSL.java
@@ -20,19 +20,23 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import org.jetbrains.annotations.NotNull;
 import org.mybatis.dynamic.sql.SortSpecification;
 import org.mybatis.dynamic.sql.common.OrderByModel;
+import org.mybatis.dynamic.sql.configuration.StatementConfiguration;
 import org.mybatis.dynamic.sql.util.Buildable;
+import org.mybatis.dynamic.sql.util.ConfigurableStatement;
 
-public class MultiSelectDSL implements Buildable<MultiSelectModel> {
+public class MultiSelectDSL implements Buildable<MultiSelectModel>, ConfigurableStatement<MultiSelectDSL> {
     private final List<UnionQuery> unionQueries = new ArrayList<>();
     private final SelectModel initialSelect;
     private OrderByModel orderByModel;
     private Long limit;
     private Long offset;
     private Long fetchFirstRows;
+    private StatementConfiguration statementConfiguration = new StatementConfiguration();
 
     public MultiSelectDSL(Buildable<SelectModel> builder) {
         initialSelect = builder.build();
@@ -80,6 +84,7 @@ public class MultiSelectDSL implements Buildable<MultiSelectModel> {
                 .withUnionQueries(unionQueries)
                 .withOrderByModel(orderByModel)
                 .withPagingModel(buildPagingModel().orElse(null))
+                .withStatementConfiguration(statementConfiguration)
                 .build();
     }
 
@@ -89,6 +94,12 @@ public class MultiSelectDSL implements Buildable<MultiSelectModel> {
                 .withOffset(offset)
                 .withFetchFirstRows(fetchFirstRows)
                 .build();
+    }
+
+    @Override
+    public MultiSelectDSL configureStatement(Consumer<StatementConfiguration> consumer) {
+        consumer.accept(statementConfiguration);
+        return this;
     }
 
     public class LimitFinisher implements Buildable<MultiSelectModel> {

--- a/src/main/java/org/mybatis/dynamic/sql/select/MultiSelectDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/MultiSelectDSL.java
@@ -36,7 +36,7 @@ public class MultiSelectDSL implements Buildable<MultiSelectModel>, Configurable
     private Long limit;
     private Long offset;
     private Long fetchFirstRows;
-    private StatementConfiguration statementConfiguration = new StatementConfiguration();
+    private final StatementConfiguration statementConfiguration = new StatementConfiguration();
 
     public MultiSelectDSL(Buildable<SelectModel> builder) {
         initialSelect = builder.build();

--- a/src/main/java/org/mybatis/dynamic/sql/select/MultiSelectModel.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/MultiSelectModel.java
@@ -24,6 +24,7 @@ import java.util.stream.Stream;
 
 import org.jetbrains.annotations.NotNull;
 import org.mybatis.dynamic.sql.common.OrderByModel;
+import org.mybatis.dynamic.sql.configuration.StatementConfiguration;
 import org.mybatis.dynamic.sql.render.RenderingStrategy;
 import org.mybatis.dynamic.sql.select.render.MultiSelectRenderer;
 import org.mybatis.dynamic.sql.select.render.SelectStatementProvider;
@@ -34,12 +35,14 @@ public class MultiSelectModel {
     private final List<UnionQuery> unionQueries;
     private final OrderByModel orderByModel;
     private final PagingModel pagingModel;
+    private final StatementConfiguration statementConfiguration;
 
     private MultiSelectModel(Builder builder) {
         initialSelect = Objects.requireNonNull(builder.initialSelect);
         unionQueries = builder.unionQueries;
         orderByModel = builder.orderByModel;
         pagingModel = builder.pagingModel;
+        statementConfiguration = Objects.requireNonNull(builder.statementConfiguration);
         Validator.assertNotEmpty(unionQueries, "ERROR.35"); //$NON-NLS-1$
     }
 
@@ -64,6 +67,7 @@ public class MultiSelectModel {
         return new MultiSelectRenderer.Builder()
                 .withMultiSelectModel(this)
                 .withRenderingStrategy(renderingStrategy)
+                .withStatementConfiguration(statementConfiguration)
                 .build()
                 .render();
     }
@@ -73,6 +77,7 @@ public class MultiSelectModel {
         private final List<UnionQuery> unionQueries = new ArrayList<>();
         private OrderByModel orderByModel;
         private PagingModel pagingModel;
+        private StatementConfiguration statementConfiguration;
 
         public Builder withInitialSelect(SelectModel initialSelect) {
             this.initialSelect = initialSelect;
@@ -91,6 +96,11 @@ public class MultiSelectModel {
 
         public Builder withPagingModel(PagingModel pagingModel) {
             this.pagingModel = pagingModel;
+            return this;
+        }
+
+        public Builder withStatementConfiguration(StatementConfiguration statementConfiguration) {
+            this.statementConfiguration = statementConfiguration;
             return this;
         }
 

--- a/src/main/java/org/mybatis/dynamic/sql/select/QueryExpressionDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/QueryExpressionDSL.java
@@ -38,7 +38,7 @@ import org.mybatis.dynamic.sql.util.Buildable;
 import org.mybatis.dynamic.sql.util.Utilities;
 import org.mybatis.dynamic.sql.where.AbstractWhereFinisher;
 import org.mybatis.dynamic.sql.where.AbstractWhereStarter;
-import org.mybatis.dynamic.sql.where.WhereModel;
+import org.mybatis.dynamic.sql.where.EmbeddedWhereModel;
 
 public class QueryExpressionDSL<R>
         extends AbstractQueryExpressionDSL<QueryExpressionDSL<R>.QueryExpressionWhereBuilder, QueryExpressionDSL<R>>
@@ -275,7 +275,7 @@ public class QueryExpressionDSL<R>
     public class QueryExpressionWhereBuilder extends AbstractWhereFinisher<QueryExpressionWhereBuilder>
             implements Buildable<R> {
         private QueryExpressionWhereBuilder() {
-            super(selectDSL.statementConfiguration);
+            super(QueryExpressionDSL.this);
         }
 
         public UnionBuilder union() {
@@ -325,7 +325,7 @@ public class QueryExpressionDSL<R>
             return this;
         }
 
-        protected WhereModel buildWhereModel() {
+        protected EmbeddedWhereModel buildWhereModel() {
             return super.buildModel();
         }
     }

--- a/src/main/java/org/mybatis/dynamic/sql/select/QueryExpressionDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/QueryExpressionDSL.java
@@ -50,7 +50,6 @@ public class QueryExpressionDSL<R>
     private final List<BasicColumn> selectList;
     private QueryExpressionWhereBuilder whereBuilder;
     private GroupByModel groupByModel;
-    private final StatementConfiguration statementConfiguration = new StatementConfiguration();
     private QueryExpressionHavingBuilder havingBuilder;
 
     protected QueryExpressionDSL(FromGatherer<R> fromGatherer, TableExpression table) {
@@ -75,7 +74,7 @@ public class QueryExpressionDSL<R>
 
     @Override
     public QueryExpressionDSL<R> configureStatement(Consumer<StatementConfiguration> consumer) {
-        consumer.accept(statementConfiguration);
+        selectDSL.configureStatement(consumer);
         return this;
     }
 
@@ -276,7 +275,7 @@ public class QueryExpressionDSL<R>
     public class QueryExpressionWhereBuilder extends AbstractWhereFinisher<QueryExpressionWhereBuilder>
             implements Buildable<R> {
         private QueryExpressionWhereBuilder() {
-            super(statementConfiguration);
+            super(selectDSL.statementConfiguration);
         }
 
         public UnionBuilder union() {
@@ -394,7 +393,7 @@ public class QueryExpressionDSL<R>
 
         @Override
         public JoinSpecificationFinisher configureStatement(Consumer<StatementConfiguration> consumer) {
-            consumer.accept(statementConfiguration);
+            selectDSL.configureStatement(consumer);
             return this;
         }
 

--- a/src/main/java/org/mybatis/dynamic/sql/select/QueryExpressionModel.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/QueryExpressionModel.java
@@ -29,7 +29,7 @@ import org.mybatis.dynamic.sql.SqlTable;
 import org.mybatis.dynamic.sql.TableExpression;
 import org.mybatis.dynamic.sql.select.join.JoinModel;
 import org.mybatis.dynamic.sql.util.Validator;
-import org.mybatis.dynamic.sql.where.WhereModel;
+import org.mybatis.dynamic.sql.where.EmbeddedWhereModel;
 
 public class QueryExpressionModel {
     private final String connector;
@@ -38,7 +38,7 @@ public class QueryExpressionModel {
     private final TableExpression table;
     private final JoinModel joinModel;
     private final Map<SqlTable, String> tableAliases;
-    private final WhereModel whereModel;
+    private final EmbeddedWhereModel whereModel;
     private final GroupByModel groupByModel;
     private final HavingModel havingModel;
 
@@ -75,7 +75,7 @@ public class QueryExpressionModel {
         return tableAliases;
     }
 
-    public Optional<WhereModel> whereModel() {
+    public Optional<EmbeddedWhereModel> whereModel() {
         return Optional.ofNullable(whereModel);
     }
 
@@ -101,7 +101,7 @@ public class QueryExpressionModel {
         private final List<BasicColumn> selectList = new ArrayList<>();
         private TableExpression table;
         private final Map<SqlTable, String> tableAliases = new HashMap<>();
-        private WhereModel whereModel;
+        private EmbeddedWhereModel whereModel;
         private JoinModel joinModel;
         private GroupByModel groupByModel;
         private HavingModel havingModel;
@@ -136,7 +136,7 @@ public class QueryExpressionModel {
             return this;
         }
 
-        public Builder withWhereModel(WhereModel whereModel) {
+        public Builder withWhereModel(EmbeddedWhereModel whereModel) {
             this.whereModel = whereModel;
             return this;
         }

--- a/src/main/java/org/mybatis/dynamic/sql/select/SelectDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/SelectDSL.java
@@ -135,6 +135,7 @@ public class SelectDSL<R> implements Buildable<R>, ConfigurableStatement<SelectD
         SelectModel selectModel = SelectModel.withQueryExpressions(buildModels())
                 .withOrderByModel(orderByModel)
                 .withPagingModel(buildPagingModel().orElse(null))
+                .withStatementConfiguration(statementConfiguration)
                 .build();
         return adapterFunction.apply(selectModel);
     }

--- a/src/main/java/org/mybatis/dynamic/sql/select/SelectDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/SelectDSL.java
@@ -50,6 +50,7 @@ public class SelectDSL<R> implements Buildable<R>, ConfigurableStatement<SelectD
     private Long limit;
     private Long offset;
     private Long fetchFirstRows;
+    final StatementConfiguration statementConfiguration = new StatementConfiguration();
 
     private SelectDSL(Function<SelectModel, R> adapterFunction) {
         this.adapterFunction = Objects.requireNonNull(adapterFunction);
@@ -124,7 +125,7 @@ public class SelectDSL<R> implements Buildable<R>, ConfigurableStatement<SelectD
 
     @Override
     public SelectDSL<R> configureStatement(Consumer<StatementConfiguration> consumer) {
-        queryExpressions.forEach(q -> q.configureStatement(consumer));
+        consumer.accept(statementConfiguration);
         return this;
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/select/SelectModel.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/SelectModel.java
@@ -24,6 +24,7 @@ import java.util.stream.Stream;
 
 import org.jetbrains.annotations.NotNull;
 import org.mybatis.dynamic.sql.common.OrderByModel;
+import org.mybatis.dynamic.sql.configuration.StatementConfiguration;
 import org.mybatis.dynamic.sql.render.RenderingContext;
 import org.mybatis.dynamic.sql.render.RenderingStrategy;
 import org.mybatis.dynamic.sql.select.render.SelectRenderer;
@@ -34,12 +35,14 @@ public class SelectModel {
     private final List<QueryExpressionModel> queryExpressions;
     private final OrderByModel orderByModel;
     private final PagingModel pagingModel;
+    private final StatementConfiguration statementConfiguration;
 
     private SelectModel(Builder builder) {
         queryExpressions = Objects.requireNonNull(builder.queryExpressions);
         Validator.assertNotEmpty(queryExpressions, "ERROR.14"); //$NON-NLS-1$
         orderByModel = builder.orderByModel;
         pagingModel = builder.pagingModel;
+        statementConfiguration = Objects.requireNonNull(builder.statementConfiguration);
     }
 
     public <R> Stream<R> mapQueryExpressions(Function<QueryExpressionModel, R> mapper) {
@@ -82,6 +85,7 @@ public class SelectModel {
         private final List<QueryExpressionModel> queryExpressions = new ArrayList<>();
         private OrderByModel orderByModel;
         private PagingModel pagingModel;
+        private StatementConfiguration statementConfiguration;
 
         public Builder withQueryExpression(QueryExpressionModel queryExpression) {
             this.queryExpressions.add(queryExpression);
@@ -100,6 +104,11 @@ public class SelectModel {
 
         public Builder withPagingModel(PagingModel pagingModel) {
             this.pagingModel = pagingModel;
+            return this;
+        }
+
+        public Builder withStatementConfiguration(StatementConfiguration statementConfiguration) {
+            this.statementConfiguration = statementConfiguration;
             return this;
         }
 

--- a/src/main/java/org/mybatis/dynamic/sql/select/SelectModel.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/SelectModel.java
@@ -57,6 +57,17 @@ public class SelectModel {
     @NotNull
     public SelectStatementProvider render(RenderingStrategy renderingStrategy) {
         RenderingContext renderingContext = RenderingContext.withRenderingStrategy(renderingStrategy).build();
+        return render(renderingContext);
+    }
+
+    /**
+     * This version is for rendering sub-queries, union queries, etc.
+     *
+     * @param renderingContext the rendering context
+     * @return a rendered select statement and parameters
+     */
+    @NotNull
+    public SelectStatementProvider render(RenderingContext renderingContext) {
         return SelectRenderer.withSelectModel(this)
                 .withRenderingContext(renderingContext)
                 .build()

--- a/src/main/java/org/mybatis/dynamic/sql/select/SelectModel.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/SelectModel.java
@@ -59,7 +59,9 @@ public class SelectModel {
 
     @NotNull
     public SelectStatementProvider render(RenderingStrategy renderingStrategy) {
-        RenderingContext renderingContext = RenderingContext.withRenderingStrategy(renderingStrategy).build();
+        RenderingContext renderingContext = RenderingContext.withRenderingStrategy(renderingStrategy)
+                .withStatementConfiguration(statementConfiguration)
+                .build();
         return render(renderingContext);
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/select/caseexpression/SearchedCaseDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/caseexpression/SearchedCaseDSL.java
@@ -29,7 +29,7 @@ import org.mybatis.dynamic.sql.VisitableCondition;
 import org.mybatis.dynamic.sql.common.AbstractBooleanExpressionDSL;
 
 public class SearchedCaseDSL implements ElseDSL<SearchedCaseDSL.SearchedCaseEnder> {
-    private final List<SearchedCaseModel.SearchedWhenCondition> whenConditions = new ArrayList<>();
+    private final List<SearchedCaseWhenCondition> whenConditions = new ArrayList<>();
     private BasicColumn elseValue;
 
     public <T> WhenDSL when(BindableColumn<T> column, VisitableCondition<T> condition,
@@ -85,8 +85,11 @@ public class SearchedCaseDSL implements ElseDSL<SearchedCaseDSL.SearchedCaseEnde
 
         @Override
         public SearchedCaseDSL then(BasicColumn column) {
-            whenConditions.add(new SearchedCaseModel.SearchedWhenCondition(getInitialCriterion(), subCriteria,
-                    column));
+            whenConditions.add(new SearchedCaseWhenCondition.Builder()
+                    .withInitialCriterion(getInitialCriterion())
+                    .withSubCriteria(subCriteria)
+                    .withThenValue(column)
+                    .build());
             return SearchedCaseDSL.this;
         }
 

--- a/src/main/java/org/mybatis/dynamic/sql/select/caseexpression/SearchedCaseModel.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/caseexpression/SearchedCaseModel.java
@@ -17,21 +17,17 @@ package org.mybatis.dynamic.sql.select.caseexpression;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import org.mybatis.dynamic.sql.AndOrCriteriaGroup;
 import org.mybatis.dynamic.sql.BasicColumn;
-import org.mybatis.dynamic.sql.SqlCriterion;
-import org.mybatis.dynamic.sql.common.AbstractBooleanExpressionModel;
 import org.mybatis.dynamic.sql.render.RenderingContext;
 import org.mybatis.dynamic.sql.select.render.SearchedCaseRenderer;
 import org.mybatis.dynamic.sql.util.FragmentAndParameters;
 import org.mybatis.dynamic.sql.util.Validator;
 
 public class SearchedCaseModel implements BasicColumn {
-    private final List<SearchedWhenCondition> whenConditions;
+    private final List<SearchedCaseWhenCondition> whenConditions;
     private final BasicColumn elseValue;
     private final String alias;
 
@@ -42,7 +38,7 @@ public class SearchedCaseModel implements BasicColumn {
         Validator.assertNotEmpty(whenConditions, "ERROR.40"); //$NON-NLS-1$
     }
 
-    public Stream<SearchedWhenCondition> whenConditions() {
+    public Stream<SearchedCaseWhenCondition> whenConditions() {
         return whenConditions.stream();
     }
 
@@ -68,27 +64,12 @@ public class SearchedCaseModel implements BasicColumn {
         return new SearchedCaseRenderer(this, renderingContext).render();
     }
 
-    public static class SearchedWhenCondition extends AbstractBooleanExpressionModel {
-
-        private final BasicColumn thenValue;
-
-        public BasicColumn thenValue() {
-            return thenValue;
-        }
-
-        public SearchedWhenCondition(SqlCriterion initialCriterion, List<AndOrCriteriaGroup> subCriteria,
-                                     BasicColumn thenValue) {
-            super(initialCriterion, subCriteria);
-            this.thenValue = Objects.requireNonNull(thenValue);
-        }
-    }
-
     public static class Builder {
-        private final List<SearchedWhenCondition> whenConditions = new ArrayList<>();
+        private final List<SearchedCaseWhenCondition> whenConditions = new ArrayList<>();
         private BasicColumn elseValue;
         private String alias;
 
-        public Builder withWhenConditions(List<SearchedWhenCondition> whenConditions) {
+        public Builder withWhenConditions(List<SearchedCaseWhenCondition> whenConditions) {
             this.whenConditions.addAll(whenConditions);
             return this;
         }

--- a/src/main/java/org/mybatis/dynamic/sql/select/caseexpression/SearchedCaseWhenCondition.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/caseexpression/SearchedCaseWhenCondition.java
@@ -13,18 +13,35 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-package org.mybatis.dynamic.sql.select;
+package org.mybatis.dynamic.sql.select.caseexpression;
 
+import java.util.Objects;
+
+import org.mybatis.dynamic.sql.BasicColumn;
 import org.mybatis.dynamic.sql.common.AbstractBooleanExpressionModel;
 
-public class HavingModel extends AbstractBooleanExpressionModel {
-    private HavingModel(Builder builder) {
+public class SearchedCaseWhenCondition extends AbstractBooleanExpressionModel {
+    private final BasicColumn thenValue;
+
+    public BasicColumn thenValue() {
+        return thenValue;
+    }
+
+    private SearchedCaseWhenCondition(Builder builder) {
         super(builder);
+        thenValue = Objects.requireNonNull(builder.thenValue);
     }
 
     public static class Builder extends AbstractBuilder<Builder> {
-        public HavingModel build() {
-            return new HavingModel(this);
+        private BasicColumn thenValue;
+
+        public Builder withThenValue(BasicColumn thenValue) {
+            this.thenValue = thenValue;
+            return this;
+        }
+
+        public SearchedCaseWhenCondition build() {
+            return new SearchedCaseWhenCondition(this);
         }
 
         @Override

--- a/src/main/java/org/mybatis/dynamic/sql/select/render/HavingRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/render/HavingRenderer.java
@@ -18,7 +18,7 @@ package org.mybatis.dynamic.sql.select.render;
 import org.mybatis.dynamic.sql.common.AbstractBooleanExpressionRenderer;
 import org.mybatis.dynamic.sql.select.HavingModel;
 
-public class HavingRenderer extends AbstractBooleanExpressionRenderer<HavingModel> {
+public class HavingRenderer extends AbstractBooleanExpressionRenderer {
     private HavingRenderer(Builder builder) {
         super("having", builder); //$NON-NLS-1$
     }
@@ -27,7 +27,7 @@ public class HavingRenderer extends AbstractBooleanExpressionRenderer<HavingMode
         return new Builder(havingModel);
     }
 
-    public static class Builder extends AbstractBuilder<HavingModel, Builder> {
+    public static class Builder extends AbstractBuilder<Builder> {
         public Builder(HavingModel havingModel) {
             super(havingModel);
         }

--- a/src/main/java/org/mybatis/dynamic/sql/select/render/MultiSelectRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/render/MultiSelectRenderer.java
@@ -62,10 +62,7 @@ public class MultiSelectRenderer {
     }
 
     private FragmentAndParameters renderSelect(SelectModel selectModel) {
-        SelectStatementProvider selectStatement = SelectRenderer.withSelectModel(selectModel)
-                .withRenderingContext(renderingContext)
-                .build()
-                .render();
+        SelectStatementProvider selectStatement = selectModel.render(renderingContext);
 
         return FragmentAndParameters
                 .withFragment("(" + selectStatement.getSelectStatement() + ")") //$NON-NLS-1$ //$NON-NLS-2$
@@ -74,10 +71,7 @@ public class MultiSelectRenderer {
     }
 
     private FragmentAndParameters renderSelect(UnionQuery unionQuery) {
-        SelectStatementProvider selectStatement = SelectRenderer.withSelectModel(unionQuery.selectModel())
-                .withRenderingContext(renderingContext)
-                .build()
-                .render();
+        SelectStatementProvider selectStatement = unionQuery.selectModel().render(renderingContext);
 
         return FragmentAndParameters.withFragment(
                 unionQuery.connector() + " (" + selectStatement.getSelectStatement() + ")") //$NON-NLS-1$ //$NON-NLS-2$

--- a/src/main/java/org/mybatis/dynamic/sql/select/render/MultiSelectRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/render/MultiSelectRenderer.java
@@ -21,6 +21,7 @@ import java.util.stream.Collectors;
 
 import org.mybatis.dynamic.sql.common.OrderByModel;
 import org.mybatis.dynamic.sql.common.OrderByRenderer;
+import org.mybatis.dynamic.sql.configuration.StatementConfiguration;
 import org.mybatis.dynamic.sql.render.RenderingContext;
 import org.mybatis.dynamic.sql.render.RenderingStrategy;
 import org.mybatis.dynamic.sql.select.MultiSelectModel;
@@ -36,7 +37,8 @@ public class MultiSelectRenderer {
 
     private MultiSelectRenderer(Builder builder) {
         renderingContext = RenderingContext
-                .withRenderingStrategy(Objects.requireNonNull(builder.renderingStrategy))
+                .withRenderingStrategy(builder.renderingStrategy)
+                .withStatementConfiguration(builder.statementConfiguration)
                 .build();
         multiSelectModel = Objects.requireNonNull(builder.multiSelectModel);
     }
@@ -102,6 +104,7 @@ public class MultiSelectRenderer {
     public static class Builder {
         private RenderingStrategy renderingStrategy;
         private MultiSelectModel multiSelectModel;
+        private StatementConfiguration statementConfiguration;
 
         public Builder withRenderingStrategy(RenderingStrategy renderingStrategy) {
             this.renderingStrategy = renderingStrategy;
@@ -110,6 +113,11 @@ public class MultiSelectRenderer {
 
         public Builder withMultiSelectModel(MultiSelectModel multiSelectModel) {
             this.multiSelectModel = multiSelectModel;
+            return this;
+        }
+
+        public Builder withStatementConfiguration(StatementConfiguration statementConfiguration) {
+            this.statementConfiguration = statementConfiguration;
             return this;
         }
 

--- a/src/main/java/org/mybatis/dynamic/sql/select/render/QueryExpressionRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/render/QueryExpressionRenderer.java
@@ -33,7 +33,6 @@ import org.mybatis.dynamic.sql.util.FragmentAndParameters;
 import org.mybatis.dynamic.sql.util.FragmentCollector;
 import org.mybatis.dynamic.sql.util.StringUtilities;
 import org.mybatis.dynamic.sql.where.WhereModel;
-import org.mybatis.dynamic.sql.where.render.WhereRenderer;
 
 public class QueryExpressionRenderer {
     private final QueryExpressionModel queryExpression;
@@ -168,10 +167,7 @@ public class QueryExpressionRenderer {
     }
 
     private Optional<FragmentAndParameters> renderWhereClause(WhereModel whereModel) {
-        return WhereRenderer.withWhereModel(whereModel)
-                .withRenderingContext(renderingContext)
-                .build()
-                .render();
+        return whereModel.render(renderingContext);
     }
 
     private Optional<FragmentAndParameters> calculateGroupByClause() {

--- a/src/main/java/org/mybatis/dynamic/sql/select/render/QueryExpressionRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/render/QueryExpressionRenderer.java
@@ -32,7 +32,7 @@ import org.mybatis.dynamic.sql.select.join.JoinModel;
 import org.mybatis.dynamic.sql.util.FragmentAndParameters;
 import org.mybatis.dynamic.sql.util.FragmentCollector;
 import org.mybatis.dynamic.sql.util.StringUtilities;
-import org.mybatis.dynamic.sql.where.WhereModel;
+import org.mybatis.dynamic.sql.where.EmbeddedWhereModel;
 
 public class QueryExpressionRenderer {
     private final QueryExpressionModel queryExpression;
@@ -166,7 +166,7 @@ public class QueryExpressionRenderer {
         return queryExpression.whereModel().flatMap(this::renderWhereClause);
     }
 
-    private Optional<FragmentAndParameters> renderWhereClause(WhereModel whereModel) {
+    private Optional<FragmentAndParameters> renderWhereClause(EmbeddedWhereModel whereModel) {
         return whereModel.render(renderingContext);
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/select/render/SearchedCaseRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/render/SearchedCaseRenderer.java
@@ -24,6 +24,7 @@ import org.mybatis.dynamic.sql.BasicColumn;
 import org.mybatis.dynamic.sql.exception.InvalidSqlException;
 import org.mybatis.dynamic.sql.render.RenderingContext;
 import org.mybatis.dynamic.sql.select.caseexpression.SearchedCaseModel;
+import org.mybatis.dynamic.sql.select.caseexpression.SearchedCaseWhenCondition;
 import org.mybatis.dynamic.sql.util.FragmentAndParameters;
 import org.mybatis.dynamic.sql.util.FragmentCollector;
 import org.mybatis.dynamic.sql.util.Messages;
@@ -56,12 +57,12 @@ public class SearchedCaseRenderer {
                 .toFragmentAndParameters(Collectors.joining(" ")); //$NON-NLS-1$
     }
 
-    private FragmentAndParameters renderWhenCondition(SearchedCaseModel.SearchedWhenCondition whenCondition) {
+    private FragmentAndParameters renderWhenCondition(SearchedCaseWhenCondition whenCondition) {
         return Stream.of(renderWhen(whenCondition), renderThen(whenCondition)).collect(FragmentCollector.collect())
                 .toFragmentAndParameters(Collectors.joining(" ")); //$NON-NLS-1$
     }
 
-    private FragmentAndParameters renderWhen(SearchedCaseModel.SearchedWhenCondition whenCondition) {
+    private FragmentAndParameters renderWhen(SearchedCaseWhenCondition whenCondition) {
         SearchedCaseWhenConditionRenderer renderer = new SearchedCaseWhenConditionRenderer.Builder(whenCondition)
                 .withRenderingContext(renderingContext)
                 .build();
@@ -70,7 +71,7 @@ public class SearchedCaseRenderer {
                 .orElseThrow(() -> new InvalidSqlException(Messages.getString("ERROR.39"))); //$NON-NLS-1$
     }
 
-    private FragmentAndParameters renderThen(SearchedCaseModel.SearchedWhenCondition whenCondition) {
+    private FragmentAndParameters renderThen(SearchedCaseWhenCondition whenCondition) {
         return whenCondition.thenValue().render(renderingContext).mapFragment(f -> "then " + f);
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/select/render/SearchedCaseWhenConditionRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/render/SearchedCaseWhenConditionRenderer.java
@@ -18,13 +18,13 @@ package org.mybatis.dynamic.sql.select.render;
 import org.mybatis.dynamic.sql.common.AbstractBooleanExpressionRenderer;
 import org.mybatis.dynamic.sql.select.caseexpression.SearchedCaseWhenCondition;
 
-public class SearchedCaseWhenConditionRenderer extends AbstractBooleanExpressionRenderer<SearchedCaseWhenCondition> {
+public class SearchedCaseWhenConditionRenderer extends AbstractBooleanExpressionRenderer {
     protected SearchedCaseWhenConditionRenderer(Builder builder) {
         super("when", builder);
     }
 
     public static class Builder
-            extends AbstractBooleanExpressionRenderer.AbstractBuilder<SearchedCaseWhenCondition, Builder> {
+            extends AbstractBooleanExpressionRenderer.AbstractBuilder<Builder> {
 
         protected Builder(SearchedCaseWhenCondition model) {
             super(model);

--- a/src/main/java/org/mybatis/dynamic/sql/select/render/SearchedCaseWhenConditionRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/render/SearchedCaseWhenConditionRenderer.java
@@ -16,17 +16,17 @@
 package org.mybatis.dynamic.sql.select.render;
 
 import org.mybatis.dynamic.sql.common.AbstractBooleanExpressionRenderer;
-import org.mybatis.dynamic.sql.select.caseexpression.SearchedCaseModel.SearchedWhenCondition;
+import org.mybatis.dynamic.sql.select.caseexpression.SearchedCaseWhenCondition;
 
-public class SearchedCaseWhenConditionRenderer extends AbstractBooleanExpressionRenderer<SearchedWhenCondition> {
+public class SearchedCaseWhenConditionRenderer extends AbstractBooleanExpressionRenderer<SearchedCaseWhenCondition> {
     protected SearchedCaseWhenConditionRenderer(Builder builder) {
         super("when", builder);
     }
 
     public static class Builder
-            extends AbstractBooleanExpressionRenderer.AbstractBuilder<SearchedWhenCondition, Builder> {
+            extends AbstractBooleanExpressionRenderer.AbstractBuilder<SearchedCaseWhenCondition, Builder> {
 
-        protected Builder(SearchedWhenCondition model) {
+        protected Builder(SearchedCaseWhenCondition model) {
             super(model);
         }
 

--- a/src/main/java/org/mybatis/dynamic/sql/select/render/TableExpressionRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/render/TableExpressionRenderer.java
@@ -39,11 +39,7 @@ public class TableExpressionRenderer implements TableExpressionVisitor<FragmentA
 
     @Override
     public FragmentAndParameters visit(SubQuery subQuery) {
-        SelectStatementProvider selectStatement = new SelectRenderer.Builder()
-                .withSelectModel(subQuery.selectModel())
-                .withRenderingContext(renderingContext)
-                .build()
-                .render();
+        SelectStatementProvider selectStatement = subQuery.selectModel().render(renderingContext);
 
         String fragment = "(" + selectStatement.getSelectStatement() + ")"; //$NON-NLS-1$ //$NON-NLS-2$
 

--- a/src/main/java/org/mybatis/dynamic/sql/update/UpdateDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/update/UpdateDSL.java
@@ -104,6 +104,7 @@ public class UpdateDSL<R> extends AbstractWhereStarter<UpdateDSL<R>.UpdateWhereB
                 .withLimit(limit)
                 .withOrderByModel(orderByModel)
                 .withWhereModel(whereBuilder == null ? null : whereBuilder.buildWhereModel())
+                .withStatementConfiguration(statementConfiguration)
                 .build();
 
         return adapterFunction.apply(updateModel);

--- a/src/main/java/org/mybatis/dynamic/sql/update/UpdateDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/update/UpdateDSL.java
@@ -45,7 +45,7 @@ import org.mybatis.dynamic.sql.util.ValueOrNullMapping;
 import org.mybatis.dynamic.sql.util.ValueWhenPresentMapping;
 import org.mybatis.dynamic.sql.where.AbstractWhereFinisher;
 import org.mybatis.dynamic.sql.where.AbstractWhereStarter;
-import org.mybatis.dynamic.sql.where.WhereModel;
+import org.mybatis.dynamic.sql.where.EmbeddedWhereModel;
 
 public class UpdateDSL<R> extends AbstractWhereStarter<UpdateDSL<R>.UpdateWhereBuilder, UpdateDSL<R>>
         implements Buildable<R> {
@@ -192,7 +192,7 @@ public class UpdateDSL<R> extends AbstractWhereStarter<UpdateDSL<R>.UpdateWhereB
     public class UpdateWhereBuilder extends AbstractWhereFinisher<UpdateWhereBuilder> implements Buildable<R> {
 
         private UpdateWhereBuilder() {
-            super(statementConfiguration);
+            super(UpdateDSL.this);
         }
 
         public UpdateDSL<R> limit(long limit) {
@@ -219,7 +219,7 @@ public class UpdateDSL<R> extends AbstractWhereStarter<UpdateDSL<R>.UpdateWhereB
             return this;
         }
 
-        protected WhereModel buildWhereModel() {
+        protected EmbeddedWhereModel buildWhereModel() {
             return buildModel();
         }
     }

--- a/src/main/java/org/mybatis/dynamic/sql/update/UpdateModel.java
+++ b/src/main/java/org/mybatis/dynamic/sql/update/UpdateModel.java
@@ -26,6 +26,7 @@ import org.jetbrains.annotations.NotNull;
 import org.mybatis.dynamic.sql.SqlTable;
 import org.mybatis.dynamic.sql.common.CommonBuilder;
 import org.mybatis.dynamic.sql.common.OrderByModel;
+import org.mybatis.dynamic.sql.configuration.StatementConfiguration;
 import org.mybatis.dynamic.sql.render.RenderingStrategy;
 import org.mybatis.dynamic.sql.update.render.UpdateRenderer;
 import org.mybatis.dynamic.sql.update.render.UpdateStatementProvider;
@@ -40,6 +41,7 @@ public class UpdateModel {
     private final List<AbstractColumnMapping> columnMappings;
     private final Long limit;
     private final OrderByModel orderByModel;
+    private final StatementConfiguration statementConfiguration;
 
     private UpdateModel(Builder builder) {
         table = Objects.requireNonNull(builder.table());
@@ -49,6 +51,7 @@ public class UpdateModel {
         limit = builder.limit();
         orderByModel = builder.orderByModel();
         Validator.assertNotEmpty(columnMappings, "ERROR.17"); //$NON-NLS-1$
+        statementConfiguration = Objects.requireNonNull(builder.statementConfiguration());
     }
 
     public SqlTable table() {
@@ -79,6 +82,7 @@ public class UpdateModel {
     public UpdateStatementProvider render(RenderingStrategy renderingStrategy) {
         return UpdateRenderer.withUpdateModel(this)
                 .withRenderingStrategy(renderingStrategy)
+                .withStatementConfiguration(statementConfiguration)
                 .build()
                 .render();
     }

--- a/src/main/java/org/mybatis/dynamic/sql/update/UpdateModel.java
+++ b/src/main/java/org/mybatis/dynamic/sql/update/UpdateModel.java
@@ -32,12 +32,12 @@ import org.mybatis.dynamic.sql.update.render.UpdateRenderer;
 import org.mybatis.dynamic.sql.update.render.UpdateStatementProvider;
 import org.mybatis.dynamic.sql.util.AbstractColumnMapping;
 import org.mybatis.dynamic.sql.util.Validator;
-import org.mybatis.dynamic.sql.where.WhereModel;
+import org.mybatis.dynamic.sql.where.EmbeddedWhereModel;
 
 public class UpdateModel {
     private final SqlTable table;
     private final String tableAlias;
-    private final WhereModel whereModel;
+    private final EmbeddedWhereModel whereModel;
     private final List<AbstractColumnMapping> columnMappings;
     private final Long limit;
     private final OrderByModel orderByModel;
@@ -62,7 +62,7 @@ public class UpdateModel {
         return Optional.ofNullable(tableAlias);
     }
 
-    public Optional<WhereModel> whereModel() {
+    public Optional<EmbeddedWhereModel> whereModel() {
         return Optional.ofNullable(whereModel);
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/update/render/SetPhraseVisitor.java
+++ b/src/main/java/org/mybatis/dynamic/sql/update/render/SetPhraseVisitor.java
@@ -29,6 +29,7 @@ import org.mybatis.dynamic.sql.util.FragmentAndParameters;
 import org.mybatis.dynamic.sql.util.NullMapping;
 import org.mybatis.dynamic.sql.util.SelectMapping;
 import org.mybatis.dynamic.sql.util.StringConstantMapping;
+import org.mybatis.dynamic.sql.util.StringUtilities;
 import org.mybatis.dynamic.sql.util.UpdateMappingVisitor;
 import org.mybatis.dynamic.sql.util.ValueMapping;
 import org.mybatis.dynamic.sql.util.ValueOrNullMapping;
@@ -58,9 +59,8 @@ public class SetPhraseVisitor extends UpdateMappingVisitor<Optional<FragmentAndP
     @Override
     public Optional<FragmentAndParameters> visit(StringConstantMapping mapping) {
         String fragment = mapping.mapColumn(renderingContext::aliasedColumnName)
-                + " = '" //$NON-NLS-1$
-                + mapping.constant()
-                + "'"; //$NON-NLS-1$
+                + " = " //$NON-NLS-1$
+                + StringUtilities.formatConstantForSQL(mapping.constant());
 
         return FragmentAndParameters.withFragment(fragment)
                 .buildOptional();

--- a/src/main/java/org/mybatis/dynamic/sql/update/render/SetPhraseVisitor.java
+++ b/src/main/java/org/mybatis/dynamic/sql/update/render/SetPhraseVisitor.java
@@ -20,7 +20,6 @@ import java.util.Optional;
 
 import org.mybatis.dynamic.sql.render.RenderedParameterInfo;
 import org.mybatis.dynamic.sql.render.RenderingContext;
-import org.mybatis.dynamic.sql.select.render.SelectRenderer;
 import org.mybatis.dynamic.sql.select.render.SelectStatementProvider;
 import org.mybatis.dynamic.sql.util.AbstractColumnMapping;
 import org.mybatis.dynamic.sql.util.ColumnToColumnMapping;
@@ -85,11 +84,7 @@ public class SetPhraseVisitor extends UpdateMappingVisitor<Optional<FragmentAndP
 
     @Override
     public Optional<FragmentAndParameters> visit(SelectMapping mapping) {
-        SelectStatementProvider selectStatement = SelectRenderer.withSelectModel(mapping.selectModel())
-                .withRenderingContext(renderingContext)
-                .build()
-                .render();
-
+        SelectStatementProvider selectStatement = mapping.selectModel().render(renderingContext);
         String fragment = mapping.mapColumn(renderingContext::aliasedColumnName)
                 + " = (" //$NON-NLS-1$
                 + selectStatement.getSelectStatement()

--- a/src/main/java/org/mybatis/dynamic/sql/update/render/UpdateRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/update/render/UpdateRenderer.java
@@ -33,7 +33,6 @@ import org.mybatis.dynamic.sql.util.FragmentAndParameters;
 import org.mybatis.dynamic.sql.util.FragmentCollector;
 import org.mybatis.dynamic.sql.util.Validator;
 import org.mybatis.dynamic.sql.where.WhereModel;
-import org.mybatis.dynamic.sql.where.render.WhereRenderer;
 
 public class UpdateRenderer {
     private final UpdateModel updateModel;
@@ -104,10 +103,7 @@ public class UpdateRenderer {
     }
 
     private Optional<FragmentAndParameters> renderWhereClause(WhereModel whereModel) {
-        return WhereRenderer.withWhereModel(whereModel)
-                .withRenderingContext(renderingContext)
-                .build()
-                .render();
+        return whereModel.render(renderingContext);
     }
 
     private Optional<FragmentAndParameters> calculateLimitClause() {

--- a/src/main/java/org/mybatis/dynamic/sql/update/render/UpdateRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/update/render/UpdateRenderer.java
@@ -32,7 +32,7 @@ import org.mybatis.dynamic.sql.update.UpdateModel;
 import org.mybatis.dynamic.sql.util.FragmentAndParameters;
 import org.mybatis.dynamic.sql.util.FragmentCollector;
 import org.mybatis.dynamic.sql.util.Validator;
-import org.mybatis.dynamic.sql.where.WhereModel;
+import org.mybatis.dynamic.sql.where.EmbeddedWhereModel;
 
 public class UpdateRenderer {
     private final UpdateModel updateModel;
@@ -101,7 +101,7 @@ public class UpdateRenderer {
         return updateModel.whereModel().flatMap(this::renderWhereClause);
     }
 
-    private Optional<FragmentAndParameters> renderWhereClause(WhereModel whereModel) {
+    private Optional<FragmentAndParameters> renderWhereClause(EmbeddedWhereModel whereModel) {
         return whereModel.render(renderingContext);
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/update/render/UpdateRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/update/render/UpdateRenderer.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 
 import org.mybatis.dynamic.sql.common.OrderByModel;
 import org.mybatis.dynamic.sql.common.OrderByRenderer;
+import org.mybatis.dynamic.sql.configuration.StatementConfiguration;
 import org.mybatis.dynamic.sql.render.ExplicitTableAliasCalculator;
 import org.mybatis.dynamic.sql.render.RenderedParameterInfo;
 import org.mybatis.dynamic.sql.render.RenderingContext;
@@ -43,6 +44,8 @@ public class UpdateRenderer {
         TableAliasCalculator tableAliasCalculator = builder.updateModel.tableAlias()
                 .map(a -> ExplicitTableAliasCalculator.of(updateModel.table(), a))
                 .orElseGet(TableAliasCalculator::empty);
+        // TODO - Add configuration to RenderingContext
+        Objects.requireNonNull(builder.statementConfiguration);
         renderingContext = RenderingContext
                 .withRenderingStrategy(Objects.requireNonNull(builder.renderingStrategy))
                 .withTableAliasCalculator(tableAliasCalculator)
@@ -134,6 +137,7 @@ public class UpdateRenderer {
     public static class Builder {
         private UpdateModel updateModel;
         private RenderingStrategy renderingStrategy;
+        private StatementConfiguration statementConfiguration;
 
         public Builder withUpdateModel(UpdateModel updateModel) {
             this.updateModel = updateModel;
@@ -142,6 +146,11 @@ public class UpdateRenderer {
 
         public Builder withRenderingStrategy(RenderingStrategy renderingStrategy) {
             this.renderingStrategy = renderingStrategy;
+            return this;
+        }
+
+        public Builder withStatementConfiguration(StatementConfiguration statementConfiguration) {
+            this.statementConfiguration = statementConfiguration;
             return this;
         }
 

--- a/src/main/java/org/mybatis/dynamic/sql/update/render/UpdateRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/update/render/UpdateRenderer.java
@@ -43,11 +43,10 @@ public class UpdateRenderer {
         TableAliasCalculator tableAliasCalculator = builder.updateModel.tableAlias()
                 .map(a -> ExplicitTableAliasCalculator.of(updateModel.table(), a))
                 .orElseGet(TableAliasCalculator::empty);
-        // TODO - Add configuration to RenderingContext
-        Objects.requireNonNull(builder.statementConfiguration);
         renderingContext = RenderingContext
                 .withRenderingStrategy(Objects.requireNonNull(builder.renderingStrategy))
                 .withTableAliasCalculator(tableAliasCalculator)
+                .withStatementConfiguration(builder.statementConfiguration)
                 .build();
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/util/StringUtilities.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/StringUtilities.java
@@ -52,4 +52,10 @@ public interface StringUtilities {
 
         return sb.toString();
     }
+
+    static String formatConstantForSQL(String in) {
+        String escaped = in.replace("'", "''"); //$NON-NLS-1$ //$NON-NLS-2$
+        return "'" + escaped + "'"; //$NON-NLS-1$ //$NON-NLS-2$
+
+    }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/AbstractWhereFinisher.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/AbstractWhereFinisher.java
@@ -29,6 +29,10 @@ public abstract class AbstractWhereFinisher<T extends AbstractWhereFinisher<T>> 
         implements ConfigurableStatement<T> {
     private final StatementConfiguration statementConfiguration;
 
+    protected AbstractWhereFinisher(StatementConfiguration statementConfiguration) {
+        this.statementConfiguration = Objects.requireNonNull(statementConfiguration);
+    }
+
     void initialize(SqlCriterion sqlCriterion) {
         setInitialCriterion(sqlCriterion, StatementType.WHERE);
     }
@@ -36,10 +40,6 @@ public abstract class AbstractWhereFinisher<T extends AbstractWhereFinisher<T>> 
     void initialize(SqlCriterion sqlCriterion, List<AndOrCriteriaGroup> subCriteria) {
         setInitialCriterion(sqlCriterion, StatementType.WHERE);
         super.subCriteria.addAll(subCriteria);
-    }
-
-    protected AbstractWhereFinisher(StatementConfiguration statementConfiguration) {
-        this.statementConfiguration = Objects.requireNonNull(statementConfiguration);
     }
 
     @Override

--- a/src/main/java/org/mybatis/dynamic/sql/where/AbstractWhereFinisher.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/AbstractWhereFinisher.java
@@ -49,6 +49,10 @@ public abstract class AbstractWhereFinisher<T extends AbstractWhereFinisher<T>> 
     }
 
     protected WhereModel buildModel() {
-        return new WhereModel(getInitialCriterion(), subCriteria, statementConfiguration);
+        return new WhereModel.Builder()
+                .withInitialCriterion(getInitialCriterion())
+                .withSubCriteria(subCriteria)
+                .withStatementConfiguration(statementConfiguration)
+                .build();
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/AbstractWhereFinisher.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/AbstractWhereFinisher.java
@@ -27,10 +27,10 @@ import org.mybatis.dynamic.sql.util.ConfigurableStatement;
 
 public abstract class AbstractWhereFinisher<T extends AbstractWhereFinisher<T>> extends AbstractBooleanExpressionDSL<T>
         implements ConfigurableStatement<T> {
-    private final StatementConfiguration statementConfiguration;
+    private final ConfigurableStatement<?> parentStatement;
 
-    protected AbstractWhereFinisher(StatementConfiguration statementConfiguration) {
-        this.statementConfiguration = Objects.requireNonNull(statementConfiguration);
+    protected AbstractWhereFinisher(ConfigurableStatement<?> parentStatement) {
+        this.parentStatement = Objects.requireNonNull(parentStatement);
     }
 
     void initialize(SqlCriterion sqlCriterion) {
@@ -44,15 +44,14 @@ public abstract class AbstractWhereFinisher<T extends AbstractWhereFinisher<T>> 
 
     @Override
     public T configureStatement(Consumer<StatementConfiguration> consumer) {
-        consumer.accept(statementConfiguration);
+        parentStatement.configureStatement(consumer);
         return getThis();
     }
 
-    protected WhereModel buildModel() {
-        return new WhereModel.Builder()
+    protected EmbeddedWhereModel buildModel() {
+        return new EmbeddedWhereModel.Builder()
                 .withInitialCriterion(getInitialCriterion())
                 .withSubCriteria(subCriteria)
-                .withStatementConfiguration(statementConfiguration)
                 .build();
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/EmbeddedWhereModel.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/EmbeddedWhereModel.java
@@ -15,12 +15,12 @@
  */
 package org.mybatis.dynamic.sql.where;
 
+import java.util.Optional;
+
 import org.mybatis.dynamic.sql.common.AbstractBooleanExpressionModel;
 import org.mybatis.dynamic.sql.render.RenderingContext;
 import org.mybatis.dynamic.sql.util.FragmentAndParameters;
 import org.mybatis.dynamic.sql.where.render.WhereRenderer;
-
-import java.util.Optional;
 
 public class EmbeddedWhereModel extends AbstractBooleanExpressionModel {
     private EmbeddedWhereModel(Builder builder) {

--- a/src/main/java/org/mybatis/dynamic/sql/where/EmbeddedWhereModel.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/EmbeddedWhereModel.java
@@ -1,0 +1,47 @@
+/*
+ *    Copyright 2016-2024 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.dynamic.sql.where;
+
+import org.mybatis.dynamic.sql.common.AbstractBooleanExpressionModel;
+import org.mybatis.dynamic.sql.render.RenderingContext;
+import org.mybatis.dynamic.sql.util.FragmentAndParameters;
+import org.mybatis.dynamic.sql.where.render.WhereRenderer;
+
+import java.util.Optional;
+
+public class EmbeddedWhereModel extends AbstractBooleanExpressionModel {
+    private EmbeddedWhereModel(Builder builder) {
+        super(builder);
+    }
+
+    public Optional<FragmentAndParameters> render(RenderingContext renderingContext) {
+        return WhereRenderer.withWhereModel(this)
+                .withRenderingContext(renderingContext)
+                .build()
+                .render();
+    }
+
+    public static class Builder extends AbstractBuilder<Builder> {
+        public EmbeddedWhereModel build() {
+            return new EmbeddedWhereModel(this);
+        }
+
+        @Override
+        protected Builder getThis() {
+            return this;
+        }
+    }
+}

--- a/src/main/java/org/mybatis/dynamic/sql/where/WhereDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/WhereDSL.java
@@ -24,7 +24,7 @@ import org.mybatis.dynamic.sql.util.Buildable;
 /**
  *  DSL for standalone where clauses.
  *
- *  This can also be used to create reusable where clauses for different statements.
+ *  <p>This can also be used to create reusable where clauses for different statements.
  */
 public class WhereDSL extends AbstractWhereStarter<WhereDSL.StandaloneWhereFinisher, WhereDSL> {
     private final StatementConfiguration statementConfiguration = new StatementConfiguration();

--- a/src/main/java/org/mybatis/dynamic/sql/where/WhereDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/WhereDSL.java
@@ -21,6 +21,11 @@ import org.jetbrains.annotations.NotNull;
 import org.mybatis.dynamic.sql.configuration.StatementConfiguration;
 import org.mybatis.dynamic.sql.util.Buildable;
 
+/**
+ *  DSL for standalone where clauses.
+ *
+ *  This can also be used to create reusable where clauses for different statements.
+ */
 public class WhereDSL extends AbstractWhereStarter<WhereDSL.StandaloneWhereFinisher, WhereDSL> {
     private final StatementConfiguration statementConfiguration = new StatementConfiguration();
     private final StandaloneWhereFinisher whereBuilder = new StandaloneWhereFinisher();
@@ -39,7 +44,7 @@ public class WhereDSL extends AbstractWhereStarter<WhereDSL.StandaloneWhereFinis
     public class StandaloneWhereFinisher extends AbstractWhereFinisher<StandaloneWhereFinisher>
             implements Buildable<WhereModel> {
         private StandaloneWhereFinisher() {
-            super(statementConfiguration);
+            super(WhereDSL.this);
         }
 
         @Override
@@ -50,7 +55,11 @@ public class WhereDSL extends AbstractWhereStarter<WhereDSL.StandaloneWhereFinis
         @NotNull
         @Override
         public WhereModel build() {
-            return buildModel();
+            return new WhereModel.Builder()
+                    .withInitialCriterion(getInitialCriterion())
+                    .withSubCriteria(subCriteria)
+                    .withStatementConfiguration(statementConfiguration)
+                    .build();
         }
 
         public WhereApplier toWhereApplier() {

--- a/src/main/java/org/mybatis/dynamic/sql/where/WhereModel.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/WhereModel.java
@@ -48,7 +48,8 @@ public class WhereModel extends AbstractBooleanExpressionModel {
      * @return rendered where clause
      */
     public Optional<WhereClauseProvider> render(RenderingStrategy renderingStrategy) {
-        RenderingContext renderingContext = RenderingContext.withRenderingStrategy(renderingStrategy).build();
+        RenderingContext renderingContext = RenderingContext.withRenderingStrategy(renderingStrategy)
+                .withStatementConfiguration(statementConfiguration).build();
 
         return render(renderingContext).map(this::toWhereClauseProvider);
     }
@@ -58,6 +59,7 @@ public class WhereModel extends AbstractBooleanExpressionModel {
         RenderingContext renderingContext = RenderingContext
                 .withRenderingStrategy(renderingStrategy)
                 .withTableAliasCalculator(tableAliasCalculator)
+                .withStatementConfiguration(statementConfiguration)
                 .build();
 
         return render(renderingContext).map(this::toWhereClauseProvider);
@@ -67,6 +69,7 @@ public class WhereModel extends AbstractBooleanExpressionModel {
         RenderingContext renderingContext = RenderingContext
                 .withRenderingStrategy(renderingStrategy)
                 .withParameterName(parameterName)
+                .withStatementConfiguration(statementConfiguration)
                 .build();
 
         return render(renderingContext).map(this::toWhereClauseProvider);
@@ -78,6 +81,7 @@ public class WhereModel extends AbstractBooleanExpressionModel {
                 .withRenderingStrategy(renderingStrategy)
                 .withTableAliasCalculator(tableAliasCalculator)
                 .withParameterName(parameterName)
+                .withStatementConfiguration(statementConfiguration)
                 .build();
 
         return render(renderingContext).map(this::toWhereClauseProvider);

--- a/src/main/java/org/mybatis/dynamic/sql/where/WhereModel.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/WhereModel.java
@@ -15,12 +15,9 @@
  */
 package org.mybatis.dynamic.sql.where;
 
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import org.mybatis.dynamic.sql.AndOrCriteriaGroup;
-import org.mybatis.dynamic.sql.SqlCriterion;
 import org.mybatis.dynamic.sql.common.AbstractBooleanExpressionModel;
 import org.mybatis.dynamic.sql.configuration.StatementConfiguration;
 import org.mybatis.dynamic.sql.render.RenderingContext;
@@ -33,10 +30,9 @@ import org.mybatis.dynamic.sql.where.render.WhereRenderer;
 public class WhereModel extends AbstractBooleanExpressionModel {
     private final StatementConfiguration statementConfiguration;
 
-    public WhereModel(SqlCriterion initialCriterion, List<AndOrCriteriaGroup> subCriteria,
-            StatementConfiguration statementConfiguration) {
-        super(initialCriterion, subCriteria);
-        this.statementConfiguration = Objects.requireNonNull(statementConfiguration);
+    private WhereModel(Builder builder) {
+        super(builder);
+        statementConfiguration = Objects.requireNonNull(builder.statementConfiguration);
     }
 
     public boolean isNonRenderingClauseAllowed() {
@@ -99,5 +95,23 @@ public class WhereModel extends AbstractBooleanExpressionModel {
         return WhereClauseProvider.withWhereClause(fragmentAndParameters.fragment())
                 .withParameters(fragmentAndParameters.parameters())
                 .build();
+    }
+
+    public static class Builder extends AbstractBuilder<Builder> {
+        private StatementConfiguration statementConfiguration;
+
+        public Builder withStatementConfiguration(StatementConfiguration statementConfiguration) {
+            this.statementConfiguration = statementConfiguration;
+            return this;
+        }
+
+        public WhereModel build() {
+            return new WhereModel(this);
+        }
+
+        @Override
+        protected Builder getThis() {
+            return this;
+        }
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/WhereModel.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/WhereModel.java
@@ -35,10 +35,6 @@ public class WhereModel extends AbstractBooleanExpressionModel {
         statementConfiguration = Objects.requireNonNull(builder.statementConfiguration);
     }
 
-    public boolean isNonRenderingClauseAllowed() {
-        return statementConfiguration.isNonRenderingWhereClauseAllowed();
-    }
-
     /**
      * Renders a where clause without table aliases.
      *

--- a/src/main/java/org/mybatis/dynamic/sql/where/WhereModel.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/WhereModel.java
@@ -47,7 +47,7 @@ public class WhereModel extends AbstractBooleanExpressionModel {
         RenderingContext renderingContext = RenderingContext.withRenderingStrategy(renderingStrategy)
                 .withStatementConfiguration(statementConfiguration).build();
 
-        return render(renderingContext).map(this::toWhereClauseProvider);
+        return render(renderingContext);
     }
 
     public Optional<WhereClauseProvider> render(RenderingStrategy renderingStrategy,
@@ -58,7 +58,7 @@ public class WhereModel extends AbstractBooleanExpressionModel {
                 .withStatementConfiguration(statementConfiguration)
                 .build();
 
-        return render(renderingContext).map(this::toWhereClauseProvider);
+        return render(renderingContext);
     }
 
     public Optional<WhereClauseProvider> render(RenderingStrategy renderingStrategy, String parameterName) {
@@ -68,7 +68,7 @@ public class WhereModel extends AbstractBooleanExpressionModel {
                 .withStatementConfiguration(statementConfiguration)
                 .build();
 
-        return render(renderingContext).map(this::toWhereClauseProvider);
+        return render(renderingContext);
     }
 
     public Optional<WhereClauseProvider> render(RenderingStrategy renderingStrategy,
@@ -80,14 +80,15 @@ public class WhereModel extends AbstractBooleanExpressionModel {
                 .withStatementConfiguration(statementConfiguration)
                 .build();
 
-        return render(renderingContext).map(this::toWhereClauseProvider);
+        return render(renderingContext);
     }
 
-    public Optional<FragmentAndParameters> render(RenderingContext renderingContext) {
+    private Optional<WhereClauseProvider> render(RenderingContext renderingContext) {
         return WhereRenderer.withWhereModel(this)
                 .withRenderingContext(renderingContext)
                 .build()
-                .render();
+                .render()
+                .map(this::toWhereClauseProvider);
     }
 
     private WhereClauseProvider toWhereClauseProvider(FragmentAndParameters fragmentAndParameters) {

--- a/src/main/java/org/mybatis/dynamic/sql/where/WhereModel.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/WhereModel.java
@@ -50,7 +50,7 @@ public class WhereModel extends AbstractBooleanExpressionModel {
     public Optional<WhereClauseProvider> render(RenderingStrategy renderingStrategy) {
         RenderingContext renderingContext = RenderingContext.withRenderingStrategy(renderingStrategy).build();
 
-        return render(renderingContext);
+        return render(renderingContext).map(this::toWhereClauseProvider);
     }
 
     public Optional<WhereClauseProvider> render(RenderingStrategy renderingStrategy,
@@ -60,7 +60,7 @@ public class WhereModel extends AbstractBooleanExpressionModel {
                 .withTableAliasCalculator(tableAliasCalculator)
                 .build();
 
-        return render(renderingContext);
+        return render(renderingContext).map(this::toWhereClauseProvider);
     }
 
     public Optional<WhereClauseProvider> render(RenderingStrategy renderingStrategy, String parameterName) {
@@ -69,7 +69,7 @@ public class WhereModel extends AbstractBooleanExpressionModel {
                 .withParameterName(parameterName)
                 .build();
 
-        return render(renderingContext);
+        return render(renderingContext).map(this::toWhereClauseProvider);
     }
 
     public Optional<WhereClauseProvider> render(RenderingStrategy renderingStrategy,
@@ -80,15 +80,14 @@ public class WhereModel extends AbstractBooleanExpressionModel {
                 .withParameterName(parameterName)
                 .build();
 
-        return render(renderingContext);
+        return render(renderingContext).map(this::toWhereClauseProvider);
     }
 
-    private Optional<WhereClauseProvider> render(RenderingContext renderingContext) {
+    public Optional<FragmentAndParameters> render(RenderingContext renderingContext) {
         return WhereRenderer.withWhereModel(this)
                 .withRenderingContext(renderingContext)
                 .build()
-                .render()
-                .map(this::toWhereClauseProvider);
+                .render();
     }
 
     private WhereClauseProvider toWhereClauseProvider(FragmentAndParameters fragmentAndParameters) {

--- a/src/main/java/org/mybatis/dynamic/sql/where/render/CriterionRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/render/CriterionRenderer.java
@@ -30,7 +30,6 @@ import org.mybatis.dynamic.sql.NotCriterion;
 import org.mybatis.dynamic.sql.SqlCriterion;
 import org.mybatis.dynamic.sql.SqlCriterionVisitor;
 import org.mybatis.dynamic.sql.render.RenderingContext;
-import org.mybatis.dynamic.sql.select.render.SelectRenderer;
 import org.mybatis.dynamic.sql.select.render.SelectStatementProvider;
 import org.mybatis.dynamic.sql.util.FragmentAndParameters;
 import org.mybatis.dynamic.sql.util.FragmentCollector;
@@ -121,11 +120,7 @@ public class CriterionRenderer implements SqlCriterionVisitor<Optional<RenderedC
     private FragmentAndParameters renderExists(ExistsCriterion criterion) {
         ExistsPredicate existsPredicate = criterion.existsPredicate();
 
-        SelectStatementProvider selectStatement = SelectRenderer
-                .withSelectModel(existsPredicate.selectModelBuilder().build())
-                .withRenderingContext(renderingContext)
-                .build()
-                .render();
+        SelectStatementProvider selectStatement = existsPredicate.selectModelBuilder().build().render(renderingContext);
 
         String fragment = existsPredicate.operator()
                 + " (" //$NON-NLS-1$

--- a/src/main/java/org/mybatis/dynamic/sql/where/render/DefaultConditionVisitor.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/render/DefaultConditionVisitor.java
@@ -30,7 +30,6 @@ import org.mybatis.dynamic.sql.BindableColumn;
 import org.mybatis.dynamic.sql.ConditionVisitor;
 import org.mybatis.dynamic.sql.render.RenderedParameterInfo;
 import org.mybatis.dynamic.sql.render.RenderingContext;
-import org.mybatis.dynamic.sql.select.render.SelectRenderer;
 import org.mybatis.dynamic.sql.select.render.SelectStatementProvider;
 import org.mybatis.dynamic.sql.util.FragmentAndParameters;
 import org.mybatis.dynamic.sql.util.FragmentCollector;

--- a/src/main/java/org/mybatis/dynamic/sql/where/render/DefaultConditionVisitor.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/render/DefaultConditionVisitor.java
@@ -94,10 +94,7 @@ public class DefaultConditionVisitor<T> implements ConditionVisitor<T, FragmentA
 
     @Override
     public FragmentAndParameters visit(AbstractSubselectCondition<T> condition) {
-        SelectStatementProvider selectStatement = SelectRenderer.withSelectModel(condition.selectModel())
-                .withRenderingContext(renderingContext)
-                .build()
-                .render();
+        SelectStatementProvider selectStatement = condition.selectModel().render(renderingContext);
 
         String finalFragment = condition.operator()
                 + " (" //$NON-NLS-1$

--- a/src/main/java/org/mybatis/dynamic/sql/where/render/WhereRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/render/WhereRenderer.java
@@ -31,7 +31,7 @@ public class WhereRenderer extends AbstractBooleanExpressionRenderer<WhereModel>
     public Optional<FragmentAndParameters> render() {
         Optional<FragmentAndParameters> whereClause = super.render();
 
-        if (whereClause.isPresent() || model.isNonRenderingClauseAllowed()) {
+        if (whereClause.isPresent() || renderingContext.isNonRenderingClauseAllowed()) {
             return whereClause;
         } else {
             throw new NonRenderingWhereClauseException();

--- a/src/main/java/org/mybatis/dynamic/sql/where/render/WhereRenderer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/render/WhereRenderer.java
@@ -17,12 +17,12 @@ package org.mybatis.dynamic.sql.where.render;
 
 import java.util.Optional;
 
+import org.mybatis.dynamic.sql.common.AbstractBooleanExpressionModel;
 import org.mybatis.dynamic.sql.common.AbstractBooleanExpressionRenderer;
 import org.mybatis.dynamic.sql.exception.NonRenderingWhereClauseException;
 import org.mybatis.dynamic.sql.util.FragmentAndParameters;
-import org.mybatis.dynamic.sql.where.WhereModel;
 
-public class WhereRenderer extends AbstractBooleanExpressionRenderer<WhereModel> {
+public class WhereRenderer extends AbstractBooleanExpressionRenderer {
     private WhereRenderer(Builder builder) {
         super("where", builder); //$NON-NLS-1$
     }
@@ -38,12 +38,12 @@ public class WhereRenderer extends AbstractBooleanExpressionRenderer<WhereModel>
         }
     }
 
-    public static Builder withWhereModel(WhereModel whereModel) {
+    public static Builder withWhereModel(AbstractBooleanExpressionModel whereModel) {
         return new Builder(whereModel);
     }
 
-    public static class Builder extends AbstractBuilder<WhereModel, Builder> {
-        public Builder(WhereModel whereModel) {
+    public static class Builder extends AbstractBuilder<Builder> {
+        public Builder(AbstractBooleanExpressionModel whereModel) {
             super(whereModel);
         }
 

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinMultiSelectBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinMultiSelectBuilder.kt
@@ -18,6 +18,7 @@ package org.mybatis.dynamic.sql.util.kotlin
 import org.mybatis.dynamic.sql.BasicColumn
 import org.mybatis.dynamic.sql.SortSpecification
 import org.mybatis.dynamic.sql.SqlBuilder
+import org.mybatis.dynamic.sql.configuration.StatementConfiguration
 import org.mybatis.dynamic.sql.select.MultiSelectDSL
 import org.mybatis.dynamic.sql.select.MultiSelectModel
 import org.mybatis.dynamic.sql.util.Buildable
@@ -72,6 +73,10 @@ class KotlinMultiSelectBuilder: Buildable<MultiSelectModel> {
 
     fun fetchFirst(fetchFirstRows: Long) {
         getDsl().fetchFirst(fetchFirstRows).rowsOnly()
+    }
+
+    fun configureStatement(c: StatementConfiguration.() -> Unit) {
+        getDsl().configureStatement(c)
     }
 
     override fun build(): MultiSelectModel =

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/elements/CaseDSLs.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/elements/CaseDSLs.kt
@@ -19,7 +19,7 @@ import org.mybatis.dynamic.sql.BasicColumn
 import org.mybatis.dynamic.sql.VisitableCondition
 import org.mybatis.dynamic.sql.select.caseexpression.BasicWhenCondition
 import org.mybatis.dynamic.sql.select.caseexpression.ConditionBasedWhenCondition
-import org.mybatis.dynamic.sql.select.caseexpression.SearchedCaseModel.SearchedWhenCondition
+import org.mybatis.dynamic.sql.select.caseexpression.SearchedCaseWhenCondition
 import org.mybatis.dynamic.sql.select.caseexpression.SimpleCaseWhenCondition
 import org.mybatis.dynamic.sql.util.kotlin.GroupingCriteriaCollector
 import org.mybatis.dynamic.sql.util.kotlin.assertNull
@@ -30,12 +30,16 @@ class KSearchedCaseDSL : KElseDSL {
             assertNull(field, "ERROR.42") //$NON-NLS-1$
             field = value
         }
-    internal val whenConditions = mutableListOf<SearchedWhenCondition>()
+    internal val whenConditions = mutableListOf<SearchedCaseWhenCondition>()
 
-    fun `when`(dslCompleter: SearchedCaseCriteriaCollector.() -> Unit) {
-        val dsl = SearchedCaseCriteriaCollector().apply(dslCompleter)
-        whenConditions.add(SearchedWhenCondition(dsl.initialCriterion, dsl.subCriteria, dsl.thenValue))
-    }
+    fun `when`(dslCompleter: SearchedCaseCriteriaCollector.() -> Unit) =
+        SearchedCaseCriteriaCollector().apply(dslCompleter).run {
+            whenConditions.add(SearchedCaseWhenCondition.Builder().withInitialCriterion(initialCriterion)
+                .withSubCriteria(subCriteria)
+                .withThenValue(thenValue)
+                .build())
+
+        }
 
     override fun `else`(column: BasicColumn) {
         this.elseValue = column

--- a/src/test/java/org/mybatis/dynamic/sql/InvalidSQLTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/InvalidSQLTest.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.mybatis.dynamic.sql.common.OrderByModel;
+import org.mybatis.dynamic.sql.configuration.StatementConfiguration;
 import org.mybatis.dynamic.sql.exception.DynamicSqlException;
 import org.mybatis.dynamic.sql.exception.InvalidSqlException;
 import org.mybatis.dynamic.sql.insert.BatchInsertModel;
@@ -243,6 +244,7 @@ class InvalidSQLTest {
 
         RenderingContext renderingContext = RenderingContext
                 .withRenderingStrategy(RenderingStrategies.MYBATIS3)
+                .withStatementConfiguration(new StatementConfiguration())
                 .build();
 
         assertThat(pagingModel).isPresent();

--- a/src/test/java/org/mybatis/dynamic/sql/mybatis3/CriterionRendererTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/mybatis3/CriterionRendererTest.java
@@ -27,6 +27,7 @@ import org.mybatis.dynamic.sql.ColumnAndConditionCriterion;
 import org.mybatis.dynamic.sql.SqlBuilder;
 import org.mybatis.dynamic.sql.SqlColumn;
 import org.mybatis.dynamic.sql.SqlTable;
+import org.mybatis.dynamic.sql.configuration.StatementConfiguration;
 import org.mybatis.dynamic.sql.render.ExplicitTableAliasCalculator;
 import org.mybatis.dynamic.sql.render.RenderingContext;
 import org.mybatis.dynamic.sql.render.RenderingStrategies;
@@ -45,7 +46,8 @@ class CriterionRendererTest {
                 .withCondition(condition)
                 .build();
 
-        RenderingContext renderingContext =RenderingContext.withRenderingStrategy(RenderingStrategies.MYBATIS3).build();
+        RenderingContext renderingContext =RenderingContext.withRenderingStrategy(RenderingStrategies.MYBATIS3)
+                .withStatementConfiguration(new StatementConfiguration()).build();
 
         CriterionRenderer renderer = new CriterionRenderer(renderingContext);
 
@@ -70,6 +72,7 @@ class CriterionRendererTest {
         RenderingContext renderingContext = RenderingContext
                 .withRenderingStrategy(RenderingStrategies.MYBATIS3)
                 .withTableAliasCalculator(ExplicitTableAliasCalculator.of(tableAliases))
+                .withStatementConfiguration(new StatementConfiguration())
                 .build();
 
         CriterionRenderer renderer = new CriterionRenderer(renderingContext);
@@ -97,6 +100,7 @@ class CriterionRendererTest {
 
         RenderingContext renderingContext = RenderingContext
                 .withRenderingStrategy(RenderingStrategies.MYBATIS3)
+                .withStatementConfiguration(new StatementConfiguration())
                 .build();
 
         CriterionRenderer renderer = new CriterionRenderer(renderingContext);
@@ -122,6 +126,7 @@ class CriterionRendererTest {
         RenderingContext renderingContext = RenderingContext
                 .withRenderingStrategy(RenderingStrategies.MYBATIS3)
                 .withTableAliasCalculator(ExplicitTableAliasCalculator.of(tableAliases))
+                .withStatementConfiguration(new StatementConfiguration())
                 .build();
 
         CriterionRenderer renderer = new CriterionRenderer(renderingContext);

--- a/src/test/java/org/mybatis/dynamic/sql/select/HavingModelTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/select/HavingModelTest.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.mybatis.dynamic.sql.SqlColumn;
 import org.mybatis.dynamic.sql.SqlTable;
+import org.mybatis.dynamic.sql.configuration.StatementConfiguration;
 import org.mybatis.dynamic.sql.render.RenderingContext;
 import org.mybatis.dynamic.sql.render.RenderingStrategies;
 import org.mybatis.dynamic.sql.select.render.HavingRenderer;
@@ -65,6 +66,7 @@ class HavingModelTest {
     private Optional<FragmentAndParameters> renderHavingModel(HavingModel havingModel) {
         RenderingContext renderingContext = RenderingContext
                 .withRenderingStrategy(RenderingStrategies.SPRING_NAMED_PARAMETER)
+                .withStatementConfiguration(new StatementConfiguration())
                 .build();
 
         return HavingRenderer.withHavingModel(havingModel)

--- a/src/test/java/org/mybatis/dynamic/sql/where/render/CriterionRendererTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/where/render/CriterionRendererTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.mybatis.dynamic.sql.ColumnAndConditionCriterion;
 import org.mybatis.dynamic.sql.SqlColumn;
 import org.mybatis.dynamic.sql.SqlTable;
+import org.mybatis.dynamic.sql.configuration.StatementConfiguration;
 import org.mybatis.dynamic.sql.render.ExplicitTableAliasCalculator;
 import org.mybatis.dynamic.sql.render.RenderingContext;
 import org.mybatis.dynamic.sql.render.RenderingStrategies;
@@ -46,6 +47,7 @@ class CriterionRendererTest {
 
         RenderingContext renderingContext = RenderingContext
                 .withRenderingStrategy(RenderingStrategies.MYBATIS3)
+                .withStatementConfiguration(new StatementConfiguration())
                 .build();
 
         CriterionRenderer renderer = new CriterionRenderer(renderingContext);
@@ -72,6 +74,7 @@ class CriterionRendererTest {
         RenderingContext renderingContext = RenderingContext
                 .withRenderingStrategy(RenderingStrategies.MYBATIS3)
                 .withTableAliasCalculator(ExplicitTableAliasCalculator.of(tableAliases))
+                .withStatementConfiguration(new StatementConfiguration())
                 .build();
 
         CriterionRenderer renderer = new CriterionRenderer(renderingContext);


### PR DESCRIPTION
This slice adds the statement configuration to the rendering context. This makes it possible to query statement configuration whenever rendering happens.

This PR also makes configuration available on all statements where it could make a change in rendering (including multi-selects and insert selects which were not included previously).

Further, this PR makes statement configuration consistent across all statements and enforces the rule that configuration on embedded select statements is ignored - only configuration on the outermost statement is in effect.
