### PR TITLE
Condition Filter and Map are now Interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,8 @@ Runtime behavior changes:
 - Rendering for all the conditions (isEqualTo, etc.) has changed. This should be transparent to most users unless you
   have coded a direct implementation of `VisitableCondition`. The change makes it easier to code custom conditions that
   are not supported by the library out of the box. The statement renderers now call methods `renderCondition` and
-  `renderLeftColumn` that you can override to implement any rendering you need.  
+  `renderLeftColumn` that you can override to implement any rendering you need. In addition, we've made `filter` and
+  `map` support optional if you implement custom conditions
 
 ## Release 1.5.2 - June 3, 2024
 

--- a/src/main/java/org/mybatis/dynamic/sql/AbstractListValueCondition.java
+++ b/src/main/java/org/mybatis/dynamic/sql/AbstractListValueCondition.java
@@ -83,6 +83,16 @@ public abstract class AbstractListValueCondition<T> implements RenderableConditi
      */
     public abstract AbstractListValueCondition<T> filter(Predicate<? super T> predicate);
 
+    /**
+     * If not empty, apply the mapping to each value in the list return a new condition with the mapped values.
+     *     Else return an empty condition (this).
+     *
+     * @param mapper a mapping function to apply to the values, if not empty
+     * @param <R> type of the new condition
+     * @return a new condition with mapped values if renderable, otherwise an empty condition
+     */
+    public abstract <R> AbstractListValueCondition<R> map(Function<? super T, ? extends R> mapper);
+
     public abstract String operator();
 
     @Override

--- a/src/main/java/org/mybatis/dynamic/sql/AbstractListValueCondition.java
+++ b/src/main/java/org/mybatis/dynamic/sql/AbstractListValueCondition.java
@@ -73,26 +73,6 @@ public abstract class AbstractListValueCondition<T> implements RenderableConditi
         }
     }
 
-    /**
-     * If not empty, apply the predicate to each value in the list and return a new condition with the filtered values.
-     *     Else returns an empty condition (this).
-     *
-     * @param predicate predicate applied to the values, if not empty
-     *
-     * @return a new condition with filtered values if renderable, otherwise an empty condition
-     */
-    public abstract AbstractListValueCondition<T> filter(Predicate<? super T> predicate);
-
-    /**
-     * If not empty, apply the mapping to each value in the list return a new condition with the mapped values.
-     *     Else return an empty condition (this).
-     *
-     * @param mapper a mapping function to apply to the values, if not empty
-     * @param <R> type of the new condition
-     * @return a new condition with mapped values if renderable, otherwise an empty condition
-     */
-    public abstract <R> AbstractListValueCondition<R> map(Function<? super T, ? extends R> mapper);
-
     public abstract String operator();
 
     @Override
@@ -109,5 +89,55 @@ public abstract class AbstractListValueCondition<T> implements RenderableConditi
         return FragmentAndParameters.withFragment(parameterInfo.renderedPlaceHolder())
                 .withParameter(parameterInfo.parameterMapKey(), leftColumn.convertParameterType(value))
                 .build();
+    }
+
+    /**
+     * Conditions may implement Filterable to add optionality to rendering.
+     *
+     * <p>If a condition is Filterable, then a user may add a filter to the usage of the condition that makes a decision
+     * whether to render the condition at runtime. Conditions that fail the filter will be dropped from the
+     * rendered SQL.
+     *
+     * <p>Implementations of Filterable may call
+     * {@link AbstractListValueCondition#filterSupport(Predicate, Function, AbstractListValueCondition, Supplier)} as
+     * a common implementation of the filtering algorithm.
+     *
+     * @param <T> the Java type related to the database column type
+     */
+    public interface Filterable<T> {
+        /**
+         * If renderable and the value matches the predicate, returns this condition. Else returns a condition
+         *     that will not render.
+         *
+         * @param predicate predicate applied to the value, if renderable
+         * @return this condition if renderable and the value matches the predicate, otherwise a condition
+         *     that will not render.
+         */
+        AbstractListValueCondition<T> filter(Predicate<? super T> predicate);
+    }
+
+    /**
+     * Conditions may implement Mappable to alter condition values or types during rendering.
+     *
+     * <p>If a condition is Mappable, then a user may add a mapper to the usage of the condition that can alter the
+     * values of a condition, or change that datatype.
+     *
+     * <p>Implementations of Mappable may call
+     * {@link AbstractListValueCondition#mapSupport(Function, Function, Supplier)} as
+     * a common implementation of the mapping algorithm.
+     *
+     * @param <T> the Java type related to the database column type
+     */
+    public interface Mappable<T> {
+        /**
+         * If renderable, apply the mapping to the value and return a new condition with the new value. Else return a
+         * condition that will not render (this).
+         *
+         * @param mapper a mapping function to apply to the value, if renderable
+         * @param <R> type of the new condition
+         * @return a new condition with the result of applying the mapper to the value of this condition,
+         *     if renderable, otherwise a condition that will not render.
+         */
+        <R> AbstractListValueCondition<R> map(Function<? super T, ? extends R> mapper);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/AbstractNoValueCondition.java
+++ b/src/main/java/org/mybatis/dynamic/sql/AbstractNoValueCondition.java
@@ -34,7 +34,21 @@ public abstract class AbstractNoValueCondition<T> implements RenderableCondition
 
     public abstract String operator();
 
-    @Override
+    /**
+     * If renderable and the supplier returns true, returns this condition. Else returns a condition that will not
+     * render.
+     *
+     * @param booleanSupplier
+     *            function that specifies whether the condition should render
+     * @param <S>
+     *            condition type - not used except for compilation compliance
+     *
+     * @return this condition if renderable and the supplier returns true, otherwise a condition that will not render.
+     */
+    public abstract <S> AbstractNoValueCondition<S> filter(BooleanSupplier booleanSupplier);
+
+
+        @Override
     public FragmentAndParameters renderCondition(RenderingContext renderingContext, BindableColumn<T> leftColumn) {
         return FragmentAndParameters.fromFragment(operator());
     }

--- a/src/main/java/org/mybatis/dynamic/sql/AbstractNoValueCondition.java
+++ b/src/main/java/org/mybatis/dynamic/sql/AbstractNoValueCondition.java
@@ -34,22 +34,23 @@ public abstract class AbstractNoValueCondition<T> implements RenderableCondition
 
     public abstract String operator();
 
-    /**
-     * If renderable and the supplier returns true, returns this condition. Else returns a condition that will not
-     * render.
-     *
-     * @param booleanSupplier
-     *            function that specifies whether the condition should render
-     * @param <S>
-     *            condition type - not used except for compilation compliance
-     *
-     * @return this condition if renderable and the supplier returns true, otherwise a condition that will not render.
-     */
-    public abstract <S> AbstractNoValueCondition<S> filter(BooleanSupplier booleanSupplier);
-
-
-        @Override
+    @Override
     public FragmentAndParameters renderCondition(RenderingContext renderingContext, BindableColumn<T> leftColumn) {
         return FragmentAndParameters.fromFragment(operator());
+    }
+
+    public interface Filterable {
+        /**
+         * If renderable and the supplier returns true, returns this condition. Else returns a condition that will not
+         * render.
+         *
+         * @param booleanSupplier
+         *            function that specifies whether the condition should render
+         * @param <S>
+         *            condition type - not used except for compilation compliance
+         *
+         * @return this condition if renderable and the supplier returns true, otherwise a condition that will not render.
+         */
+        <S> AbstractNoValueCondition<S> filter(BooleanSupplier booleanSupplier);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/AbstractNoValueCondition.java
+++ b/src/main/java/org/mybatis/dynamic/sql/AbstractNoValueCondition.java
@@ -39,6 +39,17 @@ public abstract class AbstractNoValueCondition<T> implements RenderableCondition
         return FragmentAndParameters.fromFragment(operator());
     }
 
+    /**
+     * Conditions may implement Filterable to add optionality to rendering.
+     *
+     * <p>If a condition is Filterable, then a user may add a filter to the usage of the condition that makes a decision
+     * whether to render the condition at runtime. Conditions that fail the filter will be dropped from the
+     * rendered SQL.
+     *
+     * <p>Implementations of Filterable may call
+     * {@link AbstractNoValueCondition#filterSupport(BooleanSupplier, Supplier, AbstractNoValueCondition)} as
+     * a common implementation of the filtering algorithm.
+     */
     public interface Filterable {
         /**
          * If renderable and the supplier returns true, returns this condition. Else returns a condition that will not

--- a/src/main/java/org/mybatis/dynamic/sql/AbstractSingleValueCondition.java
+++ b/src/main/java/org/mybatis/dynamic/sql/AbstractSingleValueCondition.java
@@ -64,6 +64,17 @@ public abstract class AbstractSingleValueCondition<T> implements RenderableCondi
      */
     public abstract AbstractSingleValueCondition<T> filter(Predicate<? super T> predicate);
 
+    /**
+     * If renderable, apply the mapping to the value and return a new condition with the new value. Else return a
+     * condition that will not render (this).
+     *
+     * @param mapper a mapping function to apply to the value, if renderable
+     * @param <R> type of the new condition
+     * @return a new condition with the result of applying the mapper to the value of this condition,
+     *     if renderable, otherwise a condition that will not render.
+     */
+    public abstract <R> AbstractSingleValueCondition<R> map(Function<? super T, ? extends R> mapper);
+
     public abstract String operator();
 
     @Override

--- a/src/main/java/org/mybatis/dynamic/sql/AbstractSingleValueCondition.java
+++ b/src/main/java/org/mybatis/dynamic/sql/AbstractSingleValueCondition.java
@@ -54,27 +54,6 @@ public abstract class AbstractSingleValueCondition<T> implements RenderableCondi
         }
     }
 
-    /**
-     * If renderable and the value matches the predicate, returns this condition. Else returns a condition
-     *     that will not render.
-     *
-     * @param predicate predicate applied to the value, if renderable
-     * @return this condition if renderable and the value matches the predicate, otherwise a condition
-     *     that will not render.
-     */
-    public abstract AbstractSingleValueCondition<T> filter(Predicate<? super T> predicate);
-
-    /**
-     * If renderable, apply the mapping to the value and return a new condition with the new value. Else return a
-     * condition that will not render (this).
-     *
-     * @param mapper a mapping function to apply to the value, if renderable
-     * @param <R> type of the new condition
-     * @return a new condition with the result of applying the mapper to the value of this condition,
-     *     if renderable, otherwise a condition that will not render.
-     */
-    public abstract <R> AbstractSingleValueCondition<R> map(Function<? super T, ? extends R> mapper);
-
     public abstract String operator();
 
     @Override
@@ -85,5 +64,55 @@ public abstract class AbstractSingleValueCondition<T> implements RenderableCondi
         return FragmentAndParameters.withFragment(finalFragment)
                 .withParameter(parameterInfo.parameterMapKey(), leftColumn.convertParameterType(value()))
                 .build();
+    }
+
+    /**
+     * Conditions may implement Filterable to add optionality to rendering.
+     *
+     * <p>If a condition is Filterable, then a user may add a filter to the usage of the condition that makes a decision
+     * whether to render the condition at runtime. Conditions that fail the filter will be dropped from the
+     * rendered SQL.
+     *
+     * <p>Implementations of Filterable may call
+     * {@link AbstractSingleValueCondition#filterSupport(Predicate, Supplier, AbstractSingleValueCondition)} as
+     * a common implementation of the filtering algorithm.
+     *
+     * @param <T> the Java type related to the database column type
+     */
+    public interface Filterable<T> {
+        /**
+         * If renderable and the value matches the predicate, returns this condition. Else returns a condition
+         *     that will not render.
+         *
+         * @param predicate predicate applied to the value, if renderable
+         * @return this condition if renderable and the value matches the predicate, otherwise a condition
+         *     that will not render.
+         */
+        AbstractSingleValueCondition<T> filter(Predicate<? super T> predicate);
+    }
+
+    /**
+     * Conditions may implement Mappable to alter condition values or types during rendering.
+     *
+     * <p>If a condition is Mappable, then a user may add a mapper to the usage of the condition that can alter the
+     * values of a condition, or change that datatype.
+     *
+     * <p>Implementations of Mappable may call
+     * {@link AbstractSingleValueCondition#mapSupport(Function, Function, Supplier)} as
+     * a common implementation of the mapping algorithm.
+     *
+     * @param <T> the Java type related to the database column type
+     */
+    public interface Mappable<T> {
+        /**
+         * If renderable, apply the mapping to the value and return a new condition with the new value. Else return a
+         * condition that will not render (this).
+         *
+         * @param mapper a mapping function to apply to the value, if renderable
+         * @param <R> type of the new condition
+         * @return a new condition with the result of applying the mapper to the value of this condition,
+         *     if renderable, otherwise a condition that will not render.
+         */
+        <R> AbstractSingleValueCondition<R> map(Function<? super T, ? extends R> mapper);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/AbstractTwoValueCondition.java
+++ b/src/main/java/org/mybatis/dynamic/sql/AbstractTwoValueCondition.java
@@ -88,6 +88,30 @@ public abstract class AbstractTwoValueCondition<T> implements RenderableConditio
      */
     public abstract AbstractTwoValueCondition<T> filter(Predicate<? super T> predicate);
 
+    /**
+     * If renderable, apply the mappings to the values and return a new condition with the new values. Else return a
+     * condition that will not render (this).
+     *
+     * @param mapper1 a mapping function to apply to the first value, if renderable
+     * @param mapper2 a mapping function to apply to the second value, if renderable
+     * @param <R> type of the new condition
+     * @return a new condition with the result of applying the mappers to the values of this condition,
+     *     if renderable, otherwise a condition that will not render.
+     */
+    public abstract <R> AbstractTwoValueCondition<R> map(Function<? super T, ? extends R> mapper1,
+                                                         Function<? super T, ? extends R> mapper2);
+
+    /**
+     * If renderable, apply the mapping to both values and return a new condition with the new values. Else return a
+     *     condition that will not render (this).
+     *
+     * @param mapper a mapping function to apply to both values, if renderable
+     * @param <R> type of the new condition
+     * @return a new condition with the result of applying the mappers to the values of this condition,
+     *     if renderable, otherwise a condition that will not render.
+     */
+    public abstract <R> AbstractTwoValueCondition<R> map(Function<? super T, ? extends R> mapper);
+
     public abstract String operator1();
 
     public abstract String operator2();

--- a/src/main/java/org/mybatis/dynamic/sql/AbstractTwoValueCondition.java
+++ b/src/main/java/org/mybatis/dynamic/sql/AbstractTwoValueCondition.java
@@ -67,51 +67,6 @@ public abstract class AbstractTwoValueCondition<T> implements RenderableConditio
         }
     }
 
