### PR TITLE
Add "WhenPresent" Versions of the Paging Methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ Other important changes:
   an empty In condition would render as invalid SQL and would usually cause a runtime exception from the database.
   With this change, the exception thrown is more predictable and the error is caught before sending the SQL to the
   database.
+- All the paging methods (limit, offset, fetchFirst) now have "WhenPresent" variations that will drop the phrase from
+  rendering if a null value is passed in 
 
 ## Release 1.5.2 - June 3, 2024
 

--- a/src/main/java/org/mybatis/dynamic/sql/delete/DeleteDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/delete/DeleteDSL.java
@@ -56,6 +56,10 @@ public class DeleteDSL<R> extends AbstractWhereStarter<DeleteDSL<R>.DeleteWhereB
     }
 
     public DeleteDSL<R> limit(long limit) {
+        return limitWhenPresent(limit);
+    }
+
+    public DeleteDSL<R> limitWhenPresent(Long limit) {
         this.limit = limit;
         return this;
     }
@@ -115,7 +119,11 @@ public class DeleteDSL<R> extends AbstractWhereStarter<DeleteDSL<R>.DeleteWhereB
         }
 
         public DeleteDSL<R> limit(long limit) {
-            return DeleteDSL.this.limit(limit);
+            return limitWhenPresent(limit);
+        }
+
+        public DeleteDSL<R> limitWhenPresent(Long limit) {
+            return DeleteDSL.this.limitWhenPresent(limit);
         }
 
         public DeleteDSL<R> orderBy(SortSpecification... columns) {

--- a/src/main/java/org/mybatis/dynamic/sql/exception/NonRenderingWhereClauseException.java
+++ b/src/main/java/org/mybatis/dynamic/sql/exception/NonRenderingWhereClauseException.java
@@ -15,11 +15,11 @@
  */
 package org.mybatis.dynamic.sql.exception;
 
+import java.io.Serial;
+
 import org.mybatis.dynamic.sql.configuration.GlobalConfiguration;
 import org.mybatis.dynamic.sql.configuration.StatementConfiguration;
 import org.mybatis.dynamic.sql.util.Messages;
-
-import java.io.Serial;
 
 /**
  * This exception is thrown when the where clause in a statement will not render.

--- a/src/main/java/org/mybatis/dynamic/sql/select/MultiSelectDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/MultiSelectDSL.java
@@ -62,16 +62,28 @@ public class MultiSelectDSL implements Buildable<MultiSelectModel>, Configurable
     }
 
     public LimitFinisher limit(long limit) {
+        return limitWhenPresent(limit);
+    }
+
+    public LimitFinisher limitWhenPresent(Long limit) {
         this.limit = limit;
         return new LimitFinisher();
     }
 
     public OffsetFirstFinisher offset(long offset) {
+        return offsetWhenPresent(offset);
+    }
+
+    public OffsetFirstFinisher offsetWhenPresent(Long offset) {
         this.offset = offset;
         return new OffsetFirstFinisher();
     }
 
     public FetchFirstFinisher fetchFirst(long fetchFirstRows) {
+        return fetchFirstWhenPresent(fetchFirstRows);
+    }
+
+    public FetchFirstFinisher fetchFirstWhenPresent(Long fetchFirstRows) {
         this.fetchFirstRows = fetchFirstRows;
         return new FetchFirstFinisher();
     }
@@ -104,7 +116,11 @@ public class MultiSelectDSL implements Buildable<MultiSelectModel>, Configurable
 
     public class LimitFinisher implements Buildable<MultiSelectModel> {
         public OffsetFinisher offset(long offset) {
-            MultiSelectDSL.this.offset(offset);
+            return offsetWhenPresent(offset);
+        }
+
+        public OffsetFinisher offsetWhenPresent(Long offset) {
+            MultiSelectDSL.this.offsetWhenPresent(offset);
             return new OffsetFinisher();
         }
 
@@ -125,8 +141,11 @@ public class MultiSelectDSL implements Buildable<MultiSelectModel>, Configurable
 
     public class OffsetFirstFinisher implements Buildable<MultiSelectModel> {
         public FetchFirstFinisher fetchFirst(long fetchFirstRows) {
-            MultiSelectDSL.this.fetchFirst(fetchFirstRows);
-            return new FetchFirstFinisher();
+            return fetchFirstWhenPresent(fetchFirstRows);
+        }
+
+        public FetchFirstFinisher fetchFirstWhenPresent(Long fetchFirstRows) {
+            return MultiSelectDSL.this.fetchFirstWhenPresent(fetchFirstRows);
         }
 
         @NotNull

--- a/src/main/java/org/mybatis/dynamic/sql/select/MultiSelectDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/MultiSelectDSL.java
@@ -29,7 +29,8 @@ import org.mybatis.dynamic.sql.configuration.StatementConfiguration;
 import org.mybatis.dynamic.sql.util.Buildable;
 import org.mybatis.dynamic.sql.util.ConfigurableStatement;
 
-public class MultiSelectDSL implements Buildable<MultiSelectModel>, ConfigurableStatement<MultiSelectDSL> {
+public class MultiSelectDSL implements Buildable<MultiSelectModel>, ConfigurableStatement<MultiSelectDSL>,
+        PagingDSL<MultiSelectModel> {
     private final List<UnionQuery> unionQueries = new ArrayList<>();
     private final SelectModel initialSelect;
     private OrderByModel orderByModel;
@@ -61,31 +62,22 @@ public class MultiSelectDSL implements Buildable<MultiSelectModel>, Configurable
         return this;
     }
 
-    public LimitFinisher limit(long limit) {
-        return limitWhenPresent(limit);
-    }
-
-    public LimitFinisher limitWhenPresent(Long limit) {
+    @Override
+    public LimitFinisher<MultiSelectModel> limitWhenPresent(Long limit) {
         this.limit = limit;
-        return new LimitFinisher();
+        return new LF();
     }
 
-    public OffsetFirstFinisher offset(long offset) {
-        return offsetWhenPresent(offset);
-    }
-
-    public OffsetFirstFinisher offsetWhenPresent(Long offset) {
+    @Override
+    public OffsetFirstFinisher<MultiSelectModel> offsetWhenPresent(Long offset) {
         this.offset = offset;
-        return new OffsetFirstFinisher();
+        return new OFF();
     }
 
-    public FetchFirstFinisher fetchFirst(long fetchFirstRows) {
-        return fetchFirstWhenPresent(fetchFirstRows);
-    }
-
-    public FetchFirstFinisher fetchFirstWhenPresent(Long fetchFirstRows) {
+    @Override
+    public FetchFirstFinisher<MultiSelectModel> fetchFirstWhenPresent(Long fetchFirstRows) {
         this.fetchFirstRows = fetchFirstRows;
-        return new FetchFirstFinisher();
+        return new FFF();
     }
 
     @NotNull
@@ -114,14 +106,18 @@ public class MultiSelectDSL implements Buildable<MultiSelectModel>, Configurable
         return this;
     }
 
-    public class LimitFinisher implements Buildable<MultiSelectModel> {
-        public OffsetFinisher offset(long offset) {
-            return offsetWhenPresent(offset);
+    class FFF implements FetchFirstFinisher<MultiSelectModel> {
+        @Override
+        public Buildable<MultiSelectModel> rowsOnly() {
+            return MultiSelectDSL.this;
         }
+    }
 
-        public OffsetFinisher offsetWhenPresent(Long offset) {
-            MultiSelectDSL.this.offsetWhenPresent(offset);
-            return new OffsetFinisher();
+    class LF implements LimitFinisher<MultiSelectModel> {
+        @Override
+        public Buildable<MultiSelectModel> offsetWhenPresent(Long offset) {
+            MultiSelectDSL.this.offset = offset;
+            return MultiSelectDSL.this;
         }
 
         @NotNull
@@ -131,37 +127,13 @@ public class MultiSelectDSL implements Buildable<MultiSelectModel>, Configurable
         }
     }
 
-    public class OffsetFinisher implements Buildable<MultiSelectModel> {
-        @NotNull
+    class OFF implements OffsetFirstFinisher<MultiSelectModel> {
         @Override
-        public MultiSelectModel build() {
-            return MultiSelectDSL.this.build();
-        }
-    }
-
-    public class OffsetFirstFinisher implements Buildable<MultiSelectModel> {
-        public FetchFirstFinisher fetchFirst(long fetchFirstRows) {
-            return fetchFirstWhenPresent(fetchFirstRows);
+        public FetchFirstFinisher<MultiSelectModel> fetchFirstWhenPresent(Long fetchFirstRows) {
+            MultiSelectDSL.this.fetchFirstRows = fetchFirstRows;
+            return new FFF();
         }
 
-        public FetchFirstFinisher fetchFirstWhenPresent(Long fetchFirstRows) {
-            return MultiSelectDSL.this.fetchFirstWhenPresent(fetchFirstRows);
-        }
-
-        @NotNull
-        @Override
-        public MultiSelectModel build() {
-            return MultiSelectDSL.this.build();
-        }
-    }
-
-    public class FetchFirstFinisher {
-        public RowsOnlyFinisher rowsOnly() {
-            return new RowsOnlyFinisher();
-        }
-    }
-
-    public class RowsOnlyFinisher implements Buildable<MultiSelectModel> {
         @NotNull
         @Override
         public MultiSelectModel build() {

--- a/src/main/java/org/mybatis/dynamic/sql/select/PagingDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/PagingDSL.java
@@ -1,0 +1,58 @@
+/*
+ *    Copyright 2016-2024 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.dynamic.sql.select;
+
+import org.mybatis.dynamic.sql.util.Buildable;
+
+public interface PagingDSL<T> {
+    default LimitFinisher<T> limit(long limit) {
+        return limitWhenPresent(limit);
+    }
+
+    LimitFinisher<T> limitWhenPresent(Long limit);
+
+    default OffsetFirstFinisher<T> offset(long offset) {
+        return offsetWhenPresent(offset);
+    }
+
+    OffsetFirstFinisher<T> offsetWhenPresent(Long offset);
+
+    default FetchFirstFinisher<T> fetchFirst(long fetchFirstRows) {
+        return fetchFirstWhenPresent(fetchFirstRows);
+    }
+
+    FetchFirstFinisher<T> fetchFirstWhenPresent(Long fetchFirstRows);
+
+    interface LimitFinisher<T> extends Buildable<T> {
+        default Buildable<T> offset(long offset) {
+            return offsetWhenPresent(offset);
+        }
+
+        Buildable<T> offsetWhenPresent(Long offset);
+    }
+
+    interface OffsetFirstFinisher<T> extends Buildable<T> {
+        default FetchFirstFinisher<T> fetchFirst(long fetchFirstRows) {
+            return fetchFirstWhenPresent(fetchFirstRows);
+        }
+
+        FetchFirstFinisher<T> fetchFirstWhenPresent(Long fetchFirstRows);
+    }
+
+    interface FetchFirstFinisher<T> {
+        Buildable<T> rowsOnly();
+    }
+}

--- a/src/main/java/org/mybatis/dynamic/sql/select/QueryExpressionDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/QueryExpressionDSL.java
@@ -195,15 +195,27 @@ public class QueryExpressionDSL<R>
     }
 
     public SelectDSL<R>.LimitFinisher limit(long limit) {
-        return selectDSL.limit(limit);
+        return limitWhenPresent(limit);
+    }
+
+    public SelectDSL<R>.LimitFinisher limitWhenPresent(Long limit) {
+        return selectDSL.limitWhenPresent(limit);
     }
 
     public SelectDSL<R>.OffsetFirstFinisher offset(long offset) {
-        return selectDSL.offset(offset);
+        return offsetWhenPresent(offset);
+    }
+
+    public SelectDSL<R>.OffsetFirstFinisher offsetWhenPresent(Long offset) {
+        return selectDSL.offsetWhenPresent(offset);
     }
 
     public SelectDSL<R>.FetchFirstFinisher fetchFirst(long fetchFirstRows) {
-        return selectDSL.fetchFirst(fetchFirstRows);
+        return fetchFirstWhenPresent(fetchFirstRows);
+    }
+
+    public SelectDSL<R>.FetchFirstFinisher fetchFirstWhenPresent(Long fetchFirstRows) {
+        return selectDSL.fetchFirstWhenPresent(fetchFirstRows);
     }
 
     @Override
@@ -303,15 +315,27 @@ public class QueryExpressionDSL<R>
         }
 
         public SelectDSL<R>.LimitFinisher limit(long limit) {
-            return QueryExpressionDSL.this.limit(limit);
+            return limitWhenPresent(limit);
+        }
+
+        public SelectDSL<R>.LimitFinisher limitWhenPresent(Long limit) {
+            return QueryExpressionDSL.this.limitWhenPresent(limit);
         }
 
         public SelectDSL<R>.OffsetFirstFinisher offset(long offset) {
-            return QueryExpressionDSL.this.offset(offset);
+            return offsetWhenPresent(offset);
+        }
+
+        public SelectDSL<R>.OffsetFirstFinisher offsetWhenPresent(Long offset) {
+            return QueryExpressionDSL.this.offsetWhenPresent(offset);
         }
 
         public SelectDSL<R>.FetchFirstFinisher fetchFirst(long fetchFirstRows) {
-            return QueryExpressionDSL.this.fetchFirst(fetchFirstRows);
+            return fetchFirstWhenPresent(fetchFirstRows);
+        }
+
+        public SelectDSL<R>.FetchFirstFinisher fetchFirstWhenPresent(Long fetchFirstRows) {
+            return QueryExpressionDSL.this.fetchFirstWhenPresent(fetchFirstRows);
         }
 
         @NotNull
@@ -485,15 +509,27 @@ public class QueryExpressionDSL<R>
         }
 
         public SelectDSL<R>.LimitFinisher limit(long limit) {
-            return QueryExpressionDSL.this.limit(limit);
+            return limitWhenPresent(limit);
+        }
+
+        public SelectDSL<R>.LimitFinisher limitWhenPresent(Long limit) {
+            return QueryExpressionDSL.this.limitWhenPresent(limit);
         }
 
         public SelectDSL<R>.OffsetFirstFinisher offset(long offset) {
-            return QueryExpressionDSL.this.offset(offset);
+            return offsetWhenPresent(offset);
+        }
+
+        public SelectDSL<R>.OffsetFirstFinisher offsetWhenPresent(Long offset) {
+            return QueryExpressionDSL.this.offsetWhenPresent(offset);
         }
 
         public SelectDSL<R>.FetchFirstFinisher fetchFirst(long fetchFirstRows) {
-            return QueryExpressionDSL.this.fetchFirst(fetchFirstRows);
+            return fetchFirstWhenPresent(fetchFirstRows);
+        }
+
+        public SelectDSL<R>.FetchFirstFinisher fetchFirstWhenPresent(Long fetchFirstRows) {
+            return QueryExpressionDSL.this.fetchFirstWhenPresent(fetchFirstRows);
         }
     }
 
@@ -521,15 +557,27 @@ public class QueryExpressionDSL<R>
         }
 
         public SelectDSL<R>.LimitFinisher limit(long limit) {
-            return QueryExpressionDSL.this.limit(limit);
+            return limitWhenPresent(limit);
+        }
+
+        public SelectDSL<R>.LimitFinisher limitWhenPresent(Long limit) {
+            return QueryExpressionDSL.this.limitWhenPresent(limit);
         }
 
         public SelectDSL<R>.OffsetFirstFinisher offset(long offset) {
-            return QueryExpressionDSL.this.offset(offset);
+            return offsetWhenPresent(offset);
+        }
+
+        public SelectDSL<R>.OffsetFirstFinisher offsetWhenPresent(Long offset) {
+            return QueryExpressionDSL.this.offsetWhenPresent(offset);
         }
 
         public SelectDSL<R>.FetchFirstFinisher fetchFirst(long fetchFirstRows) {
-            return QueryExpressionDSL.this.fetchFirst(fetchFirstRows);
+            return fetchFirstWhenPresent(fetchFirstRows);
+        }
+
+        public SelectDSL<R>.FetchFirstFinisher fetchFirstWhenPresent(Long fetchFirstRows) {
+            return QueryExpressionDSL.this.fetchFirstWhenPresent(fetchFirstRows);
         }
 
         @Override
@@ -575,15 +623,27 @@ public class QueryExpressionDSL<R>
             implements Buildable<R> {
 
         public SelectDSL<R>.FetchFirstFinisher fetchFirst(long fetchFirstRows) {
-            return QueryExpressionDSL.this.fetchFirst(fetchFirstRows);
+            return fetchFirstWhenPresent(fetchFirstRows);
+        }
+
+        public SelectDSL<R>.FetchFirstFinisher fetchFirstWhenPresent(Long fetchFirstRows) {
+            return QueryExpressionDSL.this.fetchFirstWhenPresent(fetchFirstRows);
         }
 
         public SelectDSL<R>.OffsetFirstFinisher offset(long offset) {
-            return QueryExpressionDSL.this.offset(offset);
+            return offsetWhenPresent(offset);
+        }
+
+        public SelectDSL<R>.OffsetFirstFinisher offsetWhenPresent(Long offset) {
+            return QueryExpressionDSL.this.offsetWhenPresent(offset);
         }
 
         public SelectDSL<R>.LimitFinisher limit(long limit) {
-            return QueryExpressionDSL.this.limit(limit);
+            return limitWhenPresent(limit);
+        }
+
+        public SelectDSL<R>.LimitFinisher limitWhenPresent(Long limit) {
+            return QueryExpressionDSL.this.limitWhenPresent(limit);
         }
 
         public SelectDSL<R> orderBy(SortSpecification... columns) {

--- a/src/main/java/org/mybatis/dynamic/sql/select/QueryExpressionDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/QueryExpressionDSL.java
@@ -42,7 +42,7 @@ import org.mybatis.dynamic.sql.where.EmbeddedWhereModel;
 
 public class QueryExpressionDSL<R>
         extends AbstractQueryExpressionDSL<QueryExpressionDSL<R>.QueryExpressionWhereBuilder, QueryExpressionDSL<R>>
-        implements Buildable<R> {
+        implements Buildable<R>, PagingDSL<R> {
 
     private final String connector;
     private final SelectDSL<R> selectDSL;
@@ -194,27 +194,18 @@ public class QueryExpressionDSL<R>
                 .build();
     }
 
-    public SelectDSL<R>.LimitFinisher limit(long limit) {
-        return limitWhenPresent(limit);
-    }
-
-    public SelectDSL<R>.LimitFinisher limitWhenPresent(Long limit) {
+    @Override
+    public PagingDSL.LimitFinisher<R> limitWhenPresent(Long limit) {
         return selectDSL.limitWhenPresent(limit);
     }
 
-    public SelectDSL<R>.OffsetFirstFinisher offset(long offset) {
-        return offsetWhenPresent(offset);
-    }
-
-    public SelectDSL<R>.OffsetFirstFinisher offsetWhenPresent(Long offset) {
+    @Override
+    public PagingDSL.OffsetFirstFinisher<R> offsetWhenPresent(Long offset) {
         return selectDSL.offsetWhenPresent(offset);
     }
 
-    public SelectDSL<R>.FetchFirstFinisher fetchFirst(long fetchFirstRows) {
-        return fetchFirstWhenPresent(fetchFirstRows);
-    }
-
-    public SelectDSL<R>.FetchFirstFinisher fetchFirstWhenPresent(Long fetchFirstRows) {
+    @Override
+    public PagingDSL.FetchFirstFinisher<R> fetchFirstWhenPresent(Long fetchFirstRows) {
         return selectDSL.fetchFirstWhenPresent(fetchFirstRows);
     }
 
@@ -285,7 +276,7 @@ public class QueryExpressionDSL<R>
     }
 
     public class QueryExpressionWhereBuilder extends AbstractWhereFinisher<QueryExpressionWhereBuilder>
-            implements Buildable<R> {
+            implements Buildable<R>, PagingDSL<R> {
         private QueryExpressionWhereBuilder() {
             super(QueryExpressionDSL.this);
         }
@@ -314,27 +305,18 @@ public class QueryExpressionDSL<R>
             return QueryExpressionDSL.this.groupBy(columns);
         }
 
-        public SelectDSL<R>.LimitFinisher limit(long limit) {
-            return limitWhenPresent(limit);
-        }
-
-        public SelectDSL<R>.LimitFinisher limitWhenPresent(Long limit) {
+        @Override
+        public PagingDSL.LimitFinisher<R> limitWhenPresent(Long limit) {
             return QueryExpressionDSL.this.limitWhenPresent(limit);
         }
 
-        public SelectDSL<R>.OffsetFirstFinisher offset(long offset) {
-            return offsetWhenPresent(offset);
-        }
-
-        public SelectDSL<R>.OffsetFirstFinisher offsetWhenPresent(Long offset) {
+        @Override
+        public PagingDSL.OffsetFirstFinisher<R> offsetWhenPresent(Long offset) {
             return QueryExpressionDSL.this.offsetWhenPresent(offset);
         }
 
-        public SelectDSL<R>.FetchFirstFinisher fetchFirst(long fetchFirstRows) {
-            return fetchFirstWhenPresent(fetchFirstRows);
-        }
-
-        public SelectDSL<R>.FetchFirstFinisher fetchFirstWhenPresent(Long fetchFirstRows) {
+        @Override
+        public PagingDSL.FetchFirstFinisher<R> fetchFirstWhenPresent(Long fetchFirstRows) {
             return QueryExpressionDSL.this.fetchFirstWhenPresent(fetchFirstRows);
         }
 
@@ -375,7 +357,7 @@ public class QueryExpressionDSL<R>
 
     public class JoinSpecificationFinisher
             extends AbstractWhereStarter<QueryExpressionWhereBuilder, JoinSpecificationFinisher>
-            implements Buildable<R> {
+            implements Buildable<R>, PagingDSL<R> {
         private final JoinSpecification.Builder joinSpecificationBuilder;
 
         public <T> JoinSpecificationFinisher(TableExpression table, BindableColumn<T> joinColumn,
@@ -508,32 +490,24 @@ public class QueryExpressionDSL<R>
             return QueryExpressionDSL.this.orderBy(columns);
         }
 
-        public SelectDSL<R>.LimitFinisher limit(long limit) {
-            return limitWhenPresent(limit);
-        }
-
-        public SelectDSL<R>.LimitFinisher limitWhenPresent(Long limit) {
+        @Override
+        public PagingDSL.LimitFinisher<R> limitWhenPresent(Long limit) {
             return QueryExpressionDSL.this.limitWhenPresent(limit);
         }
 
-        public SelectDSL<R>.OffsetFirstFinisher offset(long offset) {
-            return offsetWhenPresent(offset);
-        }
-
-        public SelectDSL<R>.OffsetFirstFinisher offsetWhenPresent(Long offset) {
+        @Override
+        public PagingDSL.OffsetFirstFinisher<R> offsetWhenPresent(Long offset) {
             return QueryExpressionDSL.this.offsetWhenPresent(offset);
         }
 
-        public SelectDSL<R>.FetchFirstFinisher fetchFirst(long fetchFirstRows) {
-            return fetchFirstWhenPresent(fetchFirstRows);
-        }
-
-        public SelectDSL<R>.FetchFirstFinisher fetchFirstWhenPresent(Long fetchFirstRows) {
+        @Override
+        public PagingDSL.FetchFirstFinisher<R> fetchFirstWhenPresent(Long fetchFirstRows) {
             return QueryExpressionDSL.this.fetchFirstWhenPresent(fetchFirstRows);
         }
     }
 
-    public class GroupByFinisher extends AbstractHavingStarter<QueryExpressionHavingBuilder> implements Buildable<R> {
+    public class GroupByFinisher extends AbstractHavingStarter<QueryExpressionHavingBuilder>
+            implements Buildable<R>, PagingDSL<R> {
         public SelectDSL<R> orderBy(SortSpecification... columns) {
             return orderBy(Arrays.asList(columns));
         }
@@ -556,27 +530,18 @@ public class QueryExpressionDSL<R>
             return QueryExpressionDSL.this.unionAll();
         }
 
-        public SelectDSL<R>.LimitFinisher limit(long limit) {
-            return limitWhenPresent(limit);
-        }
-
-        public SelectDSL<R>.LimitFinisher limitWhenPresent(Long limit) {
+        @Override
+        public PagingDSL.LimitFinisher<R> limitWhenPresent(Long limit) {
             return QueryExpressionDSL.this.limitWhenPresent(limit);
         }
 
-        public SelectDSL<R>.OffsetFirstFinisher offset(long offset) {
-            return offsetWhenPresent(offset);
-        }
-
-        public SelectDSL<R>.OffsetFirstFinisher offsetWhenPresent(Long offset) {
+        @Override
+        public PagingDSL.OffsetFirstFinisher<R> offsetWhenPresent(Long offset) {
             return QueryExpressionDSL.this.offsetWhenPresent(offset);
         }
 
-        public SelectDSL<R>.FetchFirstFinisher fetchFirst(long fetchFirstRows) {
-            return fetchFirstWhenPresent(fetchFirstRows);
-        }
-
-        public SelectDSL<R>.FetchFirstFinisher fetchFirstWhenPresent(Long fetchFirstRows) {
+        @Override
+        public PagingDSL.FetchFirstFinisher<R> fetchFirstWhenPresent(Long fetchFirstRows) {
             return QueryExpressionDSL.this.fetchFirstWhenPresent(fetchFirstRows);
         }
 
@@ -620,30 +585,21 @@ public class QueryExpressionDSL<R>
     }
 
     public class QueryExpressionHavingBuilder extends AbstractHavingFinisher<QueryExpressionHavingBuilder>
-            implements Buildable<R> {
+            implements Buildable<R>, PagingDSL<R> {
 
-        public SelectDSL<R>.FetchFirstFinisher fetchFirst(long fetchFirstRows) {
-            return fetchFirstWhenPresent(fetchFirstRows);
+        @Override
+        public PagingDSL.LimitFinisher<R> limitWhenPresent(Long limit) {
+            return QueryExpressionDSL.this.limitWhenPresent(limit);
         }
 
-        public SelectDSL<R>.FetchFirstFinisher fetchFirstWhenPresent(Long fetchFirstRows) {
-            return QueryExpressionDSL.this.fetchFirstWhenPresent(fetchFirstRows);
-        }
-
-        public SelectDSL<R>.OffsetFirstFinisher offset(long offset) {
-            return offsetWhenPresent(offset);
-        }
-
-        public SelectDSL<R>.OffsetFirstFinisher offsetWhenPresent(Long offset) {
+        @Override
+        public PagingDSL.OffsetFirstFinisher<R> offsetWhenPresent(Long offset) {
             return QueryExpressionDSL.this.offsetWhenPresent(offset);
         }
 
-        public SelectDSL<R>.LimitFinisher limit(long limit) {
-            return limitWhenPresent(limit);
-        }
-
-        public SelectDSL<R>.LimitFinisher limitWhenPresent(Long limit) {
-            return QueryExpressionDSL.this.limitWhenPresent(limit);
+        @Override
+        public PagingDSL.FetchFirstFinisher<R> fetchFirstWhenPresent(Long fetchFirstRows) {
+            return QueryExpressionDSL.this.fetchFirstWhenPresent(fetchFirstRows);
         }
 
         public SelectDSL<R> orderBy(SortSpecification... columns) {

--- a/src/main/java/org/mybatis/dynamic/sql/select/SelectDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/select/SelectDSL.java
@@ -108,16 +108,28 @@ public class SelectDSL<R> implements Buildable<R>, ConfigurableStatement<SelectD
     }
 
     public LimitFinisher limit(long limit) {
+        return limitWhenPresent(limit);
+    }
+
+    public LimitFinisher limitWhenPresent(Long limit) {
         this.limit = limit;
         return new LimitFinisher();
     }
 
     public OffsetFirstFinisher offset(long offset) {
+        return offsetWhenPresent(offset);
+    }
+
+    public OffsetFirstFinisher offsetWhenPresent(Long offset) {
         this.offset = offset;
         return new OffsetFirstFinisher();
     }
 
     public FetchFirstFinisher fetchFirst(long fetchFirstRows) {
+        return fetchFirstWhenPresent(fetchFirstRows);
+    }
+
+    public FetchFirstFinisher fetchFirstWhenPresent(Long fetchFirstRows) {
         this.fetchFirstRows = fetchFirstRows;
         return new FetchFirstFinisher();
     }
@@ -155,7 +167,11 @@ public class SelectDSL<R> implements Buildable<R>, ConfigurableStatement<SelectD
 
     public class LimitFinisher implements Buildable<R> {
         public OffsetFinisher offset(long offset) {
-            SelectDSL.this.offset(offset);
+            return offsetWhenPresent(offset);
+        }
+
+        public OffsetFinisher offsetWhenPresent(Long offset) {
+            SelectDSL.this.offsetWhenPresent(offset);
             return new OffsetFinisher();
         }
 
@@ -176,8 +192,11 @@ public class SelectDSL<R> implements Buildable<R>, ConfigurableStatement<SelectD
 
     public class OffsetFirstFinisher implements Buildable<R> {
         public FetchFirstFinisher fetchFirst(long fetchFirstRows) {
-            SelectDSL.this.fetchFirst(fetchFirstRows);
-            return new FetchFirstFinisher();
+            return fetchFirstWhenPresent(fetchFirstRows);
+        }
+
+        public FetchFirstFinisher fetchFirstWhenPresent(Long fetchFirstRows) {
+            return SelectDSL.this.fetchFirstWhenPresent(fetchFirstRows);
         }
 
         @NotNull

--- a/src/main/java/org/mybatis/dynamic/sql/update/UpdateDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/update/UpdateDSL.java
@@ -76,6 +76,10 @@ public class UpdateDSL<R> extends AbstractWhereStarter<UpdateDSL<R>.UpdateWhereB
     }
 
     public UpdateDSL<R> limit(long limit) {
+        return limitWhenPresent(limit);
+    }
+
+    public UpdateDSL<R> limitWhenPresent(Long limit) {
         this.limit = limit;
         return this;
     }
@@ -196,7 +200,11 @@ public class UpdateDSL<R> extends AbstractWhereStarter<UpdateDSL<R>.UpdateWhereB
         }
 
         public UpdateDSL<R> limit(long limit) {
-            return UpdateDSL.this.limit(limit);
+            return limitWhenPresent(limit);
+        }
+
+        public UpdateDSL<R> limitWhenPresent(Long limit) {
+            return UpdateDSL.this.limitWhenPresent(limit);
         }
 
         public UpdateDSL<R> orderBy(SortSpecification... columns) {

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinDeleteBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinDeleteBuilder.kt
@@ -30,7 +30,11 @@ class KotlinDeleteBuilder(private val dsl: DeleteDSL<DeleteModel>) :
     }
 
     fun limit(limit: Long) {
-        dsl.limit(limit)
+        limitWhenPresent(limit)
+    }
+
+    fun limitWhenPresent(limit: Long?) {
+        dsl.limitWhenPresent(limit)
     }
 
     override fun build(): DeleteModel = dsl.build()

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinMultiSelectBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinMultiSelectBuilder.kt
@@ -26,7 +26,7 @@ import org.mybatis.dynamic.sql.util.Buildable
 typealias MultiSelectCompleter = KotlinMultiSelectBuilder.() -> Unit
 
 @MyBatisDslMarker
-class KotlinMultiSelectBuilder: Buildable<MultiSelectModel> {
+class KotlinMultiSelectBuilder: Buildable<MultiSelectModel>, KotlinPagingDSL {
     private var dsl: MultiSelectDSL? = null
         set(value) {
             assertNull(field, "ERROR.33") //$NON-NLS-1$
@@ -63,27 +63,15 @@ class KotlinMultiSelectBuilder: Buildable<MultiSelectModel> {
         getDsl().orderBy(columns.asList())
     }
 
-    fun limit(limit: Long) {
-        limitWhenPresent(limit)
-    }
-
-    fun limitWhenPresent(limit: Long?) {
+    override fun limitWhenPresent(limit: Long?) {
         getDsl().limitWhenPresent(limit)
     }
 
-    fun offset(offset: Long) {
-        offsetWhenPresent(offset)
-    }
-
-    fun offsetWhenPresent(offset: Long?) {
+    override fun offsetWhenPresent(offset: Long?) {
         getDsl().offsetWhenPresent(offset)
     }
 
-    fun fetchFirst(fetchFirstRows: Long) {
-        fetchFirstWhenPresent(fetchFirstRows)
-    }
-
-    fun fetchFirstWhenPresent(fetchFirstRows: Long?) {
+    override fun fetchFirstWhenPresent(fetchFirstRows: Long?) {
         getDsl().fetchFirstWhenPresent(fetchFirstRows).rowsOnly()
     }
 

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinMultiSelectBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinMultiSelectBuilder.kt
@@ -28,7 +28,7 @@ typealias MultiSelectCompleter = KotlinMultiSelectBuilder.() -> Unit
 @MyBatisDslMarker
 class KotlinMultiSelectBuilder: Buildable<MultiSelectModel> {
     private var dsl: MultiSelectDSL? = null
-        private set(value) {
+        set(value) {
             assertNull(field, "ERROR.33") //$NON-NLS-1$
             field = value
         }
@@ -64,15 +64,27 @@ class KotlinMultiSelectBuilder: Buildable<MultiSelectModel> {
     }
 
     fun limit(limit: Long) {
-        getDsl().limit(limit)
+        limitWhenPresent(limit)
+    }
+
+    fun limitWhenPresent(limit: Long?) {
+        getDsl().limitWhenPresent(limit)
     }
 
     fun offset(offset: Long) {
-        getDsl().offset(offset)
+        offsetWhenPresent(offset)
+    }
+
+    fun offsetWhenPresent(offset: Long?) {
+        getDsl().offsetWhenPresent(offset)
     }
 
     fun fetchFirst(fetchFirstRows: Long) {
-        getDsl().fetchFirst(fetchFirstRows).rowsOnly()
+        fetchFirstWhenPresent(fetchFirstRows)
+    }
+
+    fun fetchFirstWhenPresent(fetchFirstRows: Long?) {
+        getDsl().fetchFirstWhenPresent(fetchFirstRows).rowsOnly()
     }
 
     fun configureStatement(c: StatementConfiguration.() -> Unit) {

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinPagingDSL.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinPagingDSL.kt
@@ -1,0 +1,36 @@
+/*
+ *    Copyright 2016-2024 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.dynamic.sql.util.kotlin
+
+interface KotlinPagingDSL {
+    fun limit(limit: Long) {
+        limitWhenPresent(limit)
+    }
+
+    fun limitWhenPresent(limit: Long?)
+
+    fun offset(offset: Long) {
+        offsetWhenPresent(offset)
+    }
+
+    fun offsetWhenPresent(offset: Long?)
+
+    fun fetchFirst(fetchFirstRows: Long) {
+        fetchFirstWhenPresent(fetchFirstRows)
+    }
+
+    fun fetchFirstWhenPresent(fetchFirstRows: Long?)
+}

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinSelectBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinSelectBuilder.kt
@@ -28,7 +28,7 @@ typealias SelectCompleter = KotlinSelectBuilder.() -> Unit
 
 @Suppress("TooManyFunctions")
 class KotlinSelectBuilder(private val fromGatherer: QueryExpressionDSL.FromGatherer<SelectModel>) :
-    KotlinBaseJoiningBuilder<QueryExpressionDSL<SelectModel>>(), Buildable<SelectModel> {
+    KotlinBaseJoiningBuilder<QueryExpressionDSL<SelectModel>>(), Buildable<SelectModel>, KotlinPagingDSL {
 
     private var dsl: KQueryExpressionDSL? = null
 
@@ -58,27 +58,15 @@ class KotlinSelectBuilder(private val fromGatherer: QueryExpressionDSL.FromGathe
         getDsl().orderBy(columns.toList())
     }
 
-    fun limit(limit: Long) {
-        limitWhenPresent(limit)
-    }
-
-    fun limitWhenPresent(limit: Long?) {
+    override fun limitWhenPresent(limit: Long?) {
         getDsl().limitWhenPresent(limit)
     }
 
-    fun offset(offset: Long) {
-        offsetWhenPresent(offset)
-    }
-
-    fun offsetWhenPresent(offset: Long?) {
+    override fun offsetWhenPresent(offset: Long?) {
         getDsl().offsetWhenPresent(offset)
     }
 
-    fun fetchFirst(fetchFirstRows: Long) {
-        fetchFirstWhenPresent(fetchFirstRows)
-    }
-
-    fun fetchFirstWhenPresent(fetchFirstRows: Long?) {
+    override fun fetchFirstWhenPresent(fetchFirstRows: Long?) {
         getDsl().fetchFirstWhenPresent(fetchFirstRows).rowsOnly()
     }
 

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinSelectBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinSelectBuilder.kt
@@ -59,15 +59,27 @@ class KotlinSelectBuilder(private val fromGatherer: QueryExpressionDSL.FromGathe
     }
 
     fun limit(limit: Long) {
-        getDsl().limit(limit)
+        limitWhenPresent(limit)
+    }
+
+    fun limitWhenPresent(limit: Long?) {
+        getDsl().limitWhenPresent(limit)
     }
 
     fun offset(offset: Long) {
-        getDsl().offset(offset)
+        offsetWhenPresent(offset)
+    }
+
+    fun offsetWhenPresent(offset: Long?) {
+        getDsl().offsetWhenPresent(offset)
     }
 
     fun fetchFirst(fetchFirstRows: Long) {
-        getDsl().fetchFirst(fetchFirstRows).rowsOnly()
+        fetchFirstWhenPresent(fetchFirstRows)
+    }
+
+    fun fetchFirstWhenPresent(fetchFirstRows: Long?) {
+        getDsl().fetchFirstWhenPresent(fetchFirstRows).rowsOnly()
     }
 
     fun union(union: KotlinUnionBuilder.() -> Unit): Unit =

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinUpdateBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinUpdateBuilder.kt
@@ -34,7 +34,11 @@ class KotlinUpdateBuilder(private val dsl: UpdateDSL<UpdateModel>) :
     }
 
     fun limit(limit: Long) {
-        dsl.limit(limit)
+        limitWhenPresent(limit)
+    }
+
+    fun limitWhenPresent(limit: Long?) {
+        dsl.limitWhenPresent(limit)
     }
 
     override fun build(): UpdateModel = dsl.build()

--- a/src/test/java/examples/animal/data/AnimalDataTest.java
+++ b/src/test/java/examples/animal/data/AnimalDataTest.java
@@ -109,6 +109,24 @@ class AnimalDataTest {
     }
 
     @Test
+    void testSelectAllRowsWithNullLimit() {
+        try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+            AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);
+            SelectStatementProvider selectStatement = select(id, animalName, bodyWeight, brainWeight)
+                    .from(animalData)
+                    .limitWhenPresent(null)
+                    .build()
+                    .render(RenderingStrategies.MYBATIS3);
+            List<AnimalData> animals = mapper.selectMany(selectStatement);
+
+            assertAll(
+                    () -> assertThat(animals).hasSize(65),
+                    () -> assertThat(animals).first().isNotNull().extracting(AnimalData::getId).isEqualTo(1)
+            );
+        }
+    }
+
+    @Test
     void testSelectAllRowsWithRowBounds() {
         try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
             AnimalDataMapper mapper = sqlSession.getMapper(AnimalDataMapper.class);

--- a/src/test/java/examples/animal/data/VariousPagingAndLimitScenariosTest.java
+++ b/src/test/java/examples/animal/data/VariousPagingAndLimitScenariosTest.java
@@ -1,0 +1,132 @@
+/*
+ *    Copyright 2016-2024 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package examples.animal.data;
+
+import static examples.animal.data.AnimalDataDynamicSqlSupport.animalData;
+import static examples.animal.data.AnimalDataDynamicSqlSupport.id;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mybatis.dynamic.sql.SqlBuilder.deleteFrom;
+import static org.mybatis.dynamic.sql.SqlBuilder.isLessThan;
+import static org.mybatis.dynamic.sql.SqlBuilder.select;
+import static org.mybatis.dynamic.sql.SqlBuilder.update;
+
+import org.junit.jupiter.api.Test;
+import org.mybatis.dynamic.sql.render.RenderingStrategies;
+
+class VariousPagingAndLimitScenariosTest {
+
+    @Test
+    void testOptionalLimitOnDelete() {
+        var deleteStatement = deleteFrom(animalData)
+                .limitWhenPresent(null)
+                .build()
+                .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
+
+        assertThat(deleteStatement.getDeleteStatement()).isEqualTo("delete from AnimalData");
+    }
+
+    @Test
+    void testOptionalLimitOnDeleteWithWhere() {
+        var deleteStatement = deleteFrom(animalData)
+                .where(id, isLessThan(22))
+                .limitWhenPresent(null)
+                .build()
+                .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
+
+        assertThat(deleteStatement.getDeleteStatement())
+                .isEqualTo("delete from AnimalData where id < :p1");
+    }
+
+    @Test
+    void testOptionalLimitOnUpdate() {
+        var updateStatement = update(animalData)
+                .set(id).equalTo(1)
+                .limitWhenPresent(null)
+                .build()
+                .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
+
+        assertThat(updateStatement.getUpdateStatement()).isEqualTo("update AnimalData set id = :p1");
+    }
+
+    @Test
+    void testOptionalLimitOnUpdateWithWhere() {
+        var updateStatement = update(animalData)
+                .set(id).equalTo(1)
+                .where(id, isLessThan(22))
+                .limitWhenPresent(null)
+                .build()
+                .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
+
+        assertThat(updateStatement.getUpdateStatement()).isEqualTo("update AnimalData set id = :p1 where id < :p2");
+   }
+
+    @Test
+    void testOptionalLimitOnSelect() {
+        var selectStatement = select(animalData.allColumns())
+                .from(animalData)
+                .limitWhenPresent(null)
+                .build()
+                .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
+
+        assertThat(selectStatement.getSelectStatement()).isEqualTo("select * from AnimalData");
+    }
+
+    @Test
+    void testOptionalOffsetOnSelect() {
+        var selectStatement = select(animalData.allColumns())
+                .from(animalData)
+                .offsetWhenPresent(null)
+                .build()
+                .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
+
+        assertThat(selectStatement.getSelectStatement()).isEqualTo("select * from AnimalData");
+    }
+
+    @Test
+    void testOptionalFetchFirstOnSelect() {
+        var selectStatement = select(animalData.allColumns())
+                .from(animalData)
+                .fetchFirstWhenPresent(null).rowsOnly()
+                .build()
+                .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
+
+        assertThat(selectStatement.getSelectStatement()).isEqualTo("select * from AnimalData");
+    }
+
+    @Test
+    void testOptionalLimitAndOffsetOnSelect() {
+        var selectStatement = select(animalData.allColumns())
+                .from(animalData)
+                .limitWhenPresent(null)
+                .offsetWhenPresent(null)
+                .build()
+                .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
+
+        assertThat(selectStatement.getSelectStatement()).isEqualTo("select * from AnimalData");
+    }
+
+    @Test
+    void testOptionalOffsetAndFetchOnSelect() {
+        var selectStatement = select(animalData.allColumns())
+                .from(animalData)
+                .offsetWhenPresent(null)
+                .fetchFirstWhenPresent(null).rowsOnly()
+                .build()
+                .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
+
+        assertThat(selectStatement.getSelectStatement()).isEqualTo("select * from AnimalData");
+    }
+}

--- a/src/test/java/issues/gh100/FromGroupByTest.java
+++ b/src/test/java/issues/gh100/FromGroupByTest.java
@@ -105,7 +105,7 @@ class FromGroupByTest {
 
         QueryExpressionDSL<SelectModel>.GroupByFinisher builder2 = builder1.groupBy(StudentDynamicSqlSupport.name);
 
-        SelectDSL<SelectModel>.LimitFinisher builder3 = builder2.limit(3);
+        var builder3 = builder2.limit(3);
 
         String expected = "select name, count(*)"
                 + " from student"
@@ -162,7 +162,7 @@ class FromGroupByTest {
 
         QueryExpressionDSL<SelectModel>.GroupByFinisher builder2 = builder1.groupBy(StudentDynamicSqlSupport.name);
 
-        SelectDSL<SelectModel>.OffsetFirstFinisher builder3 = builder2.offset(3);
+        var builder3 = builder2.offset(3);
 
         String expected = "select name, count(*)"
                 + " from student"
@@ -219,7 +219,7 @@ class FromGroupByTest {
 
         QueryExpressionDSL<SelectModel>.GroupByFinisher builder2 = builder1.groupBy(StudentDynamicSqlSupport.name);
 
-        SelectDSL<SelectModel>.RowsOnlyFinisher builder3 = builder2.fetchFirst(2).rowsOnly();
+        var builder3 = builder2.fetchFirst(2).rowsOnly();
 
         String expected = "select name, count(*)"
                 + " from student"
@@ -363,7 +363,7 @@ class FromGroupByTest {
 
         SelectDSL<SelectModel> builder3 = builder2.orderBy(StudentDynamicSqlSupport.name);
 
-        SelectDSL<SelectModel>.OffsetFirstFinisher builder4 = builder3.offset(2);
+        var builder4 = builder3.offset(2);
 
         String expected = "select name, count(*)"
                 + " from student"

--- a/src/test/java/issues/gh100/FromJoinWhereTest.java
+++ b/src/test/java/issues/gh100/FromJoinWhereTest.java
@@ -793,7 +793,7 @@ class FromJoinWhereTest {
 
         SelectDSL<SelectModel> builder5 = builder4.orderBy(StudentDynamicSqlSupport.id);
 
-        SelectDSL<SelectModel>.LimitFinisher builder6 = builder5.limit(3);
+        var builder6 = builder5.limit(3);
 
         String expected = "select student.id, student.name, student.idcard"
                 + " from student"
@@ -826,7 +826,7 @@ class FromJoinWhereTest {
 
         SelectDSL<SelectModel> builder5 = builder4.orderBy(StudentDynamicSqlSupport.id);
 
-        SelectDSL<SelectModel>.LimitFinisher builder6 = builder5.limit(3);
+        var builder6 = builder5.limit(3);
 
         builder6.offset(2);
 
@@ -862,7 +862,7 @@ class FromJoinWhereTest {
 
         SelectDSL<SelectModel> builder5 = builder4.orderBy(StudentDynamicSqlSupport.id);
 
-        SelectDSL<SelectModel>.LimitFinisher builder6 = builder5.limit(3);
+        var builder6 = builder5.limit(3);
 
         builder6.offset(2);
 
@@ -898,7 +898,7 @@ class FromJoinWhereTest {
 
         SelectDSL<SelectModel> builder5 = builder4.orderBy(StudentDynamicSqlSupport.id);
 
-        SelectDSL<SelectModel>.LimitFinisher builder6 = builder5.limit(3);
+        var builder6 = builder5.limit(3);
 
         builder6.offset(2);
 
@@ -934,7 +934,7 @@ class FromJoinWhereTest {
 
         SelectDSL<SelectModel> builder5 = builder4.orderBy(StudentDynamicSqlSupport.id);
 
-        SelectDSL<SelectModel>.LimitFinisher builder6 = builder5.limit(3);
+        var builder6 = builder5.limit(3);
 
         builder6.offset(2);
 
@@ -970,7 +970,7 @@ class FromJoinWhereTest {
 
         SelectDSL<SelectModel> builder5 = builder4.orderBy(StudentDynamicSqlSupport.id);
 
-        SelectDSL<SelectModel>.LimitFinisher builder6 = builder5.limit(3);
+        var builder6 = builder5.limit(3);
 
         builder6.offset(2);
 
@@ -1006,7 +1006,7 @@ class FromJoinWhereTest {
 
         SelectDSL<SelectModel> builder5 = builder4.orderBy(StudentDynamicSqlSupport.id);
 
-        SelectDSL<SelectModel>.LimitFinisher builder6 = builder5.limit(3);
+        var builder6 = builder5.limit(3);
 
         builder6.offset(2);
 
@@ -1042,9 +1042,9 @@ class FromJoinWhereTest {
 
         SelectDSL<SelectModel> builder5 = builder4.orderBy(StudentDynamicSqlSupport.id);
 
-        SelectDSL<SelectModel>.LimitFinisher builder6 = builder5.limit(3);
+        var builder6 = builder5.limit(3);
 
-        SelectDSL<SelectModel>.OffsetFinisher builder7 = builder6.offset(2);
+        var builder7 = builder6.offset(2);
 
         String expected = "select student.id, student.name, student.idcard"
                 + " from student"
@@ -1248,7 +1248,7 @@ class FromJoinWhereTest {
 
         SelectDSL<SelectModel> builder5 = builder4.orderBy(StudentDynamicSqlSupport.id);
 
-        SelectDSL<SelectModel>.OffsetFirstFinisher builder6 = builder5.offset(2);
+        var builder6 = builder5.offset(2);
 
         String expected = "select student.id, student.name, student.idcard"
                 + " from student"
@@ -1282,7 +1282,7 @@ class FromJoinWhereTest {
 
         SelectDSL<SelectModel> builder5 = builder4.orderBy(StudentDynamicSqlSupport.id);
 
-        SelectDSL<SelectModel>.OffsetFirstFinisher builder6 = builder5.offset(2);
+        var builder6 = builder5.offset(2);
 
         builder6.fetchFirst(3).rowsOnly();
 
@@ -1318,7 +1318,7 @@ class FromJoinWhereTest {
 
         SelectDSL<SelectModel> builder5 = builder4.orderBy(StudentDynamicSqlSupport.id);
 
-        SelectDSL<SelectModel>.OffsetFirstFinisher builder6 = builder5.offset(2);
+        var builder6 = builder5.offset(2);
 
         builder6.fetchFirst(3).rowsOnly();
 
@@ -1354,7 +1354,7 @@ class FromJoinWhereTest {
 
         SelectDSL<SelectModel> builder5 = builder4.orderBy(StudentDynamicSqlSupport.id);
 
-        SelectDSL<SelectModel>.OffsetFirstFinisher builder6 = builder5.offset(2);
+        var builder6 = builder5.offset(2);
 
         builder6.fetchFirst(3).rowsOnly();
 
@@ -1390,7 +1390,7 @@ class FromJoinWhereTest {
 
         SelectDSL<SelectModel> builder5 = builder4.orderBy(StudentDynamicSqlSupport.id);
 
-        SelectDSL<SelectModel>.OffsetFirstFinisher builder6 = builder5.offset(2);
+        var builder6 = builder5.offset(2);
 
         builder6.fetchFirst(3).rowsOnly();
 
@@ -1426,7 +1426,7 @@ class FromJoinWhereTest {
 
         SelectDSL<SelectModel> builder5 = builder4.orderBy(StudentDynamicSqlSupport.id);
 
-        SelectDSL<SelectModel>.OffsetFirstFinisher builder6 = builder5.offset(2);
+        var builder6 = builder5.offset(2);
 
         builder6.fetchFirst(3).rowsOnly();
 
@@ -1462,7 +1462,7 @@ class FromJoinWhereTest {
 
         SelectDSL<SelectModel> builder5 = builder4.orderBy(StudentDynamicSqlSupport.id);
 
-        SelectDSL<SelectModel>.OffsetFirstFinisher builder6 = builder5.offset(2);
+        var builder6 = builder5.offset(2);
 
         builder6.fetchFirst(3).rowsOnly();
 
@@ -1498,9 +1498,9 @@ class FromJoinWhereTest {
 
         SelectDSL<SelectModel> builder5 = builder4.orderBy(StudentDynamicSqlSupport.id);
 
-        SelectDSL<SelectModel>.OffsetFirstFinisher builder6 = builder5.offset(2);
+        var builder6 = builder5.offset(2);
 
-        SelectDSL<SelectModel>.RowsOnlyFinisher builder7 = builder6.fetchFirst(3).rowsOnly();
+        var builder7 = builder6.fetchFirst(3).rowsOnly();
 
         String expected = "select student.id, student.name, student.idcard"
                 + " from student"
@@ -1699,7 +1699,7 @@ class FromJoinWhereTest {
 
         SelectDSL<SelectModel> builder5 = builder4.orderBy(StudentDynamicSqlSupport.id);
 
-        SelectDSL<SelectModel>.RowsOnlyFinisher builder6 = builder5.fetchFirst(3).rowsOnly();
+        var builder6 = builder5.fetchFirst(3).rowsOnly();
 
         String expected = "select student.id, student.name, student.idcard"
                 + " from student"
@@ -1850,7 +1850,7 @@ class FromJoinWhereTest {
                 .select(StudentDynamicSqlSupport.id, StudentDynamicSqlSupport.name, StudentDynamicSqlSupport.idcard)
                 .from(StudentDynamicSqlSupport.student);
 
-        SelectDSL<SelectModel>.LimitFinisher builder5 = builder4.limit(3);
+        var builder5 = builder4.limit(3);
 
         String expected = "select student.id, student.name, student.idcard"
                 + " from student"
@@ -1880,7 +1880,7 @@ class FromJoinWhereTest {
                 .select(StudentDynamicSqlSupport.id, StudentDynamicSqlSupport.name, StudentDynamicSqlSupport.idcard)
                 .from(StudentDynamicSqlSupport.student);
 
-        SelectDSL<SelectModel>.LimitFinisher builder5 = builder4.limit(3);
+        var builder5 = builder4.limit(3);
 
         builder5.offset(2);
 
@@ -1913,7 +1913,7 @@ class FromJoinWhereTest {
                 .select(StudentDynamicSqlSupport.id, StudentDynamicSqlSupport.name, StudentDynamicSqlSupport.idcard)
                 .from(StudentDynamicSqlSupport.student);
 
-        SelectDSL<SelectModel>.LimitFinisher builder5 = builder4.limit(3);
+        var builder5 = builder4.limit(3);
 
         builder5.offset(2);
 
@@ -1946,7 +1946,7 @@ class FromJoinWhereTest {
                 .select(StudentDynamicSqlSupport.id, StudentDynamicSqlSupport.name, StudentDynamicSqlSupport.idcard)
                 .from(StudentDynamicSqlSupport.student);
 
-        SelectDSL<SelectModel>.LimitFinisher builder5 = builder4.limit(3);
+        var builder5 = builder4.limit(3);
 
         builder5.offset(2);
 
@@ -1979,7 +1979,7 @@ class FromJoinWhereTest {
                 .select(StudentDynamicSqlSupport.id, StudentDynamicSqlSupport.name, StudentDynamicSqlSupport.idcard)
                 .from(StudentDynamicSqlSupport.student);
 
-        SelectDSL<SelectModel>.LimitFinisher builder5 = builder4.limit(3);
+        var builder5 = builder4.limit(3);
 
         builder5.offset(2);
 
@@ -2012,7 +2012,7 @@ class FromJoinWhereTest {
                 .select(StudentDynamicSqlSupport.id, StudentDynamicSqlSupport.name, StudentDynamicSqlSupport.idcard)
                 .from(StudentDynamicSqlSupport.student);
 
-        SelectDSL<SelectModel>.LimitFinisher builder5 = builder4.limit(3);
+        var builder5 = builder4.limit(3);
 
         builder5.offset(2);
 
@@ -2045,9 +2045,9 @@ class FromJoinWhereTest {
                 .select(StudentDynamicSqlSupport.id, StudentDynamicSqlSupport.name, StudentDynamicSqlSupport.idcard)
                 .from(StudentDynamicSqlSupport.student);
 
-        SelectDSL<SelectModel>.LimitFinisher builder5 = builder4.limit(3);
+        var builder5 = builder4.limit(3);
 
-        SelectDSL<SelectModel>.OffsetFinisher builder6 = builder5.offset(2);
+        var builder6 = builder5.offset(2);
 
         String expected = "select student.id, student.name, student.idcard"
                 + " from student"
@@ -2198,7 +2198,7 @@ class FromJoinWhereTest {
                 .select(StudentDynamicSqlSupport.id, StudentDynamicSqlSupport.name, StudentDynamicSqlSupport.idcard)
                 .from(StudentDynamicSqlSupport.student);
 
-        SelectDSL<SelectModel>.OffsetFirstFinisher builder5 = builder4.offset(2);
+        var builder5 = builder4.offset(2);
 
         String expected = "select student.id, student.name, student.idcard"
                 + " from student"
@@ -2228,7 +2228,7 @@ class FromJoinWhereTest {
                 .select(StudentDynamicSqlSupport.id, StudentDynamicSqlSupport.name, StudentDynamicSqlSupport.idcard)
                 .from(StudentDynamicSqlSupport.student);
 
-        SelectDSL<SelectModel>.OffsetFirstFinisher builder5 = builder4.offset(2);
+        var builder5 = builder4.offset(2);
 
         builder5.fetchFirst(2).rowsOnly();
 
@@ -2261,7 +2261,7 @@ class FromJoinWhereTest {
                 .select(StudentDynamicSqlSupport.id, StudentDynamicSqlSupport.name, StudentDynamicSqlSupport.idcard)
                 .from(StudentDynamicSqlSupport.student);
 
-        SelectDSL<SelectModel>.OffsetFirstFinisher builder5 = builder4.offset(2);
+        var builder5 = builder4.offset(2);
 
         builder5.fetchFirst(2).rowsOnly();
 
@@ -2294,7 +2294,7 @@ class FromJoinWhereTest {
                 .select(StudentDynamicSqlSupport.id, StudentDynamicSqlSupport.name, StudentDynamicSqlSupport.idcard)
                 .from(StudentDynamicSqlSupport.student);
 
-        SelectDSL<SelectModel>.OffsetFirstFinisher builder5 = builder4.offset(2);
+        var builder5 = builder4.offset(2);
 
         builder5.fetchFirst(2).rowsOnly();
 
@@ -2327,7 +2327,7 @@ class FromJoinWhereTest {
                 .select(StudentDynamicSqlSupport.id, StudentDynamicSqlSupport.name, StudentDynamicSqlSupport.idcard)
                 .from(StudentDynamicSqlSupport.student);
 
-        SelectDSL<SelectModel>.OffsetFirstFinisher builder5 = builder4.offset(2);
+        var builder5 = builder4.offset(2);
 
         builder5.fetchFirst(2).rowsOnly();
 
@@ -2360,7 +2360,7 @@ class FromJoinWhereTest {
                 .select(StudentDynamicSqlSupport.id, StudentDynamicSqlSupport.name, StudentDynamicSqlSupport.idcard)
                 .from(StudentDynamicSqlSupport.student);
 
-        SelectDSL<SelectModel>.OffsetFirstFinisher builder5 = builder4.offset(2);
+        var builder5 = builder4.offset(2);
 
         builder5.fetchFirst(2).rowsOnly();
 
@@ -2393,9 +2393,9 @@ class FromJoinWhereTest {
                 .select(StudentDynamicSqlSupport.id, StudentDynamicSqlSupport.name, StudentDynamicSqlSupport.idcard)
                 .from(StudentDynamicSqlSupport.student);
 
-        SelectDSL<SelectModel>.OffsetFirstFinisher builder5 = builder4.offset(2);
+        var builder5 = builder4.offset(2);
 
-        SelectDSL<SelectModel>.RowsOnlyFinisher builder6 = builder5.fetchFirst(2).rowsOnly();
+        var builder6 = builder5.fetchFirst(2).rowsOnly();
 
         String expected = "select student.id, student.name, student.idcard"
                 + " from student"
@@ -2546,7 +2546,7 @@ class FromJoinWhereTest {
                 .select(StudentDynamicSqlSupport.id, StudentDynamicSqlSupport.name, StudentDynamicSqlSupport.idcard)
                 .from(StudentDynamicSqlSupport.student);
 
-        SelectDSL<SelectModel>.RowsOnlyFinisher builder5 = builder4.fetchFirst(2).rowsOnly();
+        var builder5 = builder4.fetchFirst(2).rowsOnly();
 
         String expected = "select student.id, student.name, student.idcard"
                 + " from student"
@@ -2770,7 +2770,7 @@ class FromJoinWhereTest {
 
         SelectDSL<SelectModel> builder4 = builder3.orderBy(StudentDynamicSqlSupport.id);
 
-        SelectDSL<SelectModel>.LimitFinisher builder5 = builder4.limit(3);
+        var builder5 = builder4.limit(3);
 
         String expected = "select student.id, student.name, student.idcard"
                 + " from student"
@@ -2796,7 +2796,7 @@ class FromJoinWhereTest {
 
         SelectDSL<SelectModel> builder4 = builder3.orderBy(StudentDynamicSqlSupport.id);
 
-        SelectDSL<SelectModel>.LimitFinisher builder5 = builder4.limit(3);
+        var builder5 = builder4.limit(3);
 
         builder5.offset(2);
 
@@ -2825,7 +2825,7 @@ class FromJoinWhereTest {
 
         SelectDSL<SelectModel> builder4 = builder3.orderBy(StudentDynamicSqlSupport.id);
 
-        SelectDSL<SelectModel>.LimitFinisher builder5 = builder4.limit(3);
+        var builder5 = builder4.limit(3);
 
         builder5.offset(2);
 
@@ -2854,7 +2854,7 @@ class FromJoinWhereTest {
 
         SelectDSL<SelectModel> builder4 = builder3.orderBy(StudentDynamicSqlSupport.id);
 
-        SelectDSL<SelectModel>.LimitFinisher builder5 = builder4.limit(3);
+        var builder5 = builder4.limit(3);
 
         builder5.offset(2);
 
@@ -2883,7 +2883,7 @@ class FromJoinWhereTest {
 
         SelectDSL<SelectModel> builder4 = builder3.orderBy(StudentDynamicSqlSupport.id);
 
-        SelectDSL<SelectModel>.LimitFinisher builder5 = builder4.limit(3);
+        var builder5 = builder4.limit(3);
 
         builder5.offset(2);
 
@@ -2912,7 +2912,7 @@ class FromJoinWhereTest {
 
         SelectDSL<SelectModel> builder4 = builder3.orderBy(StudentDynamicSqlSupport.id);
 
-        SelectDSL<SelectModel>.LimitFinisher builder5 = builder4.limit(3);
+        var builder5 = builder4.limit(3);
 
         builder5.offset(2);
 
@@ -2941,9 +2941,9 @@ class FromJoinWhereTest {
 
         SelectDSL<SelectModel> builder4 = builder3.orderBy(StudentDynamicSqlSupport.id);
 
-        SelectDSL<SelectModel>.LimitFinisher builder5 = builder4.limit(3);
+        var builder5 = builder4.limit(3);
 
-        SelectDSL<SelectModel>.OffsetFinisher builder6 = builder5.offset(2);
+        var builder6 = builder5.offset(2);
 
         String expected = "select student.id, student.name, student.idcard"
                 + " from student"
@@ -3074,7 +3074,7 @@ class FromJoinWhereTest {
 
         SelectDSL<SelectModel> builder4 = builder3.orderBy(StudentDynamicSqlSupport.id);
 
-        SelectDSL<SelectModel>.OffsetFirstFinisher builder5 = builder4.offset(2);
+        var builder5 = builder4.offset(2);
 
         String expected = "select student.id, student.name, student.idcard"
                 + " from student"
@@ -3100,7 +3100,7 @@ class FromJoinWhereTest {
 
         SelectDSL<SelectModel> builder4 = builder3.orderBy(StudentDynamicSqlSupport.id);
 
-        SelectDSL<SelectModel>.OffsetFirstFinisher builder5 = builder4.offset(2);
+        var builder5 = builder4.offset(2);
 
         builder5.fetchFirst(3).rowsOnly();
 
@@ -3129,7 +3129,7 @@ class FromJoinWhereTest {
 
         SelectDSL<SelectModel> builder4 = builder3.orderBy(StudentDynamicSqlSupport.id);
 
-        SelectDSL<SelectModel>.OffsetFirstFinisher builder5 = builder4.offset(2);
+        var builder5 = builder4.offset(2);
 
         builder5.fetchFirst(3).rowsOnly();
 
@@ -3158,7 +3158,7 @@ class FromJoinWhereTest {
 
         SelectDSL<SelectModel> builder4 = builder3.orderBy(StudentDynamicSqlSupport.id);
 
-        SelectDSL<SelectModel>.OffsetFirstFinisher builder5 = builder4.offset(2);
+        var builder5 = builder4.offset(2);
 
         builder5.fetchFirst(3).rowsOnly();
 
@@ -3187,7 +3187,7 @@ class FromJoinWhereTest {
 
         SelectDSL<SelectModel> builder4 = builder3.orderBy(StudentDynamicSqlSupport.id);
 
-        SelectDSL<SelectModel>.OffsetFirstFinisher builder5 = builder4.offset(2);
+        var builder5 = builder4.offset(2);
 
         builder5.fetchFirst(3).rowsOnly();
 
@@ -3216,7 +3216,7 @@ class FromJoinWhereTest {
 
         SelectDSL<SelectModel> builder4 = builder3.orderBy(StudentDynamicSqlSupport.id);
 
-        SelectDSL<SelectModel>.OffsetFirstFinisher builder5 = builder4.offset(2);
+        var builder5 = builder4.offset(2);
 
         builder5.fetchFirst(3).rowsOnly();
 
@@ -3245,9 +3245,9 @@ class FromJoinWhereTest {
 
         SelectDSL<SelectModel> builder4 = builder3.orderBy(StudentDynamicSqlSupport.id);
 
-        SelectDSL<SelectModel>.OffsetFirstFinisher builder5 = builder4.offset(2);
+        var builder5 = builder4.offset(2);
 
-        SelectDSL<SelectModel>.RowsOnlyFinisher builder6 = builder5.fetchFirst(3).rowsOnly();
+        var builder6 = builder5.fetchFirst(3).rowsOnly();
 
         String expected = "select student.id, student.name, student.idcard"
                 + " from student"
@@ -3378,7 +3378,7 @@ class FromJoinWhereTest {
 
         SelectDSL<SelectModel> builder4 = builder3.orderBy(StudentDynamicSqlSupport.id);
 
-        SelectDSL<SelectModel>.RowsOnlyFinisher builder5 = builder4.fetchFirst(3).rowsOnly();
+        var builder5 = builder4.fetchFirst(3).rowsOnly();
 
         String expected = "select student.id, student.name, student.idcard"
                 + " from student"
@@ -3471,7 +3471,7 @@ class FromJoinWhereTest {
 
         QueryExpressionDSL<SelectModel>.QueryExpressionWhereBuilder builder3 = builder2.where(StudentDynamicSqlSupport.idcard, isEqualTo("fred"));
 
-        SelectDSL<SelectModel>.LimitFinisher builder4 = builder3.limit(2);
+        var builder4 = builder3.limit(2);
 
         String expected = "select student.id, student.name, student.idcard"
                 + " from student"
@@ -3494,7 +3494,7 @@ class FromJoinWhereTest {
 
         QueryExpressionDSL<SelectModel>.QueryExpressionWhereBuilder builder3 = builder2.where(StudentDynamicSqlSupport.idcard, isEqualTo("fred"));
 
-        SelectDSL<SelectModel>.LimitFinisher builder4 = builder3.limit(2);
+        var builder4 = builder3.limit(2);
 
         builder4.offset(3);
 
@@ -3520,7 +3520,7 @@ class FromJoinWhereTest {
 
         QueryExpressionDSL<SelectModel>.QueryExpressionWhereBuilder builder3 = builder2.where(StudentDynamicSqlSupport.idcard, isEqualTo("fred"));
 
-        SelectDSL<SelectModel>.LimitFinisher builder4 = builder3.limit(2);
+        var builder4 = builder3.limit(2);
 
         builder4.offset(3);
 
@@ -3546,7 +3546,7 @@ class FromJoinWhereTest {
 
         QueryExpressionDSL<SelectModel>.QueryExpressionWhereBuilder builder3 = builder2.where(StudentDynamicSqlSupport.idcard, isEqualTo("fred"));
 
-        SelectDSL<SelectModel>.LimitFinisher builder4 = builder3.limit(2);
+        var builder4 = builder3.limit(2);
 
         builder4.offset(3);
 
@@ -3572,7 +3572,7 @@ class FromJoinWhereTest {
 
         QueryExpressionDSL<SelectModel>.QueryExpressionWhereBuilder builder3 = builder2.where(StudentDynamicSqlSupport.idcard, isEqualTo("fred"));
 
-        SelectDSL<SelectModel>.LimitFinisher builder4 = builder3.limit(2);
+        var builder4 = builder3.limit(2);
 
         builder4.offset(3);
 
@@ -3598,9 +3598,9 @@ class FromJoinWhereTest {
 
         QueryExpressionDSL<SelectModel>.QueryExpressionWhereBuilder builder3 = builder2.where(StudentDynamicSqlSupport.idcard, isEqualTo("fred"));
 
-        SelectDSL<SelectModel>.LimitFinisher builder4 = builder3.limit(2);
+        var builder4 = builder3.limit(2);
 
-        SelectDSL<SelectModel>.OffsetFinisher builder5 = builder4.offset(3);
+        var builder5 = builder4.offset(3);
 
         String expected = "select student.id, student.name, student.idcard"
                 + " from student"
@@ -3693,7 +3693,7 @@ class FromJoinWhereTest {
 
         QueryExpressionDSL<SelectModel>.QueryExpressionWhereBuilder builder3 = builder2.where(StudentDynamicSqlSupport.idcard, isEqualTo("fred"));
 
-        SelectDSL<SelectModel>.OffsetFirstFinisher builder4 = builder3.offset(3);
+        var builder4 = builder3.offset(3);
 
         String expected = "select student.id, student.name, student.idcard"
                 + " from student"
@@ -3716,7 +3716,7 @@ class FromJoinWhereTest {
 
         QueryExpressionDSL<SelectModel>.QueryExpressionWhereBuilder builder3 = builder2.where(StudentDynamicSqlSupport.idcard, isEqualTo("fred"));
 
-        SelectDSL<SelectModel>.OffsetFirstFinisher builder4 = builder3.offset(3);
+        var builder4 = builder3.offset(3);
 
         builder4.fetchFirst(2).rowsOnly();
 
@@ -3742,7 +3742,7 @@ class FromJoinWhereTest {
 
         QueryExpressionDSL<SelectModel>.QueryExpressionWhereBuilder builder3 = builder2.where(StudentDynamicSqlSupport.idcard, isEqualTo("fred"));
 
-        SelectDSL<SelectModel>.OffsetFirstFinisher builder4 = builder3.offset(3);
+        var builder4 = builder3.offset(3);
 
         builder4.fetchFirst(2).rowsOnly();
 
@@ -3768,7 +3768,7 @@ class FromJoinWhereTest {
 
         QueryExpressionDSL<SelectModel>.QueryExpressionWhereBuilder builder3 = builder2.where(StudentDynamicSqlSupport.idcard, isEqualTo("fred"));
 
-        SelectDSL<SelectModel>.OffsetFirstFinisher builder4 = builder3.offset(3);
+        var builder4 = builder3.offset(3);
 
         builder4.fetchFirst(2).rowsOnly();
 
@@ -3794,7 +3794,7 @@ class FromJoinWhereTest {
 
         QueryExpressionDSL<SelectModel>.QueryExpressionWhereBuilder builder3 = builder2.where(StudentDynamicSqlSupport.idcard, isEqualTo("fred"));
 
-        SelectDSL<SelectModel>.OffsetFirstFinisher builder4 = builder3.offset(3);
+        var builder4 = builder3.offset(3);
 
         builder4.fetchFirst(2).rowsOnly();
 
@@ -3820,9 +3820,9 @@ class FromJoinWhereTest {
 
         QueryExpressionDSL<SelectModel>.QueryExpressionWhereBuilder builder3 = builder2.where(StudentDynamicSqlSupport.idcard, isEqualTo("fred"));
 
-        SelectDSL<SelectModel>.OffsetFirstFinisher builder4 = builder3.offset(3);
+        var builder4 = builder3.offset(3);
 
-        SelectDSL<SelectModel>.RowsOnlyFinisher builder5 = builder4.fetchFirst(2).rowsOnly();
+        var builder5 = builder4.fetchFirst(2).rowsOnly();
 
         String expected = "select student.id, student.name, student.idcard"
                 + " from student"
@@ -3915,7 +3915,7 @@ class FromJoinWhereTest {
 
         QueryExpressionDSL<SelectModel>.QueryExpressionWhereBuilder builder3 = builder2.where(StudentDynamicSqlSupport.idcard, isEqualTo("fred"));
 
-        SelectDSL<SelectModel>.RowsOnlyFinisher builder4 = builder3.fetchFirst(2).rowsOnly();
+        var builder4 = builder3.fetchFirst(2).rowsOnly();
 
         String expected = "select student.id, student.name, student.idcard"
                 + " from student"


### PR DESCRIPTION
The "WhenPresent" versions of "limit", "offset", and "fetchFirst" will drop the phrase from rendering if a null value is passed in.

Resolves #837 