### PR TITLE
Improve Kotlin CASE DSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 This log will detail notable changes to MyBatis Dynamic SQL. Full details are available on the GitHub milestone pages.
 
+## Release 1.5.2 - Unreleased
+
+This is a small maintenance release with improvements to the Kotlin DSL for CASE expressions.
+
+**Important:** This is the last release that will be compatible with Java 8.
+
 ## Release 1.5.1 - April 30, 2024
 
 This is a minor release with several enhancements.
-
-**Important:** This is the last release that will be compatible with Java 8.
 
 GitHub milestone: [https://github.com/mybatis/mybatis-dynamic-sql/milestone/13?closed=1](https://github.com/mybatis/mybatis-dynamic-sql/milestone/13?closed=1)
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
   <groupId>org.mybatis.dynamic-sql</groupId>
   <artifactId>mybatis-dynamic-sql</artifactId>
-  <version>1.6.0-SNAPSHOT</version>
+  <version>1.5.2-SNAPSHOT</version>
 
   <name>MyBatis Dynamic SQL</name>
   <description>MyBatis framework for generating dynamic SQL</description>

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/elements/CaseDSLs.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/elements/CaseDSLs.kt
@@ -65,24 +65,14 @@ class KSimpleCaseDSL<T : Any> : KElseDSL {
         }
     internal val whenConditions = mutableListOf<SimpleCaseWhenCondition<T>>()
 
-    fun `when`(firstCondition: VisitableCondition<T>, vararg subsequentConditions: VisitableCondition<T>) =
+    fun `when`(vararg conditions: VisitableCondition<T>) =
         SimpleCaseThenGatherer { thenValue ->
-            val allConditions = buildList {
-                add(firstCondition)
-                addAll(subsequentConditions)
-            }
-
-            whenConditions.add(ConditionBasedWhenCondition(allConditions, thenValue))
+            whenConditions.add(ConditionBasedWhenCondition(conditions.asList(), thenValue))
         }
 
-    fun `when`(firstValue: T, vararg subsequentValues: T) =
+    fun `when`(vararg values: T) =
         SimpleCaseThenGatherer { thenValue ->
-            val allConditions = buildList {
-                add(firstValue)
-                addAll(subsequentValues)
-            }
-
-            whenConditions.add(BasicWhenCondition(allConditions, thenValue))
+            whenConditions.add(BasicWhenCondition(values.asList(), thenValue))
         }
 
     override infix fun `else`(column: BasicColumn) {

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/elements/CaseDSLs.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/elements/CaseDSLs.kt
@@ -66,25 +66,24 @@ class KSimpleCaseDSL<T : Any> : KElseDSL {
         }
     internal val whenConditions = mutableListOf<SimpleCaseWhenCondition<T>>()
 
-    fun `when`(firstCondition: VisitableCondition<T>, vararg subsequentConditions: VisitableCondition<T>,
-               completer: SimpleCaseThenGatherer.() -> Unit) =
-        SimpleCaseThenGatherer().apply(completer).run {
+    fun `when`(firstCondition: VisitableCondition<T>, vararg subsequentConditions: VisitableCondition<T>) =
+        SimpleCaseThenGatherer {
             val allConditions = buildList {
                 add(firstCondition)
                 addAll(subsequentConditions)
             }
 
-            whenConditions.add(ConditionBasedWhenCondition(allConditions, thenValue))
+            whenConditions.add(ConditionBasedWhenCondition(allConditions, it))
         }
 
-    fun `when`(firstValue: T, vararg subsequentValues: T, completer: SimpleCaseThenGatherer.() -> Unit) =
-        SimpleCaseThenGatherer().apply(completer).run {
+    fun `when`(firstValue: T, vararg subsequentValues: T) =
+        SimpleCaseThenGatherer {
             val allConditions = buildList {
                 add(firstValue)
                 addAll(subsequentValues)
             }
 
-            whenConditions.add(BasicWhenCondition(allConditions, thenValue))
+            whenConditions.add(BasicWhenCondition(allConditions, it))
         }
 
     override fun `else`(column: BasicColumn) {
@@ -92,40 +91,34 @@ class KSimpleCaseDSL<T : Any> : KElseDSL {
     }
 }
 
-class SimpleCaseThenGatherer: KThenDSL {
-    internal var thenValue: BasicColumn? = null
-        private set(value) {
-            assertNull(field, "ERROR.41") //$NON-NLS-1$
-            field = value
-        }
-
-    override fun then(column: BasicColumn) {
-        thenValue = column
+class SimpleCaseThenGatherer(private val consumer: (BasicColumn) -> Unit): KThenDSL {
+    override infix fun then(column: BasicColumn) {
+        consumer.invoke(column)
     }
 }
 
 interface KThenDSL {
-    fun then(value: String) {
+    infix fun then(value: String) {
         then(stringConstant(value))
     }
 
-    fun then(value: Boolean) {
+    infix fun then(value: Boolean) {
         then(constant<String>(value.toString()))
     }
 
-    fun then(value: Int) {
+    infix fun then(value: Int) {
         then(constant<String>(value.toString()))
     }
 
-    fun then(value: Long) {
+    infix fun then(value: Long) {
         then(constant<String>(value.toString()))
     }
 
-    fun then(value: Double) {
+    infix fun then(value: Double) {
         then(constant<String>(value.toString()))
     }
 
-    fun then(column: BasicColumn)
+    infix fun then(column: BasicColumn)
 }
 
 interface KElseDSL {

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/elements/CaseDSLs.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/elements/CaseDSLs.kt
@@ -38,10 +38,9 @@ class KSearchedCaseDSL : KElseDSL {
                 .withSubCriteria(subCriteria)
                 .withThenValue(thenValue)
                 .build())
-
         }
 
-    override fun `else`(column: BasicColumn) {
+    override infix fun `else`(column: BasicColumn) {
         this.elseValue = column
     }
 }
@@ -53,7 +52,7 @@ class SearchedCaseCriteriaCollector : GroupingCriteriaCollector(), KThenDSL {
             field = value
         }
 
-    override fun then(column: BasicColumn) {
+    override infix fun then(column: BasicColumn) {
         thenValue = column
     }
 }
@@ -67,26 +66,26 @@ class KSimpleCaseDSL<T : Any> : KElseDSL {
     internal val whenConditions = mutableListOf<SimpleCaseWhenCondition<T>>()
 
     fun `when`(firstCondition: VisitableCondition<T>, vararg subsequentConditions: VisitableCondition<T>) =
-        SimpleCaseThenGatherer {
+        SimpleCaseThenGatherer { thenValue ->
             val allConditions = buildList {
                 add(firstCondition)
                 addAll(subsequentConditions)
             }
 
-            whenConditions.add(ConditionBasedWhenCondition(allConditions, it))
+            whenConditions.add(ConditionBasedWhenCondition(allConditions, thenValue))
         }
 
     fun `when`(firstValue: T, vararg subsequentValues: T) =
-        SimpleCaseThenGatherer {
+        SimpleCaseThenGatherer { thenValue ->
             val allConditions = buildList {
                 add(firstValue)
                 addAll(subsequentValues)
             }
 
-            whenConditions.add(BasicWhenCondition(allConditions, it))
+            whenConditions.add(BasicWhenCondition(allConditions, thenValue))
         }
 
-    override fun `else`(column: BasicColumn) {
+    override infix fun `else`(column: BasicColumn) {
         this.elseValue = column
     }
 }
@@ -122,25 +121,25 @@ interface KThenDSL {
 }
 
 interface KElseDSL {
-    fun `else`(value: String) {
+    infix fun `else`(value: String) {
         `else`(stringConstant(value))
     }
 
-    fun `else`(value: Boolean) {
+    infix fun `else`(value: Boolean) {
         `else`(constant<String>(value.toString()))
     }
 
-    fun `else`(value: Int) {
+    infix fun `else`(value: Int) {
         `else`(constant<String>(value.toString()))
     }
 
-    fun `else`(value: Long) {
+    infix fun `else`(value: Long) {
         `else`(constant<String>(value.toString()))
     }
 
-    fun `else`(value: Double) {
+    infix fun `else`(value: Double) {
         `else`(constant<String>(value.toString()))
     }
 
-    fun `else`(column: BasicColumn)
+    infix fun `else`(column: BasicColumn)
 }

--- a/src/site/markdown/docs/kotlinCaseExpressions.md
+++ b/src/site/markdown/docs/kotlinCaseExpressions.md
@@ -72,7 +72,7 @@ A simple case expression can be coded like the following in the Kotlin DSL:
 
 ```kotlin
 select(case(id) {
-    `when`(1, 2, 3) { then(true) }
+    `when`(1, 2, 3) then true
     `else`(false)
   } `as` "small_id"
 ) {
@@ -91,7 +91,7 @@ you can write the query as follows:
 
 ```kotlin
 select(case(id) {
-    `when`(1, 2, 3) { then(value(true)) }
+    `when`(1, 2, 3) then value(true)
     `else`(value(false))
   } `as` "small_id"
 ) {
@@ -111,7 +111,7 @@ expected data type. Here's an example of using the `cast` function:
 
 ```kotlin
 select(case(id) {
-    `when`(1, 2, 3) { then(value(true)) }
+    `when`(1, 2, 3) then value(true)
     `else`(cast { value(false) `as` "BOOLEAN" })
   } `as` "small_id"
 ) {
@@ -134,8 +134,8 @@ A simple case expression can be coded like the following in the Kotlin DSL:
 
 ```kotlin
 select(case(total_length) {
-    `when`(isLessThan(10)) { then("small") }
-    `when`(isGreaterThan(20)) { then("large") }
+    `when`(isLessThan(10)) then "small"
+    `when`(isGreaterThan(20)) then "large"
     `else`("medium")
   } `as` "tshirt_size"
 ) {
@@ -158,8 +158,8 @@ VARCHAR, you can use the `cast` function as follows:
 
 ```kotlin
 select(case(total_length) {
-    `when`(isLessThan(10)) { then("small") }
-    `when`(isGreaterThan(20)) { then("large") }
+    `when`(isLessThan(10)) then "small"
+    `when`(isGreaterThan(20)) then "large"
     `else`(cast { "medium" `as` "VARCHAR(6)" })
   } `as` "tshirt_size"
 ) {

--- a/src/test/kotlin/examples/kotlin/animal/data/KCaseExpressionTest.kt
+++ b/src/test/kotlin/examples/kotlin/animal/data/KCaseExpressionTest.kt
@@ -888,7 +888,7 @@ class KCaseExpressionTest {
     fun testInvalidDoubleElseSimple() {
         assertThatExceptionOfType(KInvalidSQLException::class.java).isThrownBy {
             case(animalName) {
-                `when`(isEqualTo("Artic fox"), isEqualTo("Red fox")) then "'yes'"
+                `when`(isEqualTo("Artic fox"), isEqualTo("Red fox")) then "yes"
                 `else`("Fred")
                 `else`("Wilma")
             }
@@ -901,9 +901,9 @@ class KCaseExpressionTest {
             case {
                 `when` {
                     id isEqualTo 22
-                    then("'yes'")
+                    this then "yes"
                 }
-                `else`("Fred")
+                this `else` "Fred"
                 `else`("Wilma")
             }
         }.withMessage(Messages.getString("ERROR.42"))
@@ -915,8 +915,8 @@ class KCaseExpressionTest {
             case {
                 `when` {
                     id isEqualTo 22
-                    then("'yes'")
-                    then("'no'")
+                    then("yes")
+                    then("no")
                 }
             }
         }.withMessage(Messages.getString("ERROR.41"))

--- a/src/test/kotlin/examples/kotlin/animal/data/KCaseExpressionTest.kt
+++ b/src/test/kotlin/examples/kotlin/animal/data/KCaseExpressionTest.kt
@@ -457,7 +457,7 @@ class KCaseExpressionTest {
             val selectStatement = select(
                 animalName,
                 case(animalName) {
-                    `when` (isEqualTo("Artic fox"), isEqualTo("Red fox")) { then("yes") }
+                    `when` (isEqualTo("Artic fox"), isEqualTo("Red fox")) then "yes"
                     `else`("no")
                 } `as` "IsAFox"
             ) {
@@ -511,7 +511,7 @@ class KCaseExpressionTest {
             val selectStatement = select(
                 animalName,
                 case(animalName) {
-                    `when` ("Artic fox", "Red fox") { then("yes") }
+                    `when` ("Artic fox", "Red fox") then "yes"
                     `else`("no")
                 } `as` "IsAFox"
             ) {
@@ -565,7 +565,7 @@ class KCaseExpressionTest {
             val selectStatement = select(
                 animalName,
                 case(animalName) {
-                    `when` (isEqualTo("Artic fox"), isEqualTo("Red fox")) { then(true) }
+                    `when` (isEqualTo("Artic fox"), isEqualTo("Red fox")) then true
                     `else`(false)
                 } `as` "IsAFox"
             ) {
@@ -619,7 +619,7 @@ class KCaseExpressionTest {
             val selectStatement = select(
                 animalName,
                 case(animalName) {
-                    `when` ("Artic fox", "Red fox") { then(true) }
+                    `when` ("Artic fox", "Red fox") then true
                     `else`(false)
                 } `as` "IsAFox"
             ) {
@@ -673,7 +673,7 @@ class KCaseExpressionTest {
             val selectStatement = select(
                 animalName,
                 case(animalName) {
-                    `when`(isEqualTo("Artic fox"), isEqualTo("Red fox")) { then("yes") }
+                    `when`(isEqualTo("Artic fox"), isEqualTo("Red fox")) then "yes"
                 } `as` "IsAFox"
             ) {
                 from(animalData)
@@ -720,7 +720,7 @@ class KCaseExpressionTest {
             val selectStatement = select(
                 animalName,
                 case(animalName) {
-                    `when`(isEqualTo("Artic fox"), isEqualTo("Red fox")) { then(cast { "It's a fox" `as` "VARCHAR(30)" })}
+                    `when`(isEqualTo("Artic fox"), isEqualTo("Red fox")) then cast { "It's a fox" `as` "VARCHAR(30)" }
                     `else`("It's not a fox")
                 } `as` "IsAFox"
             ) {
@@ -763,7 +763,7 @@ class KCaseExpressionTest {
             val selectStatement = select(
                 animalName,
                 case(animalName) {
-                    `when`(isEqualTo("Artic fox"), isEqualTo("Red fox")) { then( 1L) }
+                    `when`(isEqualTo("Artic fox"), isEqualTo("Red fox")) then 1L
                     `else`(2L)
                 } `as` "IsAFox"
             ) {
@@ -806,7 +806,7 @@ class KCaseExpressionTest {
             val selectStatement = select(
                 animalName,
                 case(animalName) {
-                    `when`(isEqualTo("Artic fox"), isEqualTo("Red fox")) { then( 1.1) }
+                    `when`(isEqualTo("Artic fox"), isEqualTo("Red fox")) then 1.1
                     `else`(2.2)
                 } `as` "IsAFox"
             ) {
@@ -849,7 +849,7 @@ class KCaseExpressionTest {
             val selectStatement = select(
                 animalName,
                 case(animalName) {
-                    `when`(isEqualTo("Artic fox"), isEqualTo("Red fox")) { then( 1.1) }
+                    `when`(isEqualTo("Artic fox"), isEqualTo("Red fox")) then  1.1
                     `else`(cast { 2.2 `as` "DOUBLE" })
                 } `as` "IsAFox"
             ) {
@@ -888,24 +888,11 @@ class KCaseExpressionTest {
     fun testInvalidDoubleElseSimple() {
         assertThatExceptionOfType(KInvalidSQLException::class.java).isThrownBy {
             case(animalName) {
-                `when`(isEqualTo("Artic fox"), isEqualTo("Red fox")) { then("'yes'") }
+                `when`(isEqualTo("Artic fox"), isEqualTo("Red fox")) then "'yes'"
                 `else`("Fred")
                 `else`("Wilma")
             }
         }.withMessage(Messages.getString("ERROR.42"))
-    }
-
-    @Test
-    fun testInvalidDoubleThenSimple() {
-        assertThatExceptionOfType(KInvalidSQLException::class.java).isThrownBy {
-            case(animalName) {
-                `when`(isEqualTo("Artic fox"), isEqualTo("Red fox")) {
-                    then("'yes'")
-                    then("no")
-                }
-                `else`("Fred")
-            }
-        }.withMessage(Messages.getString("ERROR.41"))
     }
 
     @Test


### PR DESCRIPTION
This PR changes the "else" and "then" functions to infix. In addition, we simplify "then" functions in the simple CASE expression.

Previously...

```kotlin
select(case(id) {
    `when`(1, 2, 3) { then(true) }
    `else`(false)
  } `as` "small_id"
) {
    from(foo)
}
```

Now...

```kotlin
select(case(id) {
    `when`(1, 2, 3) then true
    `else`(false)
  } `as` "small_id"
) {
    from(foo)
}
```