-    /**
-     * If renderable and the values match the predicate, returns this condition. Else returns a condition
-     *     that will not render.
-     *
-     * @param predicate predicate applied to the values, if renderable
-     * @return this condition if renderable and the values match the predicate, otherwise a condition
-     *     that will not render.
-     */
-    public abstract AbstractTwoValueCondition<T> filter(BiPredicate<? super T, ? super T> predicate);
-
-    /**
-     * If renderable and both values match the predicate, returns this condition. Else returns a condition
-     *     that will not render. This function implements a short-circuiting test. If the
-     *     first value does not match the predicate, then the second value will not be tested.
-     *
-     * @param predicate predicate applied to both values, if renderable
-     * @return this condition if renderable and the values match the predicate, otherwise a condition
-     *     that will not render.
-     */
-    public abstract AbstractTwoValueCondition<T> filter(Predicate<? super T> predicate);
-
-    /**
-     * If renderable, apply the mappings to the values and return a new condition with the new values. Else return a
-     * condition that will not render (this).
-     *
-     * @param mapper1 a mapping function to apply to the first value, if renderable
-     * @param mapper2 a mapping function to apply to the second value, if renderable
-     * @param <R> type of the new condition
-     * @return a new condition with the result of applying the mappers to the values of this condition,
-     *     if renderable, otherwise a condition that will not render.
-     */
-    public abstract <R> AbstractTwoValueCondition<R> map(Function<? super T, ? extends R> mapper1,
-                                                         Function<? super T, ? extends R> mapper2);
-
-    /**
-     * If renderable, apply the mapping to both values and return a new condition with the new values. Else return a
-     *     condition that will not render (this).
-     *
-     * @param mapper a mapping function to apply to both values, if renderable
-     * @param <R> type of the new condition
-     * @return a new condition with the result of applying the mappers to the values of this condition,
-     *     if renderable, otherwise a condition that will not render.
-     */
-    public abstract <R> AbstractTwoValueCondition<R> map(Function<? super T, ? extends R> mapper);
-
     public abstract String operator1();
 
     public abstract String operator2();
@@ -130,5 +85,80 @@ public abstract class AbstractTwoValueCondition<T> implements RenderableConditio
                 .withParameter(parameterInfo1.parameterMapKey(), leftColumn.convertParameterType(value1()))
                 .withParameter(parameterInfo2.parameterMapKey(), leftColumn.convertParameterType(value2()))
                 .build();
