### PR TITLE
Fix Jacoco Build Error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,6 +207,15 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>org/jetbrains/kotlin/**/*</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
         <configuration>

--- a/src/test/java/examples/generated/always/mybatis/GeneratedAlwaysMapper.java
+++ b/src/test/java/examples/generated/always/mybatis/GeneratedAlwaysMapper.java
@@ -80,8 +80,8 @@ public interface GeneratedAlwaysMapper extends CommonUpdateMapper {
         return selectOne(c -> c.where(id, isEqualTo(_id)));
     }
 
-    default int insert(GeneratedAlwaysRecord record) {
-        return MyBatis3Utils.insert(this::insert, record, generatedAlways, c ->
+    default int insert(GeneratedAlwaysRecord row) {
+        return MyBatis3Utils.insert(this::insert, row, generatedAlways, c ->
             c.map(id).toProperty("id")
                     .map(firstName).toProperty("firstName")
                     .map(lastName).toProperty("lastName")


### PR DESCRIPTION
Jacoco is throwing errors on an internal Kotlin class. We can just exclude it.