### PR TITLE
Throw InvalidSqlException during rendering if an In condition is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ Other important changes:
 - The library now requires Java 17
 - Deprecated code from prior releases is removed
 - We now allow CASE expressions in ORDER BY Clauses
+- The "In" conditions will now throw `InvalidSqlException` during rendering if the list of values is empty. Previously
+  an empty In condition would render as invalid SQL and would usually cause a runtime exception from the database.
+  With this change, the exception thrown is more predictable and the error is caught before sending the SQL to the
+  database.
 
 ## Release 1.5.2 - June 3, 2024
 

--- a/src/main/java/org/mybatis/dynamic/sql/exception/DuplicateTableAliasException.java
+++ b/src/main/java/org/mybatis/dynamic/sql/exception/DuplicateTableAliasException.java
@@ -15,6 +15,7 @@
  */
 package org.mybatis.dynamic.sql.exception;
 
+import java.io.Serial;
 import java.util.Objects;
 
 import org.mybatis.dynamic.sql.SqlTable;
@@ -34,6 +35,7 @@ import org.mybatis.dynamic.sql.util.Messages;
  */
 public class DuplicateTableAliasException extends DynamicSqlException {
 
+    @Serial
     private static final long serialVersionUID = -2631664872557787391L;
 
     public DuplicateTableAliasException(SqlTable table, String newAlias, String existingAlias) {

--- a/src/main/java/org/mybatis/dynamic/sql/exception/DynamicSqlException.java
+++ b/src/main/java/org/mybatis/dynamic/sql/exception/DynamicSqlException.java
@@ -15,7 +15,10 @@
  */
 package org.mybatis.dynamic.sql.exception;
 
+import java.io.Serial;
+
 public class DynamicSqlException extends RuntimeException {
+    @Serial
     private static final long serialVersionUID = 349021672061361244L;
 
     public DynamicSqlException(String message) {

--- a/src/main/java/org/mybatis/dynamic/sql/exception/InvalidSqlException.java
+++ b/src/main/java/org/mybatis/dynamic/sql/exception/InvalidSqlException.java
@@ -15,7 +15,10 @@
  */
 package org.mybatis.dynamic.sql.exception;
 
+import java.io.Serial;
+
 public class InvalidSqlException extends DynamicSqlException {
+    @Serial
     private static final long serialVersionUID = 1666851020951347843L;
 
     public InvalidSqlException(String message) {

--- a/src/main/java/org/mybatis/dynamic/sql/exception/NonRenderingWhereClauseException.java
+++ b/src/main/java/org/mybatis/dynamic/sql/exception/NonRenderingWhereClauseException.java
@@ -19,6 +19,8 @@ import org.mybatis.dynamic.sql.configuration.GlobalConfiguration;
 import org.mybatis.dynamic.sql.configuration.StatementConfiguration;
 import org.mybatis.dynamic.sql.util.Messages;
 
+import java.io.Serial;
+
 /**
  * This exception is thrown when the where clause in a statement will not render.
  * This can happen if all the optional conditions in a where clause fail to
@@ -40,6 +42,7 @@ import org.mybatis.dynamic.sql.util.Messages;
  * @author Jeff Butler
  */
 public class NonRenderingWhereClauseException extends DynamicSqlException {
+    @Serial
     private static final long serialVersionUID = 6619119078542625135L;
 
     public NonRenderingWhereClauseException() {

--- a/src/main/java/org/mybatis/dynamic/sql/util/Validator.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/Validator.java
@@ -26,12 +26,20 @@ public class Validator {
         assertFalse(collection.isEmpty(), messageNumber);
     }
 
+    public static void assertNotEmpty(Collection<?> collection, String messageNumber, String p1) {
+        assertFalse(collection.isEmpty(), messageNumber, p1);
+    }
+
     public static void assertFalse(boolean condition, String messageNumber) {
-        internalAssertFalse(condition, Messages.getString(messageNumber));
+        if (condition) {
+            throw new InvalidSqlException(Messages.getString(messageNumber));
+        }
     }
 
     public static void assertFalse(boolean condition, String messageNumber, String p1) {
-        internalAssertFalse(condition, Messages.getString(messageNumber, p1));
+        if (condition) {
+            throw new InvalidSqlException(Messages.getString(messageNumber, p1));
+        }
     }
 
     public static void assertTrue(boolean condition, String messageNumber) {
@@ -40,11 +48,5 @@ public class Validator {
 
     public static void assertTrue(boolean condition, String messageNumber, String p1) {
         assertFalse(!condition, messageNumber, p1);
-    }
-
-    private static void internalAssertFalse(boolean condition, String message) {
-        if (condition) {
-            throw new InvalidSqlException(message);
-        }
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsIn.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsIn.java
@@ -23,6 +23,7 @@ import java.util.function.Predicate;
 
 import org.mybatis.dynamic.sql.AbstractListValueCondition;
 import org.mybatis.dynamic.sql.render.RenderingContext;
+import org.mybatis.dynamic.sql.util.Validator;
 
 public class IsIn<T> extends AbstractListValueCondition<T> {
     private static final IsIn<?> EMPTY = new IsIn<>(Collections.emptyList());
@@ -39,6 +40,7 @@ public class IsIn<T> extends AbstractListValueCondition<T> {
 
     @Override
     public boolean shouldRender(RenderingContext renderingContext) {
+        Validator.assertNotEmpty(values, "ERROR.44", "IsIn"); //$NON-NLS-1$ //$NON-NLS-2$
         return true;
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInCaseInsensitive.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInCaseInsensitive.java
@@ -24,6 +24,7 @@ import java.util.function.UnaryOperator;
 import org.mybatis.dynamic.sql.AbstractListValueCondition;
 import org.mybatis.dynamic.sql.render.RenderingContext;
 import org.mybatis.dynamic.sql.util.StringUtilities;
+import org.mybatis.dynamic.sql.util.Validator;
 
 public class IsInCaseInsensitive extends AbstractListValueCondition<String>
         implements CaseInsensitiveVisitableCondition {
@@ -39,6 +40,7 @@ public class IsInCaseInsensitive extends AbstractListValueCondition<String>
 
     @Override
     public boolean shouldRender(RenderingContext renderingContext) {
+        Validator.assertNotEmpty(values, "ERROR.44", "IsInCaseInsensitive"); //$NON-NLS-1$ //$NON-NLS-2$
         return true;
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotIn.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotIn.java
@@ -23,6 +23,7 @@ import java.util.function.Predicate;
 
 import org.mybatis.dynamic.sql.AbstractListValueCondition;
 import org.mybatis.dynamic.sql.render.RenderingContext;
+import org.mybatis.dynamic.sql.util.Validator;
 
 public class IsNotIn<T> extends AbstractListValueCondition<T> {
     private static final IsNotIn<?> EMPTY = new IsNotIn<>(Collections.emptyList());
@@ -39,6 +40,7 @@ public class IsNotIn<T> extends AbstractListValueCondition<T> {
 
     @Override
     public boolean shouldRender(RenderingContext renderingContext) {
+        Validator.assertNotEmpty(values, "ERROR.44", "IsNotIn"); //$NON-NLS-1$ //$NON-NLS-2$
         return true;
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInCaseInsensitive.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInCaseInsensitive.java
@@ -24,6 +24,7 @@ import java.util.function.UnaryOperator;
 import org.mybatis.dynamic.sql.AbstractListValueCondition;
 import org.mybatis.dynamic.sql.render.RenderingContext;
 import org.mybatis.dynamic.sql.util.StringUtilities;
+import org.mybatis.dynamic.sql.util.Validator;
 
 public class IsNotInCaseInsensitive extends AbstractListValueCondition<String>
         implements CaseInsensitiveVisitableCondition {
@@ -39,6 +40,7 @@ public class IsNotInCaseInsensitive extends AbstractListValueCondition<String>
 
     @Override
     public boolean shouldRender(RenderingContext renderingContext) {
+        Validator.assertNotEmpty(values, "ERROR.44", "IsNotInCaseInsensitive"); //$NON-NLS-1$ //$NON-NLS-2$
         return true;
     }
 

--- a/src/main/resources/org/mybatis/dynamic/sql/util/messages.properties
+++ b/src/main/resources/org/mybatis/dynamic/sql/util/messages.properties
@@ -60,4 +60,5 @@ ERROR.40=Case expressions must have at least one "when" clause
 ERROR.41=You cannot call "then" in a Kotlin case expression more than once
 ERROR.42=You cannot call `else` in a Kotlin case expression more than once
 ERROR.43=A Kotlin cast expression must have one, and only one, `as` element
+ERROR.44={0} conditions must contain at least one value
 INTERNAL.ERROR=Internal Error {0}

--- a/src/site/markdown/docs/conditions.md
+++ b/src/site/markdown/docs/conditions.md
@@ -204,20 +204,14 @@ mapping if you so desire.
 
 Starting with version 1.5.2, we made a change to the rendering rules for the "in" conditions. This was done to limit the
 danger of conditions failing to render and thus affecting more rows than expected. For the base conditions ("isIn",
-"isNotIn", etc.), if the list of values is empty, then the condition will still render, but the resulting SQL will
-be invalid and will cause a runtime exception. We believe this is the safest outcome. For example, suppose
+"isNotIn", etc.), if the list of values is empty, then the library will throw
+`org.mybatis.dynamic.sql.exception.InvalidSqlException`. We believe this is the safest outcome. For example, suppose
 a DELETE statement was coded as follows:
 
 ```java
    delete.from(foo)
      .where(status, isTrue())
      .and(id, isIn(Collections.emptyList()));
-```
-
-This statement will be rendered as follows:
-
-```sql
-   delete from foo where status = ? and id in ()
 ```
 
 This will cause a runtime error due to invalid SQL, but it eliminates the possibility of deleting ALL rows with
@@ -229,8 +223,8 @@ and the case-insensitive versions of these conditions:
 
 | Input                                    | Effect                                                                            |
 |------------------------------------------|-----------------------------------------------------------------------------------|
-| isIn(null)                               | NullPointerException                                                              |
-| isIn(Collections.emptyList())            | Rendered as "in ()" (Invalid SQL)                                                 |
+| isIn(null)                               | NullPointerException thrown                                                       |
+| isIn(Collections.emptyList())            | InvalidSqlException thrown                                                        |
 | isIn(2, 3, null)                         | Rendered as "in (?, ?, ?)" (Parameter values are 2, 3, and null)                  |
 | isInWhenPresent(null)                    | Condition Not Rendered                                                            |
 | isInWhenPresent(Collections.emptyList()) | Condition Not Rendered                                                            |

--- a/src/test/java/org/mybatis/dynamic/sql/select/SelectStatementTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/select/SelectStatementTest.java
@@ -21,7 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mybatis.dynamic.sql.SqlBuilder.*;
 
 import java.sql.JDBCType;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -284,18 +283,6 @@ class SelectStatementTest {
     }
 
     @Test
-    void testInEmptyList() {
-        List<String> emptyList = Collections.emptyList();
-        SelectStatementProvider selectStatement = select(column1, column3)
-                .from(table, "a")
-                .where(column3, isIn(emptyList))
-                .build()
-                .render(RenderingStrategies.MYBATIS3);
-
-        assertThat(selectStatement.getSelectStatement()).isEqualTo("select a.column1, a.column3 from foo a where a.column3 in ()");
-    }
-
-    @Test
     void testNotInEmptyList() {
         List<String> emptyList = Collections.emptyList();
         SelectModel selectModel = select(column1, column3)
@@ -356,17 +343,6 @@ class SelectStatementTest {
         assertThatExceptionOfType(NonRenderingWhereClauseException.class).isThrownBy(() ->
                 selectModel.render(RenderingStrategies.MYBATIS3)
         );
-    }
-
-    @Test
-    void testNotInCaseInsensitiveEmptyList() {
-        SelectStatementProvider selectStatement = select(column1, column3)
-                .from(table, "a")
-                .where(column3, isNotInCaseInsensitive(Collections.emptyList()))
-                .build()
-                .render(RenderingStrategies.MYBATIS3);
-
-        assertThat(selectStatement.getSelectStatement()).isEqualTo("select a.column1, a.column3 from foo a where upper(a.column3) not in ()");
     }
 
     @Test

--- a/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonMapperTest.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonMapperTest.kt
@@ -913,18 +913,6 @@ class PersonMapperTest {
     }
 
     @Test
-    fun testRenderingEmptyList() {
-        val selectStatement = select(id, firstName, lastName, birthDate, employed, occupation, addressId) {
-            from(person)
-            where { id isIn emptyList() }
-        }
-
-        val expected = "select id, first_name, last_name, birth_date, employed, occupation, address_id from Person " +
-                "where id in ()"
-        assertThat(selectStatement.selectStatement).isEqualTo(expected)
-    }
-
-    @Test
     fun testSumWithCase() {
         sqlSessionFactory.openSession().use { session ->
             val mapper = session.getMapper(CommonSelectMapper::class.java)


### PR DESCRIPTION
This changes the prior behavior where the condition would render as invalid SQL and a runtime exception from the database was expected.