+    }
+
+    /**
+     * Conditions may implement Filterable to add optionality to rendering.
+     *
+     * <p>If a condition is Filterable, then a user may add a filter to the usage of the condition that makes a decision
+     * whether to render the condition at runtime. Conditions that fail the filter will be dropped from the
+     * rendered SQL.
+     *
+     * <p>Implementations of Filterable may call
+     * {@link AbstractTwoValueCondition#filterSupport(Predicate, Supplier, AbstractTwoValueCondition)}
+     * or {@link AbstractTwoValueCondition#filterSupport(BiPredicate, Supplier, AbstractTwoValueCondition)} as
+     * a common implementation of the filtering algorithm.
+     *
+     * @param <T> the Java type related to the database column type
+     */
+    public interface Filterable<T> {
+        /**
+         * If renderable and the values match the predicate, returns this condition. Else returns a condition
+         *     that will not render.
+         *
+         * @param predicate predicate applied to the values, if renderable
+         * @return this condition if renderable and the values match the predicate, otherwise a condition
+         *     that will not render.
+         */
+        AbstractTwoValueCondition<T> filter(BiPredicate<? super T, ? super T> predicate);
+
+        /**
+         * If renderable and both values match the predicate, returns this condition. Else returns a condition
+         *     that will not render. This function implements a short-circuiting test. If the
+         *     first value does not match the predicate, then the second value will not be tested.
+         *
+         * @param predicate predicate applied to both values, if renderable
+         * @return this condition if renderable and the values match the predicate, otherwise a condition
+         *     that will not render.
+         */
+        AbstractTwoValueCondition<T> filter(Predicate<? super T> predicate);
+    }
+
+    /**
+     * Conditions may implement Mappable to alter condition values or types during rendering.
+     *
+     * <p>If a condition is Mappable, then a user may add a mapper to the usage of the condition that can alter the
+     * values of a condition, or change that datatype.
+     *
+     * <p>Implementations of Mappable may call
+     * {@link AbstractTwoValueCondition#mapSupport(Function, Function, BiFunction, Supplier)} as
+     * a common implementation of the mapping algorithm.
+     *
+     * @param <T> the Java type related to the database column type
+     */
+    public interface Mappable<T> {
+        /**
+         * If renderable, apply the mappings to the values and return a new condition with the new values. Else return a
+         * condition that will not render (this).
+         *
+         * @param mapper1 a mapping function to apply to the first value, if renderable
+         * @param mapper2 a mapping function to apply to the second value, if renderable
+         * @param <R> type of the new condition
+         * @return a new condition with the result of applying the mappers to the values of this condition,
+         *     if renderable, otherwise a condition that will not render.
+         */
+        <R> AbstractTwoValueCondition<R> map(Function<? super T, ? extends R> mapper1,
+                                             Function<? super T, ? extends R> mapper2);
+
+        /**
+         * If renderable, apply the mapping to both values and return a new condition with the new values. Else return a
+         *     condition that will not render (this).
+         *
+         * @param mapper a mapping function to apply to both values, if renderable
+         * @param <R> type of the new condition
+         * @return a new condition with the result of applying the mappers to the values of this condition,
+         *     if renderable, otherwise a condition that will not render.
+         */
+        <R> AbstractTwoValueCondition<R> map(Function<? super T, ? extends R> mapper);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/SqlBuilder.java
+++ b/src/main/java/org/mybatis/dynamic/sql/SqlBuilder.java
@@ -915,36 +915,36 @@ public interface SqlBuilder {
         return isNotLikeCaseInsensitiveWhenPresent(valueSupplier.get());
     }
 
-    static IsInCaseInsensitive isInCaseInsensitive(String... values) {
+    static IsInCaseInsensitive<String> isInCaseInsensitive(String... values) {
         return IsInCaseInsensitive.of(values);
     }
 
-    static IsInCaseInsensitive isInCaseInsensitive(Collection<String> values) {
+    static IsInCaseInsensitive<String> isInCaseInsensitive(Collection<String> values) {
         return IsInCaseInsensitive.of(values);
     }
 
-    static IsInCaseInsensitiveWhenPresent isInCaseInsensitiveWhenPresent(@Nullable String... values) {
+    static IsInCaseInsensitiveWhenPresent<String> isInCaseInsensitiveWhenPresent(@Nullable String... values) {
         return IsInCaseInsensitiveWhenPresent.of(values);
     }
 
-    static IsInCaseInsensitiveWhenPresent isInCaseInsensitiveWhenPresent(
+    static IsInCaseInsensitiveWhenPresent<String> isInCaseInsensitiveWhenPresent(
             @Nullable Collection<@Nullable String> values) {
         return values == null ? IsInCaseInsensitiveWhenPresent.empty() : IsInCaseInsensitiveWhenPresent.of(values);
     }
 
-    static IsNotInCaseInsensitive isNotInCaseInsensitive(String... values) {
+    static IsNotInCaseInsensitive<String> isNotInCaseInsensitive(String... values) {
         return IsNotInCaseInsensitive.of(values);
     }
 
-    static IsNotInCaseInsensitive isNotInCaseInsensitive(Collection<String> values) {
+    static IsNotInCaseInsensitive<String> isNotInCaseInsensitive(Collection<String> values) {
         return IsNotInCaseInsensitive.of(values);
     }
 
-    static IsNotInCaseInsensitiveWhenPresent isNotInCaseInsensitiveWhenPresent(@Nullable String... values) {
+    static IsNotInCaseInsensitiveWhenPresent<String> isNotInCaseInsensitiveWhenPresent(@Nullable String... values) {
         return IsNotInCaseInsensitiveWhenPresent.of(values);
     }
 
-    static IsNotInCaseInsensitiveWhenPresent isNotInCaseInsensitiveWhenPresent(
+    static IsNotInCaseInsensitiveWhenPresent<String> isNotInCaseInsensitiveWhenPresent(
             @Nullable Collection<@Nullable String> values) {
         return values == null ? IsNotInCaseInsensitiveWhenPresent.empty() :
                 IsNotInCaseInsensitiveWhenPresent.of(values);

--- a/src/main/java/org/mybatis/dynamic/sql/SqlBuilder.java
+++ b/src/main/java/org/mybatis/dynamic/sql/SqlBuilder.java
@@ -882,35 +882,36 @@ public interface SqlBuilder {
     }
 
     // conditions for strings only
-    static IsLikeCaseInsensitive isLikeCaseInsensitive(String value) {
+    static IsLikeCaseInsensitive<String> isLikeCaseInsensitive(String value) {
         return IsLikeCaseInsensitive.of(value);
     }
 
-    static IsLikeCaseInsensitive isLikeCaseInsensitive(Supplier<String> valueSupplier) {
+    static IsLikeCaseInsensitive<String> isLikeCaseInsensitive(Supplier<String> valueSupplier) {
         return isLikeCaseInsensitive(valueSupplier.get());
     }
 
-    static IsLikeCaseInsensitive isLikeCaseInsensitiveWhenPresent(@Nullable String value) {
+    static IsLikeCaseInsensitive<String> isLikeCaseInsensitiveWhenPresent(@Nullable String value) {
         return value == null ? IsLikeCaseInsensitive.empty() : IsLikeCaseInsensitive.of(value);
     }
 
-    static IsLikeCaseInsensitive isLikeCaseInsensitiveWhenPresent(Supplier<@Nullable String> valueSupplier) {
+    static IsLikeCaseInsensitive<String> isLikeCaseInsensitiveWhenPresent(Supplier<@Nullable String> valueSupplier) {
         return isLikeCaseInsensitiveWhenPresent(valueSupplier.get());
     }
 
-    static IsNotLikeCaseInsensitive isNotLikeCaseInsensitive(String value) {
+    static IsNotLikeCaseInsensitive<String> isNotLikeCaseInsensitive(String value) {
         return IsNotLikeCaseInsensitive.of(value);
     }
 
-    static IsNotLikeCaseInsensitive isNotLikeCaseInsensitive(Supplier<String> valueSupplier) {
+    static IsNotLikeCaseInsensitive<String> isNotLikeCaseInsensitive(Supplier<String> valueSupplier) {
         return isNotLikeCaseInsensitive(valueSupplier.get());
     }
 
-    static IsNotLikeCaseInsensitive isNotLikeCaseInsensitiveWhenPresent(@Nullable String value) {
+    static IsNotLikeCaseInsensitive<String> isNotLikeCaseInsensitiveWhenPresent(@Nullable String value) {
         return value == null ? IsNotLikeCaseInsensitive.empty() : IsNotLikeCaseInsensitive.of(value);
     }
 
-    static IsNotLikeCaseInsensitive isNotLikeCaseInsensitiveWhenPresent(Supplier<@Nullable String> valueSupplier) {
+    static IsNotLikeCaseInsensitive<String> isNotLikeCaseInsensitiveWhenPresent(
+            Supplier<@Nullable String> valueSupplier) {
         return isNotLikeCaseInsensitiveWhenPresent(valueSupplier.get());
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/util/StringUtilities.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/StringUtilities.java
@@ -15,6 +15,8 @@
  */
 package org.mybatis.dynamic.sql.util;
 
+import java.util.function.Function;
+
 import org.jspecify.annotations.Nullable;
 
 public interface StringUtilities {
@@ -58,5 +60,9 @@ public interface StringUtilities {
     static String formatConstantForSQL(String in) {
         String escaped = in.replace("'", "''"); //$NON-NLS-1$ //$NON-NLS-2$
         return "'" + escaped + "'"; //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    static Function<String, String> mapToUpperCase(Function<String, String> f) {
+        return f.andThen(String::toUpperCase);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/CaseInsensitiveRenderableCondition.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/CaseInsensitiveRenderableCondition.java
@@ -20,11 +20,11 @@ import org.mybatis.dynamic.sql.RenderableCondition;
 import org.mybatis.dynamic.sql.render.RenderingContext;
 import org.mybatis.dynamic.sql.util.FragmentAndParameters;
 
-public interface CaseInsensitiveRenderableCondition extends RenderableCondition<String> {
+public interface CaseInsensitiveRenderableCondition<T> extends RenderableCondition<T> {
 
     @Override
     default FragmentAndParameters renderLeftColumn(RenderingContext renderingContext,
-                                                   BindableColumn<String> leftColumn) {
+                                                   BindableColumn<T> leftColumn) {
         return RenderableCondition.super.renderLeftColumn(renderingContext, leftColumn)
                 .mapFragment(s -> "upper(" + s + ")"); //$NON-NLS-1$ //$NON-NLS-2$
     }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsBetween.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsBetween.java
@@ -23,7 +23,8 @@ import java.util.function.Predicate;
 import org.jspecify.annotations.Nullable;
 import org.mybatis.dynamic.sql.AbstractTwoValueCondition;
 
-public class IsBetween<T> extends AbstractTwoValueCondition<T> {
+public class IsBetween<T> extends AbstractTwoValueCondition<T>
+        implements AbstractTwoValueCondition.Filterable<T>, AbstractTwoValueCondition.Mappable<T> {
     private static final IsBetween<?> EMPTY = new IsBetween<Object>(-1, -1) {
         @Override
         public Object value1() {

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsBetween.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsBetween.java
@@ -71,29 +71,12 @@ public class IsBetween<T> extends AbstractTwoValueCondition<T> {
         return filterSupport(predicate, IsBetween::empty, this);
     }
 
-    /**
-     * If renderable, apply the mappings to the values and return a new condition with the new values. Else return a
-     * condition that will not render (this).
-     *
-     * @param mapper1 a mapping function to apply to the first value, if renderable
-     * @param mapper2 a mapping function to apply to the second value, if renderable
-     * @param <R> type of the new condition
-     * @return a new condition with the result of applying the mappers to the values of this condition,
-     *     if renderable, otherwise a condition that will not render.
-     */
+    @Override
     public <R> IsBetween<R> map(Function<? super T, ? extends R> mapper1, Function<? super T, ? extends R> mapper2) {
         return mapSupport(mapper1, mapper2, IsBetween::new, IsBetween::empty);
     }
 
-    /**
-     * If renderable, apply the mapping to both values and return a new condition with the new values. Else return a
-     *     condition that will not render (this).
-     *
-     * @param mapper a mapping function to apply to both values, if renderable
-     * @param <R> type of the new condition
-     * @return a new condition with the result of applying the mappers to the values of this condition,
-     *     if renderable, otherwise a condition that will not render.
-     */
+    @Override
     public <R> IsBetween<R> map(Function<? super T, ? extends R> mapper) {
         return map(mapper, mapper);
     }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsEqualTo.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsEqualTo.java
@@ -59,15 +59,7 @@ public class IsEqualTo<T> extends AbstractSingleValueCondition<T> {
         return filterSupport(predicate, IsEqualTo::empty, this);
     }
 
-    /**
-     * If renderable, apply the mapping to the value and return a new condition with the new value. Else return a
-     * condition that will not render (this).
-     *
-     * @param mapper a mapping function to apply to the value, if renderable
-     * @param <R> type of the new condition
-     * @return a new condition with the result of applying the mapper to the value of this condition,
-     *     if renderable, otherwise a condition that will not render.
-     */
+    @Override
     public <R> IsEqualTo<R> map(Function<? super T, ? extends R> mapper) {
         return mapSupport(mapper, IsEqualTo::new, IsEqualTo::empty);
     }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsEqualTo.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsEqualTo.java
@@ -21,7 +21,8 @@ import java.util.function.Predicate;
 
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 
-public class IsEqualTo<T> extends AbstractSingleValueCondition<T> {
+public class IsEqualTo<T> extends AbstractSingleValueCondition<T>
+        implements AbstractSingleValueCondition.Filterable<T>, AbstractSingleValueCondition.Mappable<T> {
 
     private static final IsEqualTo<?> EMPTY = new IsEqualTo<Object>(-1) {
         @Override

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThan.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThan.java
@@ -21,7 +21,8 @@ import java.util.function.Predicate;
 
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 
-public class IsGreaterThan<T> extends AbstractSingleValueCondition<T> {
+public class IsGreaterThan<T> extends AbstractSingleValueCondition<T>
+        implements AbstractSingleValueCondition.Filterable<T>, AbstractSingleValueCondition.Mappable<T> {
     private static final IsGreaterThan<?> EMPTY = new IsGreaterThan<Object>(-1) {
         @Override
         public Object value() {

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThan.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThan.java
@@ -58,15 +58,7 @@ public class IsGreaterThan<T> extends AbstractSingleValueCondition<T> {
         return filterSupport(predicate, IsGreaterThan::empty, this);
     }
 
-    /**
-     * If renderable, apply the mapping to the value and return a new condition with the new value. Else return a
-     * condition that will not render (this).
-     *
-     * @param mapper a mapping function to apply to the value, if renderable
-     * @param <R> type of the new condition
-     * @return a new condition with the result of applying the mapper to the value of this condition,
-     *     if renderable, otherwise a condition that will not render.
-     */
+    @Override
     public <R> IsGreaterThan<R> map(Function<? super T, ? extends R> mapper) {
         return mapSupport(mapper, IsGreaterThan::new, IsGreaterThan::empty);
     }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThanOrEqualTo.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThanOrEqualTo.java
@@ -58,15 +58,7 @@ public class IsGreaterThanOrEqualTo<T> extends AbstractSingleValueCondition<T> {
         return filterSupport(predicate, IsGreaterThanOrEqualTo::empty, this);
     }
 
-    /**
-     * If renderable, apply the mapping to the value and return a new condition with the new value. Else return a
-     * condition that will not render (this).
-     *
-     * @param mapper a mapping function to apply to the value, if renderable
-     * @param <R> type of the new condition
-     * @return a new condition with the result of applying the mapper to the value of this condition,
-     *     if renderable, otherwise a condition that will not render.
-     */
+    @Override
     public <R> IsGreaterThanOrEqualTo<R> map(Function<? super T, ? extends R> mapper) {
         return mapSupport(mapper, IsGreaterThanOrEqualTo::new, IsGreaterThanOrEqualTo::empty);
     }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThanOrEqualTo.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThanOrEqualTo.java
@@ -21,7 +21,8 @@ import java.util.function.Predicate;
 
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 
-public class IsGreaterThanOrEqualTo<T> extends AbstractSingleValueCondition<T> {
+public class IsGreaterThanOrEqualTo<T> extends AbstractSingleValueCondition<T>
+        implements AbstractSingleValueCondition.Filterable<T>, AbstractSingleValueCondition.Mappable<T> {
     private static final IsGreaterThanOrEqualTo<?> EMPTY = new IsGreaterThanOrEqualTo<Object>(-1) {
         @Override
         public Object value() {

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsIn.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsIn.java
@@ -54,14 +54,7 @@ public class IsIn<T> extends AbstractListValueCondition<T> {
         return filterSupport(predicate, IsIn::new, this, IsIn::empty);
     }
 
-    /**
-     * If not empty, apply the mapping to each value in the list return a new condition with the mapped values.
-     *     Else return an empty condition (this).
-     *
-     * @param mapper a mapping function to apply to the values, if not empty
-     * @param <R> type of the new condition
-     * @return a new condition with mapped values if renderable, otherwise an empty condition
-     */
+    @Override
     public <R> IsIn<R> map(Function<? super T, ? extends R> mapper) {
         Function<Collection<R>, IsIn<R>> constructor = IsIn::new;
         return mapSupport(mapper, constructor, IsIn::empty);

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsIn.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsIn.java
@@ -25,7 +25,8 @@ import org.mybatis.dynamic.sql.AbstractListValueCondition;
 import org.mybatis.dynamic.sql.render.RenderingContext;
 import org.mybatis.dynamic.sql.util.Validator;
 
-public class IsIn<T> extends AbstractListValueCondition<T> {
+public class IsIn<T> extends AbstractListValueCondition<T>
+        implements AbstractListValueCondition.Filterable<T>, AbstractListValueCondition.Mappable<T>{
     private static final IsIn<?> EMPTY = new IsIn<>(Collections.emptyList());
 
     public static <T> IsIn<T> empty() {
@@ -56,8 +57,7 @@ public class IsIn<T> extends AbstractListValueCondition<T> {
 
     @Override
     public <R> IsIn<R> map(Function<? super T, ? extends R> mapper) {
-        Function<Collection<R>, IsIn<R>> constructor = IsIn::new;
-        return mapSupport(mapper, constructor, IsIn::empty);
+        return mapSupport(mapper, IsIn::new, IsIn::empty);
     }
 
     @SafeVarargs

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInCaseInsensitive.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInCaseInsensitive.java
@@ -27,7 +27,7 @@ import org.mybatis.dynamic.sql.util.StringUtilities;
 import org.mybatis.dynamic.sql.util.Validator;
 
 public class IsInCaseInsensitive extends AbstractListValueCondition<String>
-        implements CaseInsensitiveRenderableCondition {
+        implements CaseInsensitiveRenderableCondition<String> {
     private static final IsInCaseInsensitive EMPTY = new IsInCaseInsensitive(Collections.emptyList());
 
     public static IsInCaseInsensitive empty() {

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInCaseInsensitive.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInCaseInsensitive.java
@@ -27,7 +27,8 @@ import org.mybatis.dynamic.sql.util.StringUtilities;
 import org.mybatis.dynamic.sql.util.Validator;
 
 public class IsInCaseInsensitive<T> extends AbstractListValueCondition<T>
-        implements CaseInsensitiveRenderableCondition<T> {
+        implements CaseInsensitiveRenderableCondition<T>, AbstractListValueCondition.Filterable<T>,
+        AbstractListValueCondition.Mappable<T> {
     private static final IsInCaseInsensitive<?> EMPTY = new IsInCaseInsensitive<>(Collections.emptyList());
 
     public static <T> IsInCaseInsensitive<T> empty() {

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInCaseInsensitive.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInCaseInsensitive.java
@@ -57,6 +57,19 @@ public class IsInCaseInsensitive<T> extends AbstractListValueCondition<T>
         return filterSupport(predicate, IsInCaseInsensitive::new, this, IsInCaseInsensitive::empty);
     }
 
+    /**
+     * If renderable, apply the mapping to the value and return a new condition with the new value. Else return a
+     * condition that will not render (this).
+     *
+     * <p>This function DOES NOT automatically transform values to uppercase, so it potentially creates a
+     * case-sensitive query. For String conditions you can use {@link StringUtilities#mapToUpperCase(Function)}
+     * to add an uppercase transform after your mapping function.
+     *
+     * @param mapper a mapping function to apply to the value, if renderable
+     * @param <R> type of the new condition
+     * @return a new condition with the result of applying the mapper to the value of this condition,
+     *     if renderable, otherwise a condition that will not render.
+     */
     @Override
     public <R> IsInCaseInsensitive<R> map(Function<? super T, ? extends R> mapper) {
         return mapSupport(mapper, IsInCaseInsensitive::new, IsInCaseInsensitive::empty);

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInCaseInsensitive.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInCaseInsensitive.java
@@ -18,23 +18,25 @@ package org.mybatis.dynamic.sql.where.condition;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.function.UnaryOperator;
 
 import org.mybatis.dynamic.sql.AbstractListValueCondition;
 import org.mybatis.dynamic.sql.render.RenderingContext;
 import org.mybatis.dynamic.sql.util.StringUtilities;
 import org.mybatis.dynamic.sql.util.Validator;
 
-public class IsInCaseInsensitive extends AbstractListValueCondition<String>
-        implements CaseInsensitiveRenderableCondition<String> {
-    private static final IsInCaseInsensitive EMPTY = new IsInCaseInsensitive(Collections.emptyList());
+public class IsInCaseInsensitive<T> extends AbstractListValueCondition<T>
+        implements CaseInsensitiveRenderableCondition<T> {
+    private static final IsInCaseInsensitive<?> EMPTY = new IsInCaseInsensitive<>(Collections.emptyList());
 
-    public static IsInCaseInsensitive empty() {
-        return EMPTY;
+    public static <T> IsInCaseInsensitive<T> empty() {
+        @SuppressWarnings("unchecked")
+        IsInCaseInsensitive<T> t = (IsInCaseInsensitive<T>) EMPTY;
+        return t;
     }
 
-    protected IsInCaseInsensitive(Collection<String> values) {
+    protected IsInCaseInsensitive(Collection<T> values) {
         super(values);
     }
 
@@ -50,28 +52,22 @@ public class IsInCaseInsensitive extends AbstractListValueCondition<String>
     }
 
     @Override
-    public IsInCaseInsensitive filter(Predicate<? super String> predicate) {
+    public IsInCaseInsensitive<T> filter(Predicate<? super T> predicate) {
         return filterSupport(predicate, IsInCaseInsensitive::new, this, IsInCaseInsensitive::empty);
     }
 
-    /**
-     * If not empty, apply the mapping to each value in the list return a new condition with the mapped values.
-     *     Else return an empty condition (this).
-     *
-     * @param mapper a mapping function to apply to the values, if not empty
-     * @return a new condition with mapped values if renderable, otherwise an empty condition
-     */
-    public IsInCaseInsensitive map(UnaryOperator<String> mapper) {
+    @Override
+    public <R> IsInCaseInsensitive<R> map(Function<? super T, ? extends R> mapper) {
         return mapSupport(mapper, IsInCaseInsensitive::new, IsInCaseInsensitive::empty);
     }
 
-    public static IsInCaseInsensitive of(String... values) {
+    public static IsInCaseInsensitive<String> of(String... values) {
         return of(Arrays.asList(values));
     }
 
-    public static IsInCaseInsensitive of(Collection<String> values) {
+    public static IsInCaseInsensitive<String> of(Collection<String> values) {
         // Keep the null safe upper case utility for backwards compatibility
         //noinspection DataFlowIssue
-        return new IsInCaseInsensitive(values).map(StringUtilities::safelyUpperCase);
+        return new IsInCaseInsensitive<>(values).map(StringUtilities::safelyUpperCase);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInCaseInsensitiveWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInCaseInsensitiveWhenPresent.java
@@ -27,7 +27,7 @@ import org.mybatis.dynamic.sql.util.StringUtilities;
 import org.mybatis.dynamic.sql.util.Utilities;
 
 public class IsInCaseInsensitiveWhenPresent extends AbstractListValueCondition<String>
-        implements CaseInsensitiveRenderableCondition {
+        implements CaseInsensitiveRenderableCondition<String> {
     private static final IsInCaseInsensitiveWhenPresent EMPTY =
             new IsInCaseInsensitiveWhenPresent(Collections.emptyList());
 

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInCaseInsensitiveWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInCaseInsensitiveWhenPresent.java
@@ -18,24 +18,26 @@ package org.mybatis.dynamic.sql.where.condition;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.function.UnaryOperator;
 
 import org.jspecify.annotations.Nullable;
 import org.mybatis.dynamic.sql.AbstractListValueCondition;
 import org.mybatis.dynamic.sql.util.StringUtilities;
 import org.mybatis.dynamic.sql.util.Utilities;
 
-public class IsInCaseInsensitiveWhenPresent extends AbstractListValueCondition<String>
-        implements CaseInsensitiveRenderableCondition<String> {
-    private static final IsInCaseInsensitiveWhenPresent EMPTY =
-            new IsInCaseInsensitiveWhenPresent(Collections.emptyList());
+public class IsInCaseInsensitiveWhenPresent<T> extends AbstractListValueCondition<T>
+        implements CaseInsensitiveRenderableCondition<T> {
+    private static final IsInCaseInsensitiveWhenPresent<?> EMPTY =
+            new IsInCaseInsensitiveWhenPresent<>(Collections.emptyList());
 
-    public static IsInCaseInsensitiveWhenPresent empty() {
-        return EMPTY;
+    public static <T> IsInCaseInsensitiveWhenPresent<T> empty() {
+        @SuppressWarnings("unchecked")
+        IsInCaseInsensitiveWhenPresent<T> t = (IsInCaseInsensitiveWhenPresent<T>) EMPTY;
+        return t;
     }
 
-    protected IsInCaseInsensitiveWhenPresent(Collection<@Nullable String> values) {
+    protected IsInCaseInsensitiveWhenPresent(Collection<@Nullable T> values) {
         super(Utilities.removeNullElements(values));
     }
 
@@ -45,29 +47,23 @@ public class IsInCaseInsensitiveWhenPresent extends AbstractListValueCondition<S
     }
 
     @Override
-    public IsInCaseInsensitiveWhenPresent filter(Predicate<? super String> predicate) {
+    public IsInCaseInsensitiveWhenPresent<T> filter(Predicate<? super T> predicate) {
         return filterSupport(predicate, IsInCaseInsensitiveWhenPresent::new, this,
                 IsInCaseInsensitiveWhenPresent::empty);
     }
 
-    /**
-     * If not empty, apply the mapping to each value in the list return a new condition with the mapped values.
-     *     Else return an empty condition (this).
-     *
-     * @param mapper a mapping function to apply to the values, if not empty
-     * @return a new condition with mapped values if renderable, otherwise an empty condition
-     */
-    public IsInCaseInsensitiveWhenPresent map(UnaryOperator<String> mapper) {
+    @Override
+    public <R> IsInCaseInsensitiveWhenPresent<R> map(Function<? super T, ? extends R> mapper) {
         return mapSupport(mapper, IsInCaseInsensitiveWhenPresent::new, IsInCaseInsensitiveWhenPresent::empty);
     }
 
-    public static IsInCaseInsensitiveWhenPresent of(@Nullable String... values) {
+    public static IsInCaseInsensitiveWhenPresent<String> of(@Nullable String... values) {
         return of(Arrays.asList(values));
     }
 
-    public static IsInCaseInsensitiveWhenPresent of(Collection<@Nullable String> values) {
+    public static IsInCaseInsensitiveWhenPresent<String> of(Collection<@Nullable String> values) {
         // Keep the null safe upper case utility for backwards compatibility
         //noinspection DataFlowIssue
-        return new IsInCaseInsensitiveWhenPresent(values).map(StringUtilities::safelyUpperCase);
+        return new IsInCaseInsensitiveWhenPresent<>(values).map(StringUtilities::safelyUpperCase);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInCaseInsensitiveWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInCaseInsensitiveWhenPresent.java
@@ -24,6 +24,7 @@ import java.util.function.Predicate;
 
 import org.jspecify.annotations.Nullable;
 import org.mybatis.dynamic.sql.AbstractListValueCondition;
+import org.mybatis.dynamic.sql.util.StringUtilities;
 
 public class IsInCaseInsensitiveWhenPresent<T> extends AbstractListValueCondition<T>
         implements CaseInsensitiveRenderableCondition<T>, AbstractListValueCondition.Filterable<T>,
@@ -52,6 +53,19 @@ public class IsInCaseInsensitiveWhenPresent<T> extends AbstractListValueConditio
                 IsInCaseInsensitiveWhenPresent::empty);
     }
 
+    /**
+     * If renderable, apply the mapping to the value and return a new condition with the new value. Else return a
+     * condition that will not render (this).
+     *
+     * <p>This function DOES NOT automatically transform values to uppercase, so it potentially creates a
+     * case-sensitive query. For String conditions you can use {@link StringUtilities#mapToUpperCase(Function)}
+     * to add an uppercase transform after your mapping function.
+     *
+     * @param mapper a mapping function to apply to the value, if renderable
+     * @param <R> type of the new condition
+     * @return a new condition with the result of applying the mapper to the value of this condition,
+     *     if renderable, otherwise a condition that will not render.
+     */
     @Override
     public <R> IsInCaseInsensitiveWhenPresent<R> map(Function<? super T, ? extends R> mapper) {
         return mapSupport(mapper, IsInCaseInsensitiveWhenPresent::new, IsInCaseInsensitiveWhenPresent::empty);

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInCaseInsensitiveWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInCaseInsensitiveWhenPresent.java
@@ -36,7 +36,7 @@ public class IsInCaseInsensitiveWhenPresent<T> extends AbstractListValueConditio
         return t;
     }
 
-    protected IsInCaseInsensitiveWhenPresent(Collection<String> values) {
+    protected IsInCaseInsensitiveWhenPresent(Collection<T> values) {
         super(values);
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInCaseInsensitiveWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInCaseInsensitiveWhenPresent.java
@@ -26,7 +26,8 @@ import org.jspecify.annotations.Nullable;
 import org.mybatis.dynamic.sql.AbstractListValueCondition;
 
 public class IsInCaseInsensitiveWhenPresent<T> extends AbstractListValueCondition<T>
-        implements CaseInsensitiveRenderableCondition<T> {
+        implements CaseInsensitiveRenderableCondition<T>, AbstractListValueCondition.Filterable<T>,
+        AbstractListValueCondition.Mappable<T> {
     private static final IsInCaseInsensitiveWhenPresent<?> EMPTY =
             new IsInCaseInsensitiveWhenPresent<>(Collections.emptyList());
 

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInWhenPresent.java
@@ -25,7 +25,8 @@ import java.util.function.Predicate;
 import org.jspecify.annotations.Nullable;
 import org.mybatis.dynamic.sql.AbstractListValueCondition;
 
-public class IsInWhenPresent<T> extends AbstractListValueCondition<T> {
+public class IsInWhenPresent<T> extends AbstractListValueCondition<T>
+        implements AbstractListValueCondition.Filterable<T>, AbstractListValueCondition.Mappable<T>{
     private static final IsInWhenPresent<?> EMPTY = new IsInWhenPresent<>(Collections.emptyList());
 
     public static <T> IsInWhenPresent<T> empty() {
@@ -48,17 +49,9 @@ public class IsInWhenPresent<T> extends AbstractListValueCondition<T> {
         return filterSupport(predicate, IsInWhenPresent::new, this, IsInWhenPresent::empty);
     }
 
-    /**
-     * If not empty, apply the mapping to each value in the list return a new condition with the mapped values.
-     *     Else return an empty condition (this).
-     *
-     * @param mapper a mapping function to apply to the values, if not empty
-     * @param <R> type of the new condition
-     * @return a new condition with mapped values if renderable, otherwise an empty condition
-     */
+    @Override
     public <R> IsInWhenPresent<R> map(Function<? super T, ? extends R> mapper) {
-        Function<Collection<R>, IsInWhenPresent<R>> constructor = IsInWhenPresent::new;
-        return mapSupport(mapper, constructor, IsInWhenPresent::empty);
+        return mapSupport(mapper, IsInWhenPresent::new, IsInWhenPresent::empty);
     }
 
     @SafeVarargs

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThan.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThan.java
@@ -21,7 +21,9 @@ import java.util.function.Predicate;
 
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 
-public class IsLessThan<T> extends AbstractSingleValueCondition<T> {
+public class IsLessThan<T> extends AbstractSingleValueCondition<T>
+        implements AbstractSingleValueCondition.Filterable<T>, AbstractSingleValueCondition.Mappable<T> {
+
     private static final IsLessThan<?> EMPTY = new IsLessThan<Object>(-1) {
         @Override
         public Object value() {

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThan.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThan.java
@@ -58,15 +58,7 @@ public class IsLessThan<T> extends AbstractSingleValueCondition<T> {
         return filterSupport(predicate, IsLessThan::empty, this);
     }
 
-    /**
-     * If renderable, apply the mapping to the value and return a new condition with the new value. Else return a
-     * condition that will not render (this).
-     *
-     * @param mapper a mapping function to apply to the value, if renderable
-     * @param <R> type of the new condition
-     * @return a new condition with the result of applying the mapper to the value of this condition,
-     *     if renderable, otherwise a condition that will not render.
-     */
+    @Override
     public <R> IsLessThan<R> map(Function<? super T, ? extends R> mapper) {
         return mapSupport(mapper, IsLessThan::new, IsLessThan::empty);
     }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThanOrEqualTo.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThanOrEqualTo.java
@@ -58,15 +58,7 @@ public class IsLessThanOrEqualTo<T> extends AbstractSingleValueCondition<T> {
         return filterSupport(predicate, IsLessThanOrEqualTo::empty, this);
     }
 
-    /**
-     * If renderable, apply the mapping to the value and return a new condition with the new value. Else return a
-     * condition that will not render (this).
-     *
-     * @param mapper a mapping function to apply to the value, if renderable
-     * @param <R> type of the new condition
-     * @return a new condition with the result of applying the mapper to the value of this condition,
-     *     if renderable, otherwise a condition that will not render.
-     */
+    @Override
     public <R> IsLessThanOrEqualTo<R> map(Function<? super T, ? extends R> mapper) {
         return mapSupport(mapper, IsLessThanOrEqualTo::new, IsLessThanOrEqualTo::empty);
     }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThanOrEqualTo.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThanOrEqualTo.java
@@ -21,7 +21,8 @@ import java.util.function.Predicate;
 
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 
-public class IsLessThanOrEqualTo<T> extends AbstractSingleValueCondition<T> {
+public class IsLessThanOrEqualTo<T> extends AbstractSingleValueCondition<T>
+        implements AbstractSingleValueCondition.Filterable<T>, AbstractSingleValueCondition.Mappable<T> {
     private static final IsLessThanOrEqualTo<?> EMPTY = new IsLessThanOrEqualTo<Object>(-1) {
         @Override
         public Object value() {

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLike.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLike.java
@@ -21,7 +21,9 @@ import java.util.function.Predicate;
 
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 
-public class IsLike<T> extends AbstractSingleValueCondition<T> {
+public class IsLike<T> extends AbstractSingleValueCondition<T>
+        implements AbstractSingleValueCondition.Filterable<T>, AbstractSingleValueCondition.Mappable<T> {
+
     private static final IsLike<?> EMPTY = new IsLike<Object>(-1) {
         @Override
         public Object value() {

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLike.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLike.java
@@ -58,15 +58,7 @@ public class IsLike<T> extends AbstractSingleValueCondition<T> {
         return filterSupport(predicate, IsLike::empty, this);
     }
 
-    /**
-     * If renderable, apply the mapping to the value and return a new condition with the new value. Else return a
-     * condition that will not render (this).
-     *
-     * @param mapper a mapping function to apply to the value, if renderable
-     * @param <R> type of the new condition
-     * @return a new condition with the result of applying the mapper to the value of this condition,
-     *     if renderable, otherwise a condition that will not render.
-     */
+    @Override
     public <R> IsLike<R> map(Function<? super T, ? extends R> mapper) {
         return mapSupport(mapper, IsLike::new, IsLike::empty);
     }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLikeCaseInsensitive.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLikeCaseInsensitive.java
@@ -16,15 +16,15 @@
 package org.mybatis.dynamic.sql.where.condition;
 
 import java.util.NoSuchElementException;
+import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.function.UnaryOperator;
 
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 import org.mybatis.dynamic.sql.util.StringUtilities;
 
-public class IsLikeCaseInsensitive extends AbstractSingleValueCondition<String>
-        implements CaseInsensitiveRenderableCondition {
-    private static final IsLikeCaseInsensitive EMPTY = new IsLikeCaseInsensitive("") { //$NON-NLS-1$
+public class IsLikeCaseInsensitive<T> extends AbstractSingleValueCondition<T>
+        implements CaseInsensitiveRenderableCondition<T> {
+    private static final IsLikeCaseInsensitive<?> EMPTY = new IsLikeCaseInsensitive<>("") { //$NON-NLS-1$
         @Override
         public String value() {
             throw new NoSuchElementException("No value present"); //$NON-NLS-1$
@@ -36,11 +36,13 @@ public class IsLikeCaseInsensitive extends AbstractSingleValueCondition<String>
         }
     };
 
-    public static IsLikeCaseInsensitive empty() {
-        return EMPTY;
+    public static <T> IsLikeCaseInsensitive<T> empty() {
+        @SuppressWarnings("unchecked")
+        IsLikeCaseInsensitive<T> t = (IsLikeCaseInsensitive<T>) EMPTY;
+        return t;
     }
 
-    protected IsLikeCaseInsensitive(String value) {
+    protected IsLikeCaseInsensitive(T value) {
         super(value);
     }
 
@@ -50,25 +52,18 @@ public class IsLikeCaseInsensitive extends AbstractSingleValueCondition<String>
     }
 
     @Override
-    public IsLikeCaseInsensitive filter(Predicate<? super String> predicate) {
+    public IsLikeCaseInsensitive<T> filter(Predicate<? super T> predicate) {
         return filterSupport(predicate, IsLikeCaseInsensitive::empty, this);
     }
 
-    /**
-     * If renderable, apply the mapping to the value and return a new condition with the new value. Else return a
-     * condition that will not render (this).
-     *
-     * @param mapper a mapping function to apply to the value, if renderable
-     * @return a new condition with the result of applying the mapper to the value of this condition,
-     *     if renderable, otherwise a condition that will not render.
-     */
-    public IsLikeCaseInsensitive map(UnaryOperator<String> mapper) {
+    @Override
+    public <R> IsLikeCaseInsensitive<R> map(Function<? super T, ? extends R> mapper) {
         return mapSupport(mapper, IsLikeCaseInsensitive::new, IsLikeCaseInsensitive::empty);
     }
 
-    public static IsLikeCaseInsensitive of(String value) {
+    public static IsLikeCaseInsensitive<String> of(String value) {
         // Keep the null safe upper case utility for backwards compatibility
         //noinspection DataFlowIssue
-        return new IsLikeCaseInsensitive(value).map(StringUtilities::safelyUpperCase);
+        return new IsLikeCaseInsensitive<>(value).map(StringUtilities::safelyUpperCase);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLikeCaseInsensitive.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLikeCaseInsensitive.java
@@ -57,6 +57,19 @@ public class IsLikeCaseInsensitive<T> extends AbstractSingleValueCondition<T>
         return filterSupport(predicate, IsLikeCaseInsensitive::empty, this);
     }
 
+    /**
+     * If renderable, apply the mapping to the value and return a new condition with the new value. Else return a
+     * condition that will not render (this).
+     *
+     * <p>This function DOES NOT automatically transform values to uppercase, so it potentially creates a
+     * case-sensitive query. For String conditions you can use {@link StringUtilities#mapToUpperCase(Function)}
+     * to add an uppercase transform after your mapping function.
+     *
+     * @param mapper a mapping function to apply to the value, if renderable
+     * @param <R> type of the new condition
+     * @return a new condition with the result of applying the mapper to the value of this condition,
+     *     if renderable, otherwise a condition that will not render.
+     */
     @Override
     public <R> IsLikeCaseInsensitive<R> map(Function<? super T, ? extends R> mapper) {
         return mapSupport(mapper, IsLikeCaseInsensitive::new, IsLikeCaseInsensitive::empty);

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLikeCaseInsensitive.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLikeCaseInsensitive.java
@@ -23,7 +23,8 @@ import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 import org.mybatis.dynamic.sql.util.StringUtilities;
 
 public class IsLikeCaseInsensitive<T> extends AbstractSingleValueCondition<T>
-        implements CaseInsensitiveRenderableCondition<T> {
+        implements CaseInsensitiveRenderableCondition<T>, AbstractSingleValueCondition.Filterable<T>,
+        AbstractSingleValueCondition.Mappable<T> {
     private static final IsLikeCaseInsensitive<?> EMPTY = new IsLikeCaseInsensitive<>("") { //$NON-NLS-1$
         @Override
         public String value() {

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotBetween.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotBetween.java
@@ -23,7 +23,8 @@ import java.util.function.Predicate;
 import org.jspecify.annotations.Nullable;
 import org.mybatis.dynamic.sql.AbstractTwoValueCondition;
 
-public class IsNotBetween<T> extends AbstractTwoValueCondition<T> {
+public class IsNotBetween<T> extends AbstractTwoValueCondition<T>
+        implements AbstractTwoValueCondition.Filterable<T>, AbstractTwoValueCondition.Mappable<T> {
     private static final IsNotBetween<?> EMPTY = new IsNotBetween<Object>(-1, -1) {
         @Override
         public Object value1() {

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotBetween.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotBetween.java
@@ -71,30 +71,13 @@ public class IsNotBetween<T> extends AbstractTwoValueCondition<T> {
         return filterSupport(predicate, IsNotBetween::empty, this);
     }
 
-    /**
-     * If renderable, apply the mappings to the values and return a new condition with the new values. Else return a
-     * condition that will not render (this).
-     *
-     * @param mapper1 a mapping function to apply to the first value, if renderable
-     * @param mapper2 a mapping function to apply to the second value, if renderable
-     * @param <R> type of the new condition
-     * @return a new condition with the result of applying the mappers to the values of this condition,
-     *     if renderable, otherwise a condition that will not render.
-     */
+    @Override
     public <R> IsNotBetween<R> map(Function<? super T, ? extends R> mapper1,
             Function<? super T, ? extends R> mapper2) {
         return mapSupport(mapper1, mapper2, IsNotBetween::new, IsNotBetween::empty);
     }
 
-    /**
-     * If renderable, apply the mapping to both values and return a new condition with the new values. Else return a
-     *     condition that will not render (this).
-     *
-     * @param mapper a mapping function to apply to both values, if renderable
-     * @param <R> type of the new condition
-     * @return a new condition with the result of applying the mappers to the values of this condition,
-     *     if renderable, otherwise a condition that will not render.
-     */
+    @Override
     public <R> IsNotBetween<R> map(Function<? super T, ? extends R> mapper) {
         return map(mapper, mapper);
     }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotEqualTo.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotEqualTo.java
@@ -58,15 +58,7 @@ public class IsNotEqualTo<T> extends AbstractSingleValueCondition<T> {
         return filterSupport(predicate, IsNotEqualTo::empty, this);
     }
 
-    /**
-     * If renderable, apply the mapping to the value and return a new condition with the new value. Else return a
-     * condition that will not render (this).
-     *
-     * @param mapper a mapping function to apply to the value, if renderable
-     * @param <R> type of the new condition
-     * @return a new condition with the result of applying the mapper to the value of this condition,
-     *     if renderable, otherwise a condition that will not render.
-     */
+    @Override
     public <R> IsNotEqualTo<R> map(Function<? super T, ? extends R> mapper) {
         return mapSupport(mapper, IsNotEqualTo::new, IsNotEqualTo::empty);
     }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotEqualTo.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotEqualTo.java
@@ -21,7 +21,8 @@ import java.util.function.Predicate;
 
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 
-public class IsNotEqualTo<T> extends AbstractSingleValueCondition<T> {
+public class IsNotEqualTo<T> extends AbstractSingleValueCondition<T>
+        implements AbstractSingleValueCondition.Filterable<T>, AbstractSingleValueCondition.Mappable<T> {
     private static final IsNotEqualTo<?> EMPTY = new IsNotEqualTo<Object>(-1) {
         @Override
         public Object value() {

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotIn.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotIn.java
@@ -25,7 +25,8 @@ import org.mybatis.dynamic.sql.AbstractListValueCondition;
 import org.mybatis.dynamic.sql.render.RenderingContext;
 import org.mybatis.dynamic.sql.util.Validator;
 
-public class IsNotIn<T> extends AbstractListValueCondition<T> {
+public class IsNotIn<T> extends AbstractListValueCondition<T>
+        implements AbstractListValueCondition.Filterable<T>, AbstractListValueCondition.Mappable<T>{
     private static final IsNotIn<?> EMPTY = new IsNotIn<>(Collections.emptyList());
 
     public static <T> IsNotIn<T> empty() {
@@ -56,8 +57,7 @@ public class IsNotIn<T> extends AbstractListValueCondition<T> {
 
     @Override
     public <R> IsNotIn<R> map(Function<? super T, ? extends R> mapper) {
-        Function<Collection<R>, IsNotIn<R>> constructor = IsNotIn::new;
-        return mapSupport(mapper, constructor, IsNotIn::empty);
+        return mapSupport(mapper, IsNotIn::new, IsNotIn::empty);
     }
 
     @SafeVarargs

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotIn.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotIn.java
@@ -54,14 +54,7 @@ public class IsNotIn<T> extends AbstractListValueCondition<T> {
         return filterSupport(predicate, IsNotIn::new, this, IsNotIn::empty);
     }
 
-    /**
-     * If not empty, apply the mapping to each value in the list return a new condition with the mapped values.
-     *     Else return an empty condition (this).
-     *
-     * @param mapper a mapping function to apply to the values, if not empty
-     * @param <R> type of the new condition
-     * @return a new condition with mapped values if renderable, otherwise an empty condition
-     */
+    @Override
     public <R> IsNotIn<R> map(Function<? super T, ? extends R> mapper) {
         Function<Collection<R>, IsNotIn<R>> constructor = IsNotIn::new;
         return mapSupport(mapper, constructor, IsNotIn::empty);

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInCaseInsensitive.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInCaseInsensitive.java
@@ -27,7 +27,8 @@ import org.mybatis.dynamic.sql.util.StringUtilities;
 import org.mybatis.dynamic.sql.util.Validator;
 
 public class IsNotInCaseInsensitive<T> extends AbstractListValueCondition<T>
-        implements CaseInsensitiveRenderableCondition<T> {
+        implements CaseInsensitiveRenderableCondition<T>, AbstractListValueCondition.Filterable<T>,
+        AbstractListValueCondition.Mappable<T> {
     private static final IsNotInCaseInsensitive<?> EMPTY = new IsNotInCaseInsensitive<>(Collections.emptyList());
 
     public static <T> IsNotInCaseInsensitive<T> empty() {

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInCaseInsensitive.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInCaseInsensitive.java
@@ -57,6 +57,19 @@ public class IsNotInCaseInsensitive<T> extends AbstractListValueCondition<T>
         return filterSupport(predicate, IsNotInCaseInsensitive::new, this, IsNotInCaseInsensitive::empty);
     }
 
+    /**
+     * If renderable, apply the mapping to the value and return a new condition with the new value. Else return a
+     * condition that will not render (this).
+     *
+     * <p>This function DOES NOT automatically transform values to uppercase, so it potentially creates a
+     * case-sensitive query. For String conditions you can use {@link StringUtilities#mapToUpperCase(Function)}
+     * to add an uppercase transform after your mapping function.
+     *
+     * @param mapper a mapping function to apply to the value, if renderable
+     * @param <R> type of the new condition
+     * @return a new condition with the result of applying the mapper to the value of this condition,
+     *     if renderable, otherwise a condition that will not render.
+     */
     @Override
     public <R> IsNotInCaseInsensitive<R> map(Function<? super T, ? extends R> mapper) {
         return mapSupport(mapper, IsNotInCaseInsensitive::new, IsNotInCaseInsensitive::empty);

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInCaseInsensitive.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInCaseInsensitive.java
@@ -18,23 +18,25 @@ package org.mybatis.dynamic.sql.where.condition;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.function.UnaryOperator;
 
 import org.mybatis.dynamic.sql.AbstractListValueCondition;
 import org.mybatis.dynamic.sql.render.RenderingContext;
 import org.mybatis.dynamic.sql.util.StringUtilities;
 import org.mybatis.dynamic.sql.util.Validator;
 
-public class IsNotInCaseInsensitive extends AbstractListValueCondition<String>
-        implements CaseInsensitiveRenderableCondition<String> {
-    private static final IsNotInCaseInsensitive EMPTY = new IsNotInCaseInsensitive(Collections.emptyList());
+public class IsNotInCaseInsensitive<T> extends AbstractListValueCondition<T>
+        implements CaseInsensitiveRenderableCondition<T> {
+    private static final IsNotInCaseInsensitive<?> EMPTY = new IsNotInCaseInsensitive<>(Collections.emptyList());
 
-    public static IsNotInCaseInsensitive empty() {
-        return EMPTY;
+    public static <T> IsNotInCaseInsensitive<T> empty() {
+        @SuppressWarnings("unchecked")
+        IsNotInCaseInsensitive<T> t = (IsNotInCaseInsensitive<T>) EMPTY;
+        return t;
     }
 
-    protected IsNotInCaseInsensitive(Collection<String> values) {
+    protected IsNotInCaseInsensitive(Collection<T> values) {
         super(values);
     }
 
@@ -50,28 +52,22 @@ public class IsNotInCaseInsensitive extends AbstractListValueCondition<String>
     }
 
     @Override
-    public IsNotInCaseInsensitive filter(Predicate<? super String> predicate) {
+    public IsNotInCaseInsensitive<T> filter(Predicate<? super T> predicate) {
         return filterSupport(predicate, IsNotInCaseInsensitive::new, this, IsNotInCaseInsensitive::empty);
     }
 
-    /**
-     * If not empty, apply the mapping to each value in the list return a new condition with the mapped values.
-     *     Else return an empty condition (this).
-     *
-     * @param mapper a mapping function to apply to the values, if not empty
-     * @return a new condition with mapped values if renderable, otherwise an empty condition
-     */
-    public IsNotInCaseInsensitive map(UnaryOperator<String> mapper) {
+    @Override
+    public <R> IsNotInCaseInsensitive<R> map(Function<? super T, ? extends R> mapper) {
         return mapSupport(mapper, IsNotInCaseInsensitive::new, IsNotInCaseInsensitive::empty);
     }
 
-    public static IsNotInCaseInsensitive of(String... values) {
+    public static IsNotInCaseInsensitive<String> of(String... values) {
         return of(Arrays.asList(values));
     }
 
-    public static IsNotInCaseInsensitive of(Collection<String> values) {
+    public static IsNotInCaseInsensitive<String> of(Collection<String> values) {
         // Keep the null safe upper case utility for backwards compatibility
         //noinspection DataFlowIssue
-        return new IsNotInCaseInsensitive(values).map(StringUtilities::safelyUpperCase);
+        return new IsNotInCaseInsensitive<>(values).map(StringUtilities::safelyUpperCase);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInCaseInsensitive.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInCaseInsensitive.java
@@ -27,7 +27,7 @@ import org.mybatis.dynamic.sql.util.StringUtilities;
 import org.mybatis.dynamic.sql.util.Validator;
 
 public class IsNotInCaseInsensitive extends AbstractListValueCondition<String>
-        implements CaseInsensitiveRenderableCondition {
+        implements CaseInsensitiveRenderableCondition<String> {
     private static final IsNotInCaseInsensitive EMPTY = new IsNotInCaseInsensitive(Collections.emptyList());
 
     public static IsNotInCaseInsensitive empty() {

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInCaseInsensitiveWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInCaseInsensitiveWhenPresent.java
@@ -26,7 +26,8 @@ import org.jspecify.annotations.Nullable;
 import org.mybatis.dynamic.sql.AbstractListValueCondition;
 
 public class IsNotInCaseInsensitiveWhenPresent<T> extends AbstractListValueCondition<T>
-        implements CaseInsensitiveRenderableCondition<T> {
+        implements CaseInsensitiveRenderableCondition<T>, AbstractListValueCondition.Filterable<T>,
+        AbstractListValueCondition.Mappable<T> {
     private static final IsNotInCaseInsensitiveWhenPresent<?> EMPTY =
             new IsNotInCaseInsensitiveWhenPresent<>(Collections.emptyList());
 

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInCaseInsensitiveWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInCaseInsensitiveWhenPresent.java
@@ -18,24 +18,26 @@ package org.mybatis.dynamic.sql.where.condition;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.function.UnaryOperator;
 
 import org.jspecify.annotations.Nullable;
 import org.mybatis.dynamic.sql.AbstractListValueCondition;
 import org.mybatis.dynamic.sql.util.StringUtilities;
 import org.mybatis.dynamic.sql.util.Utilities;
 
-public class IsNotInCaseInsensitiveWhenPresent extends AbstractListValueCondition<String>
-        implements CaseInsensitiveRenderableCondition<String> {
-    private static final IsNotInCaseInsensitiveWhenPresent EMPTY =
-            new IsNotInCaseInsensitiveWhenPresent(Collections.emptyList());
+public class IsNotInCaseInsensitiveWhenPresent<T> extends AbstractListValueCondition<T>
+        implements CaseInsensitiveRenderableCondition<T> {
+    private static final IsNotInCaseInsensitiveWhenPresent<?> EMPTY =
+            new IsNotInCaseInsensitiveWhenPresent<>(Collections.emptyList());
 
-    public static IsNotInCaseInsensitiveWhenPresent empty() {
-        return EMPTY;
+    public static <T> IsNotInCaseInsensitiveWhenPresent<T> empty() {
+        @SuppressWarnings("unchecked")
+        IsNotInCaseInsensitiveWhenPresent<T> t = (IsNotInCaseInsensitiveWhenPresent<T>) EMPTY;
+        return t;
     }
 
-    protected IsNotInCaseInsensitiveWhenPresent(Collection<@Nullable String> values) {
+    protected IsNotInCaseInsensitiveWhenPresent(Collection<@Nullable T> values) {
         super(Utilities.removeNullElements(values));
     }
 
@@ -45,29 +47,23 @@ public class IsNotInCaseInsensitiveWhenPresent extends AbstractListValueConditio
     }
 
     @Override
-    public IsNotInCaseInsensitiveWhenPresent filter(Predicate<? super String> predicate) {
+    public IsNotInCaseInsensitiveWhenPresent<T> filter(Predicate<? super T> predicate) {
         return filterSupport(predicate, IsNotInCaseInsensitiveWhenPresent::new,
                 this, IsNotInCaseInsensitiveWhenPresent::empty);
     }
 
-    /**
-     * If not empty, apply the mapping to each value in the list return a new condition with the mapped values.
-     *     Else return an empty condition (this).
-     *
-     * @param mapper a mapping function to apply to the values, if not empty
-     * @return a new condition with mapped values if renderable, otherwise an empty condition
-     */
-    public IsNotInCaseInsensitiveWhenPresent map(UnaryOperator<String> mapper) {
+    @Override
+    public <R> IsNotInCaseInsensitiveWhenPresent<R> map(Function<? super T, ? extends R> mapper) {
         return mapSupport(mapper, IsNotInCaseInsensitiveWhenPresent::new, IsNotInCaseInsensitiveWhenPresent::empty);
     }
 
-    public static IsNotInCaseInsensitiveWhenPresent of(@Nullable String... values) {
+    public static IsNotInCaseInsensitiveWhenPresent<String> of(@Nullable String... values) {
         return of(Arrays.asList(values));
     }
 
-    public static IsNotInCaseInsensitiveWhenPresent of(Collection<@Nullable String> values) {
+    public static IsNotInCaseInsensitiveWhenPresent<String> of(Collection<@Nullable String> values) {
         // Keep the null safe upper case utility for backwards compatibility
         //noinspection DataFlowIssue
-        return new IsNotInCaseInsensitiveWhenPresent(values).map(StringUtilities::safelyUpperCase);
+        return new IsNotInCaseInsensitiveWhenPresent<>(values).map(StringUtilities::safelyUpperCase);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInCaseInsensitiveWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInCaseInsensitiveWhenPresent.java
@@ -36,7 +36,7 @@ public class IsNotInCaseInsensitiveWhenPresent<T> extends AbstractListValueCondi
         return t;
     }
 
-    protected IsNotInCaseInsensitiveWhenPresent(Collection<String> values) {
+    protected IsNotInCaseInsensitiveWhenPresent(Collection<T> values) {
         super(values);
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInCaseInsensitiveWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInCaseInsensitiveWhenPresent.java
@@ -27,7 +27,7 @@ import org.mybatis.dynamic.sql.util.StringUtilities;
 import org.mybatis.dynamic.sql.util.Utilities;
 
 public class IsNotInCaseInsensitiveWhenPresent extends AbstractListValueCondition<String>
-        implements CaseInsensitiveRenderableCondition {
+        implements CaseInsensitiveRenderableCondition<String> {
     private static final IsNotInCaseInsensitiveWhenPresent EMPTY =
             new IsNotInCaseInsensitiveWhenPresent(Collections.emptyList());
 

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInCaseInsensitiveWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInCaseInsensitiveWhenPresent.java
@@ -24,6 +24,7 @@ import java.util.function.Predicate;
 
 import org.jspecify.annotations.Nullable;
 import org.mybatis.dynamic.sql.AbstractListValueCondition;
+import org.mybatis.dynamic.sql.util.StringUtilities;
 
 public class IsNotInCaseInsensitiveWhenPresent<T> extends AbstractListValueCondition<T>
         implements CaseInsensitiveRenderableCondition<T>, AbstractListValueCondition.Filterable<T>,
@@ -52,6 +53,19 @@ public class IsNotInCaseInsensitiveWhenPresent<T> extends AbstractListValueCondi
                 this, IsNotInCaseInsensitiveWhenPresent::empty);
     }
 
+    /**
+     * If renderable, apply the mapping to the value and return a new condition with the new value. Else return a
+     * condition that will not render (this).
+     *
+     * <p>This function DOES NOT automatically transform values to uppercase, so it potentially creates a
+     * case-sensitive query. For String conditions you can use {@link StringUtilities#mapToUpperCase(Function)}
+     * to add an uppercase transform after your mapping function.
+     *
+     * @param mapper a mapping function to apply to the value, if renderable
+     * @param <R> type of the new condition
+     * @return a new condition with the result of applying the mapper to the value of this condition,
+     *     if renderable, otherwise a condition that will not render.
+     */
     @Override
     public <R> IsNotInCaseInsensitiveWhenPresent<R> map(Function<? super T, ? extends R> mapper) {
         return mapSupport(mapper, IsNotInCaseInsensitiveWhenPresent::new, IsNotInCaseInsensitiveWhenPresent::empty);

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInWhenPresent.java
@@ -24,7 +24,8 @@ import java.util.function.Predicate;
 
 import org.mybatis.dynamic.sql.AbstractListValueCondition;
 
-public class IsNotInWhenPresent<T> extends AbstractListValueCondition<T> {
+public class IsNotInWhenPresent<T> extends AbstractListValueCondition<T>
+        implements AbstractListValueCondition.Filterable<T>, AbstractListValueCondition.Mappable<T>{
     private static final IsNotInWhenPresent<?> EMPTY = new IsNotInWhenPresent<>(Collections.emptyList());
 
     public static <T> IsNotInWhenPresent<T> empty() {
@@ -47,17 +48,9 @@ public class IsNotInWhenPresent<T> extends AbstractListValueCondition<T> {
         return filterSupport(predicate, IsNotInWhenPresent::new, this, IsNotInWhenPresent::empty);
     }
 
-    /**
-     * If not empty, apply the mapping to each value in the list return a new condition with the mapped values.
-     *     Else return an empty condition (this).
-     *
-     * @param mapper a mapping function to apply to the values, if not empty
-     * @param <R> type of the new condition
-     * @return a new condition with mapped values if renderable, otherwise an empty condition
-     */
+    @Override
     public <R> IsNotInWhenPresent<R> map(Function<? super T, ? extends R> mapper) {
-        Function<Collection<R>, IsNotInWhenPresent<R>> constructor = IsNotInWhenPresent::new;
-        return mapSupport(mapper, constructor, IsNotInWhenPresent::empty);
+        return mapSupport(mapper, IsNotInWhenPresent::new, IsNotInWhenPresent::empty);
     }
 
     @SafeVarargs

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotLike.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotLike.java
@@ -58,18 +58,7 @@ public class IsNotLike<T> extends AbstractSingleValueCondition<T> {
         return filterSupport(predicate, IsNotLike::empty, this);
     }
 
-    /**
-     * If renderable, apply the mapping to the value and return a new condition with the new value. Else return a
-     * condition that will not render (this).
-     *
-     * @param mapper
-     *            a mapping function to apply to the value, if renderable
-     * @param <R>
-     *            type of the new condition
-     *
-     * @return a new condition with the result of applying the mapper to the value of this condition, if renderable,
-     *         otherwise a condition that will not render.
-     */
+    @Override
     public <R> IsNotLike<R> map(Function<? super T, ? extends R> mapper) {
         return mapSupport(mapper, IsNotLike::new, IsNotLike::empty);
     }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotLike.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotLike.java
@@ -21,7 +21,8 @@ import java.util.function.Predicate;
 
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 
-public class IsNotLike<T> extends AbstractSingleValueCondition<T> {
+public class IsNotLike<T> extends AbstractSingleValueCondition<T>
+        implements AbstractSingleValueCondition.Filterable<T>, AbstractSingleValueCondition.Mappable<T> {
     private static final IsNotLike<?> EMPTY = new IsNotLike<Object>(-1) {
         @Override
         public Object value() {

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotLikeCaseInsensitive.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotLikeCaseInsensitive.java
@@ -57,6 +57,19 @@ public class IsNotLikeCaseInsensitive<T> extends AbstractSingleValueCondition<T>
         return filterSupport(predicate, IsNotLikeCaseInsensitive::empty, this);
     }
 
+    /**
+     * If renderable, apply the mapping to the value and return a new condition with the new value. Else return a
+     * condition that will not render (this).
+     *
+     * <p>This function DOES NOT automatically transform values to uppercase, so it potentially creates a
+     * case-sensitive query. For String conditions you can use {@link StringUtilities#mapToUpperCase(Function)}
+     * to add an uppercase transform after your mapping function.
+     *
+     * @param mapper a mapping function to apply to the value, if renderable
+     * @param <R> type of the new condition
+     * @return a new condition with the result of applying the mapper to the value of this condition,
+     *     if renderable, otherwise a condition that will not render.
+     */
     @Override
     public <R> IsNotLikeCaseInsensitive<R> map(Function<? super T, ? extends R> mapper) {
         return mapSupport(mapper, IsNotLikeCaseInsensitive::new, IsNotLikeCaseInsensitive::empty);

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotLikeCaseInsensitive.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotLikeCaseInsensitive.java
@@ -23,7 +23,8 @@ import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 import org.mybatis.dynamic.sql.util.StringUtilities;
 
 public class IsNotLikeCaseInsensitive<T> extends AbstractSingleValueCondition<T>
-        implements CaseInsensitiveRenderableCondition<T> {
+        implements CaseInsensitiveRenderableCondition<T>, AbstractSingleValueCondition.Filterable<T>,
+        AbstractSingleValueCondition.Mappable<T> {
     private static final IsNotLikeCaseInsensitive<?> EMPTY = new IsNotLikeCaseInsensitive<>("") { //$NON-NLS-1$
         @Override
         public String value() {
@@ -56,16 +57,7 @@ public class IsNotLikeCaseInsensitive<T> extends AbstractSingleValueCondition<T>
         return filterSupport(predicate, IsNotLikeCaseInsensitive::empty, this);
     }
 
-    /**
-     * If renderable, apply the mapping to the value and return a new condition with the new value. Else return a
-     * condition that will not render (this).
-     *
-     * @param mapper
-     *            a mapping function to apply to the value, if renderable
-     *
-     * @return a new condition with the result of applying the mapper to the value of this condition, if renderable,
-     *         otherwise a condition that will not render.
-     */
+    @Override
     public <R> IsNotLikeCaseInsensitive<R> map(Function<? super T, ? extends R> mapper) {
         return mapSupport(mapper, IsNotLikeCaseInsensitive::new, IsNotLikeCaseInsensitive::empty);
     }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotLikeCaseInsensitive.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotLikeCaseInsensitive.java
@@ -16,15 +16,15 @@
 package org.mybatis.dynamic.sql.where.condition;
 
 import java.util.NoSuchElementException;
+import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.function.UnaryOperator;
 
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 import org.mybatis.dynamic.sql.util.StringUtilities;
 
-public class IsNotLikeCaseInsensitive extends AbstractSingleValueCondition<String>
-        implements CaseInsensitiveRenderableCondition {
-    private static final IsNotLikeCaseInsensitive EMPTY = new IsNotLikeCaseInsensitive("") { //$NON-NLS-1$
+public class IsNotLikeCaseInsensitive<T> extends AbstractSingleValueCondition<T>
+        implements CaseInsensitiveRenderableCondition<T> {
+    private static final IsNotLikeCaseInsensitive<?> EMPTY = new IsNotLikeCaseInsensitive<>("") { //$NON-NLS-1$
         @Override
         public String value() {
             throw new NoSuchElementException("No value present"); //$NON-NLS-1$
@@ -36,11 +36,13 @@ public class IsNotLikeCaseInsensitive extends AbstractSingleValueCondition<Strin
         }
     };
 
-    public static IsNotLikeCaseInsensitive empty() {
-        return EMPTY;
+    public static <T> IsNotLikeCaseInsensitive<T> empty() {
+        @SuppressWarnings("unchecked")
+        IsNotLikeCaseInsensitive<T> t = (IsNotLikeCaseInsensitive<T>) EMPTY;
+        return t;
     }
 
-    protected IsNotLikeCaseInsensitive(String value) {
+    protected IsNotLikeCaseInsensitive(T value) {
         super(value);
     }
 
@@ -50,7 +52,7 @@ public class IsNotLikeCaseInsensitive extends AbstractSingleValueCondition<Strin
     }
 
     @Override
-    public IsNotLikeCaseInsensitive filter(Predicate<? super String> predicate) {
+    public IsNotLikeCaseInsensitive<T> filter(Predicate<? super T> predicate) {
         return filterSupport(predicate, IsNotLikeCaseInsensitive::empty, this);
     }
 
@@ -64,13 +66,13 @@ public class IsNotLikeCaseInsensitive extends AbstractSingleValueCondition<Strin
      * @return a new condition with the result of applying the mapper to the value of this condition, if renderable,
      *         otherwise a condition that will not render.
      */
-    public IsNotLikeCaseInsensitive map(UnaryOperator<String> mapper) {
+    public <R> IsNotLikeCaseInsensitive<R> map(Function<? super T, ? extends R> mapper) {
         return mapSupport(mapper, IsNotLikeCaseInsensitive::new, IsNotLikeCaseInsensitive::empty);
     }
 
-    public static IsNotLikeCaseInsensitive of(String value) {
+    public static IsNotLikeCaseInsensitive<String> of(String value) {
         // Keep the null safe upper case utility for backwards compatibility
         //noinspection DataFlowIssue
-        return new IsNotLikeCaseInsensitive(value).map(StringUtilities::safelyUpperCase);
+        return new IsNotLikeCaseInsensitive<>(value).map(StringUtilities::safelyUpperCase);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotNull.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotNull.java
@@ -19,7 +19,7 @@ import java.util.function.BooleanSupplier;
 
 import org.mybatis.dynamic.sql.AbstractNoValueCondition;
 
-public class IsNotNull<T> extends AbstractNoValueCondition<T> {
+public class IsNotNull<T> extends AbstractNoValueCondition<T> implements AbstractNoValueCondition.Filterable {
     private static final IsNotNull<?> EMPTY = new IsNotNull<>() {
         @Override
         public boolean isEmpty() {

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotNull.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotNull.java
@@ -42,17 +42,7 @@ public class IsNotNull<T> extends AbstractNoValueCondition<T> {
         return "is not null"; //$NON-NLS-1$
     }
 
-    /**
-     * If renderable and the supplier returns true, returns this condition. Else returns a condition that will not
-     * render.
-     *
-     * @param booleanSupplier
-     *            function that specifies whether the condition should render
-     * @param <S>
-     *            condition type - not used except for compilation compliance
-     *
-     * @return this condition if renderable and the supplier returns true, otherwise a condition that will not render.
-     */
+    @Override
     public <S> IsNotNull<S> filter(BooleanSupplier booleanSupplier) {
         @SuppressWarnings("unchecked")
         IsNotNull<S> self = (IsNotNull<S>) this;

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNull.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNull.java
@@ -19,7 +19,7 @@ import java.util.function.BooleanSupplier;
 
 import org.mybatis.dynamic.sql.AbstractNoValueCondition;
 
-public class IsNull<T> extends AbstractNoValueCondition<T> {
+public class IsNull<T> extends AbstractNoValueCondition<T> implements AbstractNoValueCondition.Filterable {
     private static final IsNull<?> EMPTY = new IsNull<>() {
         @Override
         public boolean isEmpty() {

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNull.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNull.java
@@ -42,17 +42,7 @@ public class IsNull<T> extends AbstractNoValueCondition<T> {
         return "is null"; //$NON-NLS-1$
     }
 
-    /**
-     * If renderable and the supplier returns true, returns this condition. Else returns a condition that will not
-     * render.
-     *
-     * @param booleanSupplier
-     *            function that specifies whether the condition should render
-     * @param <S>
-     *            condition type - not used except for compilation compliance
-     *
-     * @return this condition if renderable and the supplier returns true, otherwise a condition that will not render.
-     */
+    @Override
     public <S> IsNull<S> filter(BooleanSupplier booleanSupplier) {
         @SuppressWarnings("unchecked")
         IsNull<S> self = (IsNull<S>) this;

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/elements/SqlElements.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/elements/SqlElements.kt
@@ -324,14 +324,14 @@ fun isTrue(): IsEqualTo<Boolean> = isEqualTo(true)
 fun isFalse(): IsEqualTo<Boolean> = isEqualTo(false)
 
 // conditions for strings only
-fun isLikeCaseInsensitive(value: String): IsLikeCaseInsensitive = SqlBuilder.isLikeCaseInsensitive(value)
+fun isLikeCaseInsensitive(value: String): IsLikeCaseInsensitive<String> = SqlBuilder.isLikeCaseInsensitive(value)
 
-fun isLikeCaseInsensitiveWhenPresent(value: String?): IsLikeCaseInsensitive =
+fun isLikeCaseInsensitiveWhenPresent(value: String?): IsLikeCaseInsensitive<String> =
     SqlBuilder.isLikeCaseInsensitiveWhenPresent(value)
 
-fun isNotLikeCaseInsensitive(value: String): IsNotLikeCaseInsensitive = SqlBuilder.isNotLikeCaseInsensitive(value)
+fun isNotLikeCaseInsensitive(value: String): IsNotLikeCaseInsensitive<String> = SqlBuilder.isNotLikeCaseInsensitive(value)
 
-fun isNotLikeCaseInsensitiveWhenPresent(value: String?): IsNotLikeCaseInsensitive =
+fun isNotLikeCaseInsensitiveWhenPresent(value: String?): IsNotLikeCaseInsensitive<String> =
     SqlBuilder.isNotLikeCaseInsensitiveWhenPresent(value)
 
 fun isInCaseInsensitive(vararg values: String): IsInCaseInsensitive = isInCaseInsensitive(values.asList())

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/elements/SqlElements.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/elements/SqlElements.kt
@@ -334,40 +334,43 @@ fun isNotLikeCaseInsensitive(value: String): IsNotLikeCaseInsensitive<String> = 
 fun isNotLikeCaseInsensitiveWhenPresent(value: String?): IsNotLikeCaseInsensitive<String> =
     SqlBuilder.isNotLikeCaseInsensitiveWhenPresent(value)
 
-fun isInCaseInsensitive(vararg values: String): IsInCaseInsensitive = isInCaseInsensitive(values.asList())
+fun isInCaseInsensitive(vararg values: String): IsInCaseInsensitive<String> = isInCaseInsensitive(values.asList())
 
 @JvmName("isInArrayCaseInsensitive")
-fun isInCaseInsensitive(values: Array<out String>): IsInCaseInsensitive = SqlBuilder.isInCaseInsensitive(values.asList())
+fun isInCaseInsensitive(values: Array<out String>): IsInCaseInsensitive<String> =
+    SqlBuilder.isInCaseInsensitive(values.asList())
 
-fun isInCaseInsensitive(values: Collection<String>): IsInCaseInsensitive = SqlBuilder.isInCaseInsensitive(values)
+fun isInCaseInsensitive(values: Collection<String>): IsInCaseInsensitive<String> =
+    SqlBuilder.isInCaseInsensitive(values)
 
-fun isInCaseInsensitiveWhenPresent(vararg values: String?): IsInCaseInsensitiveWhenPresent =
+fun isInCaseInsensitiveWhenPresent(vararg values: String?): IsInCaseInsensitiveWhenPresent<String> =
     isInCaseInsensitiveWhenPresent(values.asList())
 
 @JvmName("isInArrayCaseInsensitiveWhenPresent")
-fun isInCaseInsensitiveWhenPresent(values: Array<out String?>?): IsInCaseInsensitiveWhenPresent =
+fun isInCaseInsensitiveWhenPresent(values: Array<out String?>?): IsInCaseInsensitiveWhenPresent<String> =
     SqlBuilder.isInCaseInsensitiveWhenPresent(values?.asList())
 
-fun isInCaseInsensitiveWhenPresent(values: Collection<String?>?): IsInCaseInsensitiveWhenPresent =
+fun isInCaseInsensitiveWhenPresent(values: Collection<String?>?): IsInCaseInsensitiveWhenPresent<String> =
     SqlBuilder.isInCaseInsensitiveWhenPresent(values)
 
-fun isNotInCaseInsensitive(vararg values: String): IsNotInCaseInsensitive = isNotInCaseInsensitive(values.asList())
+fun isNotInCaseInsensitive(vararg values: String): IsNotInCaseInsensitive<String> =
+    isNotInCaseInsensitive(values.asList())
 
 @JvmName("isNotInArrayCaseInsensitive")
-fun isNotInCaseInsensitive(values: Array<out String>): IsNotInCaseInsensitive =
+fun isNotInCaseInsensitive(values: Array<out String>): IsNotInCaseInsensitive<String> =
     SqlBuilder.isNotInCaseInsensitive(values.asList())
 
-fun isNotInCaseInsensitive(values: Collection<String>): IsNotInCaseInsensitive =
+fun isNotInCaseInsensitive(values: Collection<String>): IsNotInCaseInsensitive<String> =
     SqlBuilder.isNotInCaseInsensitive(values)
 
-fun isNotInCaseInsensitiveWhenPresent(vararg values: String?): IsNotInCaseInsensitiveWhenPresent =
+fun isNotInCaseInsensitiveWhenPresent(vararg values: String?): IsNotInCaseInsensitiveWhenPresent<String> =
     isNotInCaseInsensitiveWhenPresent(values.asList())
 
 @JvmName("isNotInArrayCaseInsensitiveWhenPresent")
-fun isNotInCaseInsensitiveWhenPresent(values: Array<out String?>?): IsNotInCaseInsensitiveWhenPresent =
+fun isNotInCaseInsensitiveWhenPresent(values: Array<out String?>?): IsNotInCaseInsensitiveWhenPresent<String> =
     SqlBuilder.isNotInCaseInsensitiveWhenPresent(values?.asList())
 
-fun isNotInCaseInsensitiveWhenPresent(values: Collection<String?>?): IsNotInCaseInsensitiveWhenPresent =
+fun isNotInCaseInsensitiveWhenPresent(values: Collection<String?>?): IsNotInCaseInsensitiveWhenPresent<String> =
     SqlBuilder.isNotInCaseInsensitiveWhenPresent(values)
 
 // order by support

--- a/src/site/markdown/docs/extending.md
+++ b/src/site/markdown/docs/extending.md
@@ -304,7 +304,8 @@ Here's an example of implementing a LIKE condition that supports ESCAPE:
 
 ```java
 @NullMarked
-public class IsLikeEscape<T> extends AbstractSingleValueCondition<T> {
+public class IsLikeEscape<T> extends AbstractSingleValueCondition<T>
+        implements AbstractSingleValueCondition.Filterable<T>, AbstractSingleValueCondition.Mappable<T> {
     private static final IsLikeEscape<?> EMPTY = new IsLikeEscape<Object>(-1, null) {
         @Override
         public Object value() {
@@ -354,6 +355,7 @@ public class IsLikeEscape<T> extends AbstractSingleValueCondition<T> {
         return filterSupport(predicate, IsLikeEscape::empty, this);
     }
 
+    @Override
     public <R> IsLikeEscape<R> map(Function<? super T, ? extends R> mapper) {
         return mapSupport(mapper, v -> new IsLikeEscape<>(v, escapeCharacter), IsLikeEscape::empty);
     }
@@ -374,4 +376,5 @@ Important notes:
 2. The class constructor accepts an escape character that will be rendered into an ESCAPE phrase
 3. The class overrides `renderCondition` and changes the library generated `FragmentAndParameters` to add the ESCAPE
    phrase. **This is the key to what's needed to implement a custom condition.**
-4. The class provides `map` and `filter` functions as is expected for any condition in the library
+4. The class implements `Filterable` and `Mappable` to provide `filter` and `map` functions as is expected for most
+   conditions in the library

--- a/src/test/java/examples/mysql/IsLikeEscape.java
+++ b/src/test/java/examples/mysql/IsLikeEscape.java
@@ -27,7 +27,8 @@ import org.mybatis.dynamic.sql.render.RenderingContext;
 import org.mybatis.dynamic.sql.util.FragmentAndParameters;
 
 @NullMarked
-public class IsLikeEscape<T> extends AbstractSingleValueCondition<T> {
+public class IsLikeEscape<T> extends AbstractSingleValueCondition<T>
+        implements AbstractSingleValueCondition.Filterable<T>, AbstractSingleValueCondition.Mappable<T> {
     private static final IsLikeEscape<?> EMPTY = new IsLikeEscape<Object>(-1, null) {
         @Override
         public Object value() {

--- a/src/test/java/examples/mysql/IsLikeEscape.java
+++ b/src/test/java/examples/mysql/IsLikeEscape.java
@@ -77,6 +77,7 @@ public class IsLikeEscape<T> extends AbstractSingleValueCondition<T> {
         return filterSupport(predicate, IsLikeEscape::empty, this);
     }
 
+    @Override
     public <R> IsLikeEscape<R> map(Function<? super T, ? extends R> mapper) {
         return mapSupport(mapper, v -> new IsLikeEscape<>(v, escapeCharacter), IsLikeEscape::empty);
     }

--- a/src/test/java/examples/mysql/MemberOfCondition.java
+++ b/src/test/java/examples/mysql/MemberOfCondition.java
@@ -16,12 +16,26 @@
 package examples.mysql;
 
 import java.util.Objects;
+import java.util.function.BooleanSupplier;
 
 import org.jspecify.annotations.NullMarked;
 import org.mybatis.dynamic.sql.AbstractNoValueCondition;
 
 @NullMarked
 public class MemberOfCondition<T> extends AbstractNoValueCondition<T> {
+    private static final MemberOfCondition<?> EMPTY = new MemberOfCondition<>("") {
+        @Override
+        public boolean isEmpty() {
+            return true;
+        }
+    };
+
+    public static <T> MemberOfCondition<T> empty() {
+        @SuppressWarnings("unchecked")
+        MemberOfCondition<T> t = (MemberOfCondition<T>) EMPTY;
+        return t;
+    }
+
     private final String jsonArray;
 
     protected MemberOfCondition(String jsonArray) {
@@ -31,6 +45,13 @@ public class MemberOfCondition<T> extends AbstractNoValueCondition<T> {
     @Override
     public String operator() {
         return "member of(" + jsonArray + ")";
+    }
+
+    @Override
+    public <S> MemberOfCondition<S> filter(BooleanSupplier booleanSupplier) {
+        @SuppressWarnings("unchecked")
+        MemberOfCondition<S> self = (MemberOfCondition<S>) this;
+        return filterSupport(booleanSupplier, MemberOfCondition::empty, self);
     }
 
     public static <T> MemberOfCondition<T> memberOf(String jsonArray) {

--- a/src/test/java/examples/mysql/MemberOfCondition.java
+++ b/src/test/java/examples/mysql/MemberOfCondition.java
@@ -16,26 +16,12 @@
 package examples.mysql;
 
 import java.util.Objects;
-import java.util.function.BooleanSupplier;
 
 import org.jspecify.annotations.NullMarked;
 import org.mybatis.dynamic.sql.AbstractNoValueCondition;
 
 @NullMarked
 public class MemberOfCondition<T> extends AbstractNoValueCondition<T> {
-    private static final MemberOfCondition<?> EMPTY = new MemberOfCondition<>("") {
-        @Override
-        public boolean isEmpty() {
-            return true;
-        }
-    };
-
-    public static <T> MemberOfCondition<T> empty() {
-        @SuppressWarnings("unchecked")
-        MemberOfCondition<T> t = (MemberOfCondition<T>) EMPTY;
-        return t;
-    }
-
     private final String jsonArray;
 
     protected MemberOfCondition(String jsonArray) {
@@ -45,13 +31,6 @@ public class MemberOfCondition<T> extends AbstractNoValueCondition<T> {
     @Override
     public String operator() {
         return "member of(" + jsonArray + ")";
-    }
-
-    @Override
-    public <S> MemberOfCondition<S> filter(BooleanSupplier booleanSupplier) {
-        @SuppressWarnings("unchecked")
-        MemberOfCondition<S> self = (MemberOfCondition<S>) this;
-        return filterSupport(booleanSupplier, MemberOfCondition::empty, self);
     }
 
     public static <T> MemberOfCondition<T> memberOf(String jsonArray) {

--- a/src/test/java/org/mybatis/dynamic/sql/where/condition/FilterAndMapTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/where/condition/FilterAndMapTest.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 
 import org.junit.jupiter.api.Test;
 import org.mybatis.dynamic.sql.SqlBuilder;
+import org.mybatis.dynamic.sql.util.StringUtilities;
 
 class FilterAndMapTest {
     @Test
@@ -533,4 +534,40 @@ class FilterAndMapTest {
         assertThat(cond.value2()).isEqualTo(4);
     }
 
+    @Test
+    void testMappingAnEmptyListCondition() {
+        var cond = SqlBuilder.isNotIn("Fred", "Wilma");
+        var filtered = cond.filter(s -> false);
+        var mapped = filtered.map(s -> s);
+        assertThat(mapped.isEmpty()).isTrue();
+        assertThat(filtered).isSameAs(mapped);
+    }
+
+    @Test
+    void testIsInCaseInsensitiveWhenPresentMap() {
+        var cond = SqlBuilder.isInCaseInsensitiveWhenPresent("Fred", "Wilma");
+        var mapped = cond.map(s -> s + " Flintstone");
+        assertThat(mapped.values().toList()).containsExactly("FRED Flintstone", "WILMA Flintstone");
+    }
+
+    @Test
+    void testIsInCaseInsensitiveWhenPresentMapCaseInsensitive() {
+        var cond = SqlBuilder.isInCaseInsensitiveWhenPresent("Fred", "Wilma");
+        var mapped = cond.map(StringUtilities.mapToUpperCase(s -> s + " Flintstone"));
+        assertThat(mapped.values().toList()).containsExactly("FRED FLINTSTONE", "WILMA FLINTSTONE");
+    }
+
+    @Test
+    void testIsNotInCaseInsensitiveWhenPresentMap() {
+        var cond = SqlBuilder.isNotInCaseInsensitiveWhenPresent("Fred", "Wilma");
+        var mapped = cond.map(s -> s + " Flintstone");
+        assertThat(mapped.values().toList()).containsExactly("FRED Flintstone", "WILMA Flintstone");
+    }
+
+    @Test
+    void testIsNotInCaseInsensitiveWhenPresentMapCaseInsensitive() {
+        var cond = SqlBuilder.isNotInCaseInsensitiveWhenPresent("Fred", "Wilma");
+        var mapped = cond.map(StringUtilities.mapToUpperCase(s -> s + " Flintstone"));
+        assertThat(mapped.values().toList()).containsExactly("FRED FLINTSTONE", "WILMA FLINTSTONE");
+    }
 }

--- a/src/test/java/org/mybatis/dynamic/sql/where/condition/FilterAndMapTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/where/condition/FilterAndMapTest.java
@@ -28,14 +28,14 @@ import org.mybatis.dynamic.sql.SqlBuilder;
 class FilterAndMapTest {
     @Test
     void testTypeConversion() {
-        IsEqualTo<Integer> cond = SqlBuilder.isEqualTo("1").map(Integer::parseInt);
+        var cond = SqlBuilder.isEqualTo("1").map(Integer::parseInt);
         assertThat(cond.isEmpty()).isFalse();
         assertThat(cond.value()).isEqualTo(1);
     }
 
     @Test
     void testTypeConversionWithNullThrowsException() {
-        IsEqualTo<String> cond = SqlBuilder.isEqualTo((String) null);
+        var cond = SqlBuilder.isEqualTo((String) null);
         assertThatExceptionOfType(NumberFormatException.class).isThrownBy(() ->
                 cond.map(Integer::parseInt)
         );
@@ -43,7 +43,7 @@ class FilterAndMapTest {
 
     @Test
     void testTypeConversionWithNullAndFilterDoesNotThrowException() {
-        IsEqualTo<Integer> cond = SqlBuilder.isEqualTo((String) null).filter(Objects::nonNull).map(Integer::parseInt);
+        var cond = SqlBuilder.isEqualTo((String) null).filter(Objects::nonNull).map(Integer::parseInt);
         assertThat(cond.isEmpty()).isTrue();
     }
 
@@ -328,8 +328,8 @@ class FilterAndMapTest {
 
     @Test
     void testIsLikeCaseInsensitiveRenderableTruePredicateShouldReturnSameObject() {
-        IsLikeCaseInsensitive cond = SqlBuilder.isLikeCaseInsensitive("Fred");
-        IsLikeCaseInsensitive filtered = cond.filter(s -> true);
+        var cond = SqlBuilder.isLikeCaseInsensitive("Fred");
+        var filtered = cond.filter(s -> true);
         assertThat(filtered.value()).isEqualTo("FRED");
         assertThat(filtered.isEmpty()).isFalse();
         assertThat(cond).isSameAs(filtered);
@@ -337,24 +337,24 @@ class FilterAndMapTest {
 
     @Test
     void testIsLikeCaseInsensitiveRenderableFalsePredicate() {
-        IsLikeCaseInsensitive cond = SqlBuilder.isLikeCaseInsensitive("Fred");
-        IsLikeCaseInsensitive filtered = cond.filter(s -> false);
+        var cond = SqlBuilder.isLikeCaseInsensitive("Fred");
+        var filtered = cond.filter(s -> false);
         assertThat(cond.isEmpty()).isFalse();
         assertThat(filtered.isEmpty()).isTrue();
     }
 
     @Test
     void testIsLikeCaseInsensitiveFilterUnRenderableShouldReturnSameObject() {
-        IsLikeCaseInsensitive cond = SqlBuilder.isLikeCaseInsensitive("Fred").filter(s -> false);
-        IsLikeCaseInsensitive filtered = cond.filter(s -> true);
+        var cond = SqlBuilder.isLikeCaseInsensitive("Fred").filter(s -> false);
+        var filtered = cond.filter(s -> true);
         assertThat(filtered.isEmpty()).isTrue();
         assertThat(cond).isSameAs(filtered);
     }
 
     @Test
     void testIsLikeCaseInsensitiveMapUnRenderableShouldNotThrowNullPointerException() {
-        IsLikeCaseInsensitive cond = SqlBuilder.isLikeCaseInsensitive("Fred").filter(s -> false);
-        IsLikeCaseInsensitive mapped = cond.map(String::toUpperCase);
+        IsLikeCaseInsensitive<String> cond = SqlBuilder.isLikeCaseInsensitive("Fred").filter(s -> false);
+        IsLikeCaseInsensitive<String> mapped = cond.map(String::toUpperCase);
         assertThat(cond.isEmpty()).isTrue();
         assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(cond::value);
         assertThat(cond).isSameAs(mapped);
@@ -395,8 +395,8 @@ class FilterAndMapTest {
 
     @Test
     void testIsNotLikeCaseInsensitiveRenderableTruePredicateShouldReturnSameObject() {
-        IsNotLikeCaseInsensitive cond = SqlBuilder.isNotLikeCaseInsensitive("Fred");
-        IsNotLikeCaseInsensitive filtered = cond.filter(s -> true);
+        var cond = SqlBuilder.isNotLikeCaseInsensitive("Fred");
+        var filtered = cond.filter(s -> true);
         assertThat(filtered.value()).isEqualTo("FRED");
         assertThat(filtered.isEmpty()).isFalse();
         assertThat(cond).isSameAs(filtered);
@@ -404,24 +404,24 @@ class FilterAndMapTest {
 
     @Test
     void testIsNotLikeCaseInsensitiveRenderableFalsePredicate() {
-        IsNotLikeCaseInsensitive cond = SqlBuilder.isNotLikeCaseInsensitive("Fred");
-        IsNotLikeCaseInsensitive filtered = cond.filter(s -> false);
+        var cond = SqlBuilder.isNotLikeCaseInsensitive("Fred");
+        var filtered = cond.filter(s -> false);
         assertThat(cond.isEmpty()).isFalse();
         assertThat(filtered.isEmpty()).isTrue();
     }
 
     @Test
     void testIsNotLikeCaseInsensitiveFilterUnRenderableShouldReturnSameObject() {
-        IsNotLikeCaseInsensitive cond = SqlBuilder.isNotLikeCaseInsensitive("Fred").filter(s -> false);
-        IsNotLikeCaseInsensitive filtered = cond.filter(s -> true);
+        var cond = SqlBuilder.isNotLikeCaseInsensitive("Fred").filter(s -> false);
+        var filtered = cond.filter(s -> true);
         assertThat(filtered.isEmpty()).isTrue();
         assertThat(cond).isSameAs(filtered);
     }
 
     @Test
     void testIsNotLikeCaseInsensitiveMapUnRenderableShouldNotThrowNullPointerException() {
-        IsNotLikeCaseInsensitive cond = SqlBuilder.isNotLikeCaseInsensitive("Fred").filter(s -> false);
-        IsNotLikeCaseInsensitive mapped = cond.map(String::toUpperCase);
+        var cond = SqlBuilder.isNotLikeCaseInsensitive("Fred").filter(s -> false);
+        var mapped = cond.map(String::toUpperCase);
         assertThat(cond.isEmpty()).isTrue();
         assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(cond::value);
         assertThat(cond).isSameAs(mapped);

--- a/src/test/java/org/mybatis/dynamic/sql/where/condition/FilterAndMapTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/where/condition/FilterAndMapTest.java
@@ -447,25 +447,25 @@ class FilterAndMapTest {
 
     @Test
     void testIsNotInCaseInsensitiveRenderableMapShouldReturnMappedObject() {
-        IsNotInCaseInsensitive cond = SqlBuilder.isNotInCaseInsensitive("Fred  ", "Wilma  ");
-        List<String> values = cond.values().toList();
+        var cond = SqlBuilder.isNotInCaseInsensitive("Fred  ", "Wilma  ");
+        var values = cond.values().toList();
         assertThat(values).containsExactly("FRED  ", "WILMA  ");
         assertThat(cond.isEmpty()).isFalse();
 
-        IsNotInCaseInsensitive mapped = cond.map(String::trim);
-        List<String> mappedValues = mapped.values().toList();
+        var mapped = cond.map(String::trim);
+        var mappedValues = mapped.values().toList();
         assertThat(mappedValues).containsExactly("FRED", "WILMA");
     }
 
     @Test
     void testIsInCaseInsensitiveRenderableMapShouldReturnMappedObject() {
-        IsInCaseInsensitive cond = SqlBuilder.isInCaseInsensitive("Fred  ", "Wilma  ");
-        List<String> values = cond.values().toList();
+        var cond = SqlBuilder.isInCaseInsensitive("Fred  ", "Wilma  ");
+        var values = cond.values().toList();
         assertThat(values).containsExactly("FRED  ", "WILMA  ");
         assertThat(cond.isEmpty()).isFalse();
 
-        IsInCaseInsensitive mapped = cond.map(String::trim);
-        List<String> mappedValues = mapped.values().toList();
+        var mapped = cond.map(String::trim);
+        var mappedValues = mapped.values().toList();
         assertThat(mappedValues).containsExactly("FRED", "WILMA");
     }
 

--- a/src/test/java/org/mybatis/dynamic/sql/where/condition/SupplierTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/where/condition/SupplierTest.java
@@ -260,28 +260,28 @@ class SupplierTest {
 
     @Test
     void testIsLikeCaseInsensitive() {
-        IsLikeCaseInsensitive cond = SqlBuilder.isLikeCaseInsensitive(() -> "%f%");
+        IsLikeCaseInsensitive<String> cond = SqlBuilder.isLikeCaseInsensitive(() -> "%f%");
         assertThat(cond.value()).isEqualTo("%F%");
         assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsLikeCaseInsensitiveNull() {
-        IsLikeCaseInsensitive cond = SqlBuilder.isLikeCaseInsensitive(() -> null);
+        IsLikeCaseInsensitive<String> cond = SqlBuilder.isLikeCaseInsensitive(() -> null);
         assertThat(cond.value()).isNull();
         assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsLikeCaseInsensitiveWhenPresent() {
-        IsLikeCaseInsensitive cond = SqlBuilder.isLikeCaseInsensitiveWhenPresent(() -> "%f%");
+        IsLikeCaseInsensitive<String> cond = SqlBuilder.isLikeCaseInsensitiveWhenPresent(() -> "%f%");
         assertThat(cond.value()).isEqualTo("%F%");
         assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsLikeCaseInsensitiveWhenPresentNull() {
-        IsLikeCaseInsensitive cond = SqlBuilder.isLikeCaseInsensitiveWhenPresent(() -> null);
+        IsLikeCaseInsensitive<String> cond = SqlBuilder.isLikeCaseInsensitiveWhenPresent(() -> null);
         assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(cond::value);
         assertThat(cond.isEmpty()).isTrue();
     }
@@ -330,28 +330,28 @@ class SupplierTest {
 
     @Test
     void testIsNotLikeCaseInsensitive() {
-        IsNotLikeCaseInsensitive cond = SqlBuilder.isNotLikeCaseInsensitive(() -> "%f%");
+        IsNotLikeCaseInsensitive<String> cond = SqlBuilder.isNotLikeCaseInsensitive(() -> "%f%");
         assertThat(cond.value()).isEqualTo("%F%");
         assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsNotLikeCaseInsensitiveNull() {
-        IsNotLikeCaseInsensitive cond = SqlBuilder.isNotLikeCaseInsensitive(() -> null);
+        IsNotLikeCaseInsensitive<String> cond = SqlBuilder.isNotLikeCaseInsensitive(() -> null);
         assertThat(cond.value()).isNull();
         assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsNotLikeCaseInsensitiveWhenPresent() {
-        IsNotLikeCaseInsensitive cond = SqlBuilder.isNotLikeCaseInsensitiveWhenPresent(() -> "%f%");
+        IsNotLikeCaseInsensitive<String> cond = SqlBuilder.isNotLikeCaseInsensitiveWhenPresent(() -> "%f%");
         assertThat(cond.value()).isEqualTo("%F%");
         assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsNotLikeCaseInsensitiveWhenPresentNull() {
-        IsNotLikeCaseInsensitive cond = SqlBuilder.isNotLikeCaseInsensitiveWhenPresent(() -> null);
+        IsNotLikeCaseInsensitive<String> cond = SqlBuilder.isNotLikeCaseInsensitiveWhenPresent(() -> null);
         assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(cond::value);
         assertThat(cond.isEmpty()).isTrue();
     }

--- a/src/test/kotlin/examples/kotlin/mybatis3/mariadb/KIsLikeEscape.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/mariadb/KIsLikeEscape.kt
@@ -10,7 +10,8 @@ import org.mybatis.dynamic.sql.util.FragmentAndParameters
 sealed class KIsLikeEscape<T : Any>(
     value: T,
     private val escapeCharacter: Char? = null
-) : AbstractSingleValueCondition<T>(value) {
+) : AbstractSingleValueCondition<T>(value), AbstractSingleValueCondition.Filterable<T>,
+    AbstractSingleValueCondition.Mappable<T> {
 
     override fun operator(): String = "like"
 

--- a/src/test/kotlin/examples/kotlin/mybatis3/mariadb/KIsLikeEscape.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/mariadb/KIsLikeEscape.kt
@@ -24,7 +24,7 @@ sealed class KIsLikeEscape<T : Any>(
     override fun filter(predicate: Predicate<in T>): KIsLikeEscape<T> =
         filterSupport(predicate, EmptyIsLikeEscape::empty, this)
 
-    fun <R : Any> map(mapper : Function<in T, out R>): KIsLikeEscape<R> =
+    override fun <R : Any> map(mapper : Function<in T, out R>): KIsLikeEscape<R> =
         mapSupport(mapper, { r -> ConcreteIsLikeEscape(r, escapeCharacter) }, EmptyIsLikeEscape::empty)
 
     companion object {


### PR DESCRIPTION
In #917 we added the ability to implement arbitrary conditions. With this PR, we make that easier to do - primarily by extracting the `filter` and `map` methods into interfaces that may or may not be implemented. This makes it easier to implement simple conditions and gives developers more choice over what they implement.

The built-in conditions all implement both `filter` and `map`, so there is no impact to existing code.