### PR TITLE
Add Array Based Methods to Kotlin DSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@ types - which is a rare usage. Please let us know if this causes an undo hardshi
    a good safety measure in some cases.
 5. Added Array based functions for the "in" and "not in" conditions in the Kotlin DSL. These functions allow a more
    natural use of an Array as an input for an "in" condition. They also allow easy reuse of a vararg argument in a
-   function.
+   function. ([#781](https://github.com/mybatis/mybatis-dynamic-sql/pull/781))
 
 ## Release 1.5.0 - April 21, 2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,9 @@ types - which is a rare usage. Please let us know if this causes an undo hardshi
    as rendering empty lists). This change should be transparent to users unless they have implemented custom conditions.
 4. Added a configuration setting to allow empty list conditions to render. This could generate invalid SQL, but might be
    a good safety measure in some cases.
+5. Added Array based functions for the "in" and "not in" conditions in the Kotlin DSL. These functions allow a more
+   natural use of an Array as an input for an "in" condition. They also allow easy reuse of a vararg argument in a
+   function.
 
 ## Release 1.5.0 - April 21, 2023
 

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/GroupingCriteriaCollector.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/GroupingCriteriaCollector.kt
@@ -317,6 +317,10 @@ open class GroupingCriteriaCollector : SubCriteriaCollector() {
 
     fun <T> BindableColumn<T>.isIn(vararg values: T & Any) = isIn(values.asList())
 
+    @JvmName("isInArray")
+    infix fun <T> BindableColumn<T>.isIn(values: Array<out T & Any>) =
+        invoke(org.mybatis.dynamic.sql.util.kotlin.elements.isIn(values))
+
     infix fun <T> BindableColumn<T>.isIn(values: Collection<T & Any>) =
         invoke(org.mybatis.dynamic.sql.util.kotlin.elements.isIn(values))
 
@@ -325,10 +329,18 @@ open class GroupingCriteriaCollector : SubCriteriaCollector() {
 
     fun <T> BindableColumn<T>.isInWhenPresent(vararg values: T?) = isInWhenPresent(values.asList())
 
+    @JvmName("isInArrayWhenPresent")
+    infix fun <T> BindableColumn<T>.isInWhenPresent(values: Array<out T?>?) =
+        invoke(org.mybatis.dynamic.sql.util.kotlin.elements.isInWhenPresent(values))
+
     infix fun <T> BindableColumn<T>.isInWhenPresent(values: Collection<T?>?) =
         invoke(org.mybatis.dynamic.sql.util.kotlin.elements.isInWhenPresent(values))
 
     fun <T> BindableColumn<T>.isNotIn(vararg values: T & Any) = isNotIn(values.asList())
+
+    @JvmName("isNotInArray")
+    infix fun <T> BindableColumn<T>.isNotIn(values: Array<out T & Any>) =
+        invoke(org.mybatis.dynamic.sql.util.kotlin.elements.isNotIn(values))
 
     infix fun <T> BindableColumn<T>.isNotIn(values: Collection<T & Any>) =
         invoke(org.mybatis.dynamic.sql.util.kotlin.elements.isNotIn(values))
@@ -337,6 +349,10 @@ open class GroupingCriteriaCollector : SubCriteriaCollector() {
         invoke(org.mybatis.dynamic.sql.util.kotlin.elements.isNotIn(subQuery))
 
     fun <T> BindableColumn<T>.isNotInWhenPresent(vararg values: T?) = isNotInWhenPresent(values.asList())
+
+    @JvmName("isNotInArrayWhenPresent")
+    infix fun <T> BindableColumn<T>.isNotInWhenPresent(values: Array<out T?>?) =
+        invoke(org.mybatis.dynamic.sql.util.kotlin.elements.isNotInWhenPresent(values))
 
     infix fun <T> BindableColumn<T>.isNotInWhenPresent(values: Collection<T?>?) =
         invoke(org.mybatis.dynamic.sql.util.kotlin.elements.isNotInWhenPresent(values))
@@ -394,11 +410,19 @@ open class GroupingCriteriaCollector : SubCriteriaCollector() {
 
     fun BindableColumn<String>.isInCaseInsensitive(vararg values: String) = isInCaseInsensitive(values.asList())
 
+    @JvmName("isInArrayCaseInsensitive")
+    infix fun BindableColumn<String>.isInCaseInsensitive(values: Array<out String>) =
+        invoke(org.mybatis.dynamic.sql.util.kotlin.elements.isInCaseInsensitive(values))
+
     infix fun BindableColumn<String>.isInCaseInsensitive(values: Collection<String>) =
         invoke(org.mybatis.dynamic.sql.util.kotlin.elements.isInCaseInsensitive(values))
 
     fun BindableColumn<String>.isInCaseInsensitiveWhenPresent(vararg values: String?) =
         isInCaseInsensitiveWhenPresent(values.asList())
+
+    @JvmName("isInArrayCaseInsensitiveWhenPresent")
+    infix fun BindableColumn<String>.isInCaseInsensitiveWhenPresent(values: Array<out String?>?) =
+        invoke(org.mybatis.dynamic.sql.util.kotlin.elements.isInCaseInsensitiveWhenPresent(values))
 
     infix fun BindableColumn<String>.isInCaseInsensitiveWhenPresent(values: Collection<String?>?) =
         invoke(org.mybatis.dynamic.sql.util.kotlin.elements.isInCaseInsensitiveWhenPresent(values))
@@ -406,11 +430,19 @@ open class GroupingCriteriaCollector : SubCriteriaCollector() {
     fun BindableColumn<String>.isNotInCaseInsensitive(vararg values: String) =
         isNotInCaseInsensitive(values.asList())
 
+    @JvmName("isNotInArrayCaseInsensitive")
+    infix fun BindableColumn<String>.isNotInCaseInsensitive(values: Array<out String>) =
+        invoke(org.mybatis.dynamic.sql.util.kotlin.elements.isNotInCaseInsensitive(values))
+
     infix fun BindableColumn<String>.isNotInCaseInsensitive(values: Collection<String>) =
         invoke(org.mybatis.dynamic.sql.util.kotlin.elements.isNotInCaseInsensitive(values))
 
     fun BindableColumn<String>.isNotInCaseInsensitiveWhenPresent(vararg values: String?) =
         isNotInCaseInsensitiveWhenPresent(values.asList())
+
+    @JvmName("isNotInArrayCaseInsensitiveWhenPresent")
+    infix fun BindableColumn<String>.isNotInCaseInsensitiveWhenPresent(values: Array<out String?>?) =
+        invoke(org.mybatis.dynamic.sql.util.kotlin.elements.isNotInCaseInsensitiveWhenPresent(values))
 
     infix fun BindableColumn<String>.isNotInCaseInsensitiveWhenPresent(values: Collection<String?>?) =
         invoke(org.mybatis.dynamic.sql.util.kotlin.elements.isNotInCaseInsensitiveWhenPresent(values))

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/elements/SqlElements.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/elements/SqlElements.kt
@@ -262,6 +262,9 @@ fun <T> isLessThanOrEqualToWhenPresent(value: T?): IsLessThanOrEqualTo<T> =
 
 fun <T> isIn(vararg values: T & Any): IsIn<T> = isIn(values.asList())
 
+@JvmName("isInArray")
+fun <T> isIn(values: Array<out T & Any>): IsIn<T> = SqlBuilder.isIn(values.asList())
+
 fun <T> isIn(values: Collection<T & Any>): IsIn<T> = SqlBuilder.isIn(values)
 
 fun <T> isIn(subQuery: KotlinSubQueryBuilder.() -> Unit): IsInWithSubselect<T> =
@@ -269,9 +272,15 @@ fun <T> isIn(subQuery: KotlinSubQueryBuilder.() -> Unit): IsInWithSubselect<T> =
 
 fun <T> isInWhenPresent(vararg values: T?): IsIn<T> = isInWhenPresent(values.asList())
 
+@JvmName("isInArrayWhenPresent")
+fun <T> isInWhenPresent(values: Array<out T?>?): IsIn<T> = SqlBuilder.isInWhenPresent(values?.asList())
+
 fun <T> isInWhenPresent(values: Collection<T?>?): IsIn<T> = SqlBuilder.isInWhenPresent(values)
 
 fun <T> isNotIn(vararg values: T & Any): IsNotIn<T> = isNotIn(values.asList())
+
+@JvmName("isNotInArray")
+fun <T> isNotIn(values: Array<out T & Any>): IsNotIn<T> = SqlBuilder.isNotIn(values.asList())
 
 fun <T> isNotIn(values: Collection<T & Any>): IsNotIn<T> = SqlBuilder.isNotIn(values)
 
@@ -279,6 +288,9 @@ fun <T> isNotIn(subQuery: KotlinSubQueryBuilder.() -> Unit): IsNotInWithSubselec
     SqlBuilder.isNotIn(KotlinSubQueryBuilder().apply(subQuery))
 
 fun <T> isNotInWhenPresent(vararg values: T?): IsNotIn<T> = isNotInWhenPresent(values.asList())
+
+@JvmName("isNotInArrayWhenPresent")
+fun <T> isNotInWhenPresent(values: Array<out T?>?): IsNotIn<T> = SqlBuilder.isNotInWhenPresent(values?.asList())
 
 fun <T> isNotInWhenPresent(values: Collection<T?>?): IsNotIn<T> = SqlBuilder.isNotInWhenPresent(values)
 
@@ -318,21 +330,36 @@ fun isNotLikeCaseInsensitiveWhenPresent(value: String?): IsNotLikeCaseInsensitiv
 
 fun isInCaseInsensitive(vararg values: String): IsInCaseInsensitive = isInCaseInsensitive(values.asList())
 
+@JvmName("isInArrayCaseInsensitive")
+fun isInCaseInsensitive(values: Array<out String>): IsInCaseInsensitive = SqlBuilder.isInCaseInsensitive(values.asList())
+
 fun isInCaseInsensitive(values: Collection<String>): IsInCaseInsensitive = SqlBuilder.isInCaseInsensitive(values)
 
 fun isInCaseInsensitiveWhenPresent(vararg values: String?): IsInCaseInsensitive =
     isInCaseInsensitiveWhenPresent(values.asList())
+
+@JvmName("isInArrayCaseInsensitiveWhenPresent")
+fun isInCaseInsensitiveWhenPresent(values: Array<out String?>?): IsInCaseInsensitive =
+    SqlBuilder.isInCaseInsensitiveWhenPresent(values?.asList())
 
 fun isInCaseInsensitiveWhenPresent(values: Collection<String?>?): IsInCaseInsensitive =
     SqlBuilder.isInCaseInsensitiveWhenPresent(values)
 
 fun isNotInCaseInsensitive(vararg values: String): IsNotInCaseInsensitive = isNotInCaseInsensitive(values.asList())
 
+@JvmName("isNotInArrayCaseInsensitive")
+fun isNotInCaseInsensitive(values: Array<out String>): IsNotInCaseInsensitive =
+    SqlBuilder.isNotInCaseInsensitive(values.asList())
+
 fun isNotInCaseInsensitive(values: Collection<String>): IsNotInCaseInsensitive =
     SqlBuilder.isNotInCaseInsensitive(values)
 
 fun isNotInCaseInsensitiveWhenPresent(vararg values: String?): IsNotInCaseInsensitive =
     isNotInCaseInsensitiveWhenPresent(values.asList())
+
+@JvmName("isNotInArrayCaseInsensitiveWhenPresent")
+fun isNotInCaseInsensitiveWhenPresent(values: Array<out String?>?): IsNotInCaseInsensitive =
+    SqlBuilder.isNotInCaseInsensitiveWhenPresent(values?.asList())
 
 fun isNotInCaseInsensitiveWhenPresent(values: Collection<String?>?): IsNotInCaseInsensitive =
     SqlBuilder.isNotInCaseInsensitiveWhenPresent(values)

--- a/src/site/markdown/docs/kotlinWhereClauses.md
+++ b/src/site/markdown/docs/kotlinWhereClauses.md
@@ -85,11 +85,10 @@ where clauses with and/or/not phrases. See the following example of a complex wh
 select(foo) {
     from(bar)
     where {
-        id isEqualTo 3
-        and { id isEqualTo 4 }
+       id isEqualTo 3
+       or { id isEqualTo 4 }
+       and { not { id isEqualTo 6 } }
     }
-    or { id isEqualTo 4 }
-    and { not { id isEqualTo 6 } }
 }
 ```
 
@@ -215,8 +214,10 @@ These criteria should be updated by moving the column and condition into a lambd
 ```kotlin
 select(foo) {
    from(bar)
-   where { id isEqualTo 3 }
-   or { id isEqualTo 4 }
+   where {
+      id isEqualTo 3
+      or { id isEqualTo 4 }
+   }
 }
 ```
 

--- a/src/test/kotlin/examples/kotlin/spring/canonical/InfixElementsTest.kt
+++ b/src/test/kotlin/examples/kotlin/spring/canonical/InfixElementsTest.kt
@@ -677,7 +677,7 @@ open class InfixElementsTest {
     fun testIsNotLike() {
         val selectStatement = select(firstName) {
             from(person)
-            where { firstName  isNotLike "F%" }
+            where { firstName isNotLike "F%" }
             orderBy(id)
         }
 
@@ -695,7 +695,7 @@ open class InfixElementsTest {
     fun testIsNotLikeWhenPresent() {
         val selectStatement = select(firstName) {
             from(person)
-            where { firstName  isNotLikeWhenPresent "F%" }
+            where { firstName isNotLikeWhenPresent "F%" }
             orderBy(id)
         }
 
@@ -955,10 +955,10 @@ open class InfixElementsTest {
         val selectStatement = select(firstName) {
             from(person)
             where {
-                upper(firstName) (
-                isLike(fn).filter(String::isNotBlank)
-                    .map(String::uppercase)
-                    .map { "%$it%" })
+                upper(firstName)(
+                    isLike(fn).filter(String::isNotBlank)
+                        .map(String::uppercase)
+                        .map { "%$it%" })
             }
             orderBy(id)
             configureStatement { isNonRenderingWhereClauseAllowed = true }
@@ -981,7 +981,7 @@ open class InfixElementsTest {
         val selectStatement = select(firstName) {
             from(person)
             where {
-                upper(firstName) (isLike(fn).filter(String::isNotBlank)
+                upper(firstName)(isLike(fn).filter(String::isNotBlank)
                     .map(String::uppercase)
                     .map { "%$it%" })
             }
@@ -1263,5 +1263,253 @@ open class InfixElementsTest {
         }
 
         assertThat(selectStatement.selectStatement).isEqualTo("select id from Person")
+    }
+
+    @Test
+    fun testIsInArray() {
+        fun search(vararg names: String) {
+            val selectStatement = select(firstName) {
+                from(person)
+                where { firstName isIn names }
+                orderBy(id)
+            }
+
+            assertThat(selectStatement.selectStatement)
+                .isEqualTo("select first_name from Person where first_name in (:p1,:p2) order by id")
+
+            val rows = template.selectList(selectStatement, String::class)
+
+            assertThat(rows).hasSize(2)
+            assertThat(rows[0]).isEqualTo("Fred")
+        }
+
+        search("Fred", "Wilma")
+    }
+
+    @Test
+    fun testIsInArrayWhenPresent() {
+        fun search(vararg names: String?) {
+            val selectStatement = select(firstName) {
+                from(person)
+                where { firstName isInWhenPresent names }
+                orderBy(id)
+            }
+
+            assertThat(selectStatement.selectStatement)
+                .isEqualTo("select first_name from Person where first_name in (:p1,:p2) order by id")
+
+            val rows = template.selectList(selectStatement, String::class)
+
+            assertThat(rows).hasSize(2)
+            assertThat(rows[0]).isEqualTo("Fred")
+        }
+
+        search("Fred", null, "Wilma")
+    }
+
+    @Test
+    fun testIsInArrayWhenPresentNullArray() {
+        val selectStatement = select(firstName) {
+            from(person)
+            where {
+                id isLessThan 10
+                and { firstName isInWhenPresent null as Array<String>? }
+            }
+            orderBy(id)
+        }
+
+        assertThat(selectStatement.selectStatement)
+            .isEqualTo("select first_name from Person where id < :p1 order by id")
+
+        val rows = template.selectList(selectStatement, String::class)
+
+        assertThat(rows).hasSize(6)
+        assertThat(rows[0]).isEqualTo("Fred")
+    }
+
+    @Test
+    fun testIsNotInArray() {
+        fun search(vararg names: String) {
+            val selectStatement = select(firstName) {
+                from(person)
+                where { firstName isNotIn names }
+                orderBy(id)
+            }
+
+            assertThat(selectStatement.selectStatement)
+                .isEqualTo("select first_name from Person where first_name not in (:p1,:p2) order by id")
+
+            val rows = template.selectList(selectStatement, String::class)
+
+            assertThat(rows).hasSize(4)
+            assertThat(rows[0]).isEqualTo("Pebbles")
+        }
+
+        search("Fred", "Wilma")
+    }
+
+    @Test
+    fun testIsNotInArrayWhenPresent() {
+        fun search(vararg names: String?) {
+            val selectStatement = select(firstName) {
+                from(person)
+                where { firstName isNotInWhenPresent names }
+                orderBy(id)
+            }
+
+            assertThat(selectStatement.selectStatement)
+                .isEqualTo("select first_name from Person where first_name not in (:p1,:p2) order by id")
+
+            val rows = template.selectList(selectStatement, String::class)
+
+            assertThat(rows).hasSize(4)
+            assertThat(rows[0]).isEqualTo("Pebbles")
+        }
+
+        search("Fred", null, "Wilma")
+    }
+
+    @Test
+    fun testIsNotInArrayWhenPresentNullArray() {
+        val selectStatement = select(firstName) {
+            from(person)
+            where {
+                id isLessThan 10
+                and { firstName isNotInWhenPresent null as Array<String>? }
+            }
+            orderBy(id)
+        }
+
+        assertThat(selectStatement.selectStatement)
+            .isEqualTo("select first_name from Person where id < :p1 order by id")
+
+        val rows = template.selectList(selectStatement, String::class)
+
+        assertThat(rows).hasSize(6)
+        assertThat(rows[0]).isEqualTo("Fred")
+    }
+
+    @Test
+    fun testIsInArrayCaseInsensitive() {
+        fun search(vararg names: String) {
+            val selectStatement = select(firstName) {
+                from(person)
+                where { firstName isInCaseInsensitive names }
+                orderBy(id)
+            }
+
+            assertThat(selectStatement.selectStatement)
+                .isEqualTo("select first_name from Person where upper(first_name) in (:p1,:p2) order by id")
+
+            val rows = template.selectList(selectStatement, String::class)
+
+            assertThat(rows).hasSize(2)
+            assertThat(rows[0]).isEqualTo("Fred")
+        }
+
+        search("Fred", "Wilma")
+    }
+
+    @Test
+    fun testIsInArrayCaseInsensitiveWhenPresent() {
+        fun search(vararg names: String?) {
+            val selectStatement = select(firstName) {
+                from(person)
+                where { firstName isInCaseInsensitiveWhenPresent names }
+                orderBy(id)
+            }
+
+            assertThat(selectStatement.selectStatement)
+                .isEqualTo("select first_name from Person where upper(first_name) in (:p1,:p2) order by id")
+
+            val rows = template.selectList(selectStatement, String::class)
+
+            assertThat(rows).hasSize(2)
+            assertThat(rows[0]).isEqualTo("Fred")
+        }
+
+        search("Fred", null, "Wilma")
+    }
+
+    @Test
+    fun testIsInArrayCaseInsensitiveWhenPresentNullArray() {
+        val selectStatement = select(firstName) {
+            from(person)
+            where {
+                id isLessThan 10
+                and { firstName isInCaseInsensitiveWhenPresent null as Array<String>? }
+            }
+            orderBy(id)
+        }
+
+        assertThat(selectStatement.selectStatement)
+            .isEqualTo("select first_name from Person where id < :p1 order by id")
+
+        val rows = template.selectList(selectStatement, String::class)
+
+        assertThat(rows).hasSize(6)
+        assertThat(rows[0]).isEqualTo("Fred")
+    }
+
+    @Test
+    fun testIsNotInArrayCaseInsensitive() {
+        fun search(vararg names: String) {
+            val selectStatement = select(firstName) {
+                from(person)
+                where { firstName isNotInCaseInsensitive names }
+                orderBy(id)
+            }
+
+            assertThat(selectStatement.selectStatement)
+                .isEqualTo("select first_name from Person where upper(first_name) not in (:p1,:p2) order by id")
+
+            val rows = template.selectList(selectStatement, String::class)
+
+            assertThat(rows).hasSize(4)
+            assertThat(rows[0]).isEqualTo("Pebbles")
+        }
+
+        search("Fred", "Wilma")
+    }
+
+    @Test
+    fun testIsNotInArrayCaseInsensitiveWhenPresent() {
+        fun search(vararg names: String?) {
+            val selectStatement = select(firstName) {
+                from(person)
+                where { firstName isNotInCaseInsensitiveWhenPresent names }
+                orderBy(id)
+            }
+
+            assertThat(selectStatement.selectStatement)
+                .isEqualTo("select first_name from Person where upper(first_name) not in (:p1,:p2) order by id")
+
+            val rows = template.selectList(selectStatement, String::class)
+
+            assertThat(rows).hasSize(4)
+            assertThat(rows[0]).isEqualTo("Pebbles")
+        }
+
+        search("Fred", null, "Wilma")
+    }
+
+    @Test
+    fun testIsNotInArrayCaseInsensitiveWhenPresentNullArray() {
+        val selectStatement = select(firstName) {
+            from(person)
+            where {
+                id isLessThan 10
+                and { firstName isNotInCaseInsensitiveWhenPresent null as Array<String>? }
+            }
+            orderBy(id)
+        }
+
+        assertThat(selectStatement.selectStatement)
+            .isEqualTo("select first_name from Person where id < :p1 order by id")
+
+        val rows = template.selectList(selectStatement, String::class)
+
+        assertThat(rows).hasSize(6)
+        assertThat(rows[0]).isEqualTo("Fred")
     }
 }

--- a/src/test/kotlin/nullability/test/InWhenPresentTest.kt
+++ b/src/test/kotlin/nullability/test/InWhenPresentTest.kt
@@ -176,7 +176,7 @@ class InWhenPresentTest {
 
             fun testFunction() {
                 countFrom(person) {
-                    where { id (isInWhenPresent(null)) }
+                    where { id (isInWhenPresent(null as List<Int>?) ) }
                 }
             }
         """

--- a/src/test/kotlin/nullability/test/NotInWhenPresentTest.kt
+++ b/src/test/kotlin/nullability/test/NotInWhenPresentTest.kt
@@ -176,7 +176,7 @@ class NotInWhenPresentTest {
 
             fun testFunction() {
                 countFrom(person) {
-                    where { id (isNotInWhenPresent(null)) }
+                    where { id (isNotInWhenPresent(null as List<Int>?) ) }
                 }
             }
         """


### PR DESCRIPTION
This allows easier use of Kotlin Arrays as input to "in" and "not in" conditions, and also allows reuse of `vararg` parameters.