### PR TITLE
Improve case insensitive conditions

### DIFF
--- a/src/main/java/org/mybatis/dynamic/sql/util/StringUtilities.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/StringUtilities.java
@@ -15,8 +15,6 @@
  */
 package org.mybatis.dynamic.sql.util;
 
-import org.jspecify.annotations.Nullable;
-
 public interface StringUtilities {
 
     static String spaceAfter(String in) {
@@ -25,10 +23,6 @@ public interface StringUtilities {
 
     static String spaceBefore(String in) {
         return " " + in; //$NON-NLS-1$
-    }
-
-    static @Nullable String safelyUpperCase(@Nullable String s) {
-        return s == null ? null : s.toUpperCase();
     }
 
     static String toCamelCase(String inputString) {
@@ -63,7 +57,7 @@ public interface StringUtilities {
     static <T> T upperCaseIfPossible(T value) {
         if (value instanceof String) {
             @SuppressWarnings("unchecked")
-            T t = (T) safelyUpperCase((String) value);
+            T t = (T) ((String) value).toUpperCase();
             return t;
         }
 

--- a/src/main/java/org/mybatis/dynamic/sql/util/StringUtilities.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/StringUtilities.java
@@ -15,8 +15,6 @@
  */
 package org.mybatis.dynamic.sql.util;
 
-import java.util.function.Function;
-
 import org.jspecify.annotations.Nullable;
 
 public interface StringUtilities {
@@ -62,7 +60,13 @@ public interface StringUtilities {
         return "'" + escaped + "'"; //$NON-NLS-1$ //$NON-NLS-2$
     }
 
-    static Function<String, String> mapToUpperCase(Function<String, String> f) {
-        return f.andThen(String::toUpperCase);
+    static <T> T upperCaseIfPossible(T value) {
+        if (value instanceof String) {
+            @SuppressWarnings("unchecked")
+            T t = (T) safelyUpperCase((String) value);
+            return t;
+        }
+
+        return value;
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInCaseInsensitive.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInCaseInsensitive.java
@@ -20,7 +20,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import org.mybatis.dynamic.sql.AbstractListValueCondition;
 import org.mybatis.dynamic.sql.render.RenderingContext;
@@ -39,7 +38,7 @@ public class IsInCaseInsensitive<T> extends AbstractListValueCondition<T>
     }
 
     protected IsInCaseInsensitive(Collection<T> values) {
-        super(values.stream().map(StringUtilities::upperCaseIfPossible).collect(Collectors.toList()));
+        super(values.stream().map(StringUtilities::upperCaseIfPossible).toList());
     }
 
     @Override

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInCaseInsensitive.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInCaseInsensitive.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import org.mybatis.dynamic.sql.AbstractListValueCondition;
 import org.mybatis.dynamic.sql.render.RenderingContext;
@@ -38,7 +39,7 @@ public class IsInCaseInsensitive<T> extends AbstractListValueCondition<T>
     }
 
     protected IsInCaseInsensitive(Collection<T> values) {
-        super(values);
+        super(values.stream().map(StringUtilities::upperCaseIfPossible).collect(Collectors.toList()));
     }
 
     @Override
@@ -57,19 +58,6 @@ public class IsInCaseInsensitive<T> extends AbstractListValueCondition<T>
         return filterSupport(predicate, IsInCaseInsensitive::new, this, IsInCaseInsensitive::empty);
     }
 
-    /**
-     * If renderable, apply the mapping to the value and return a new condition with the new value. Else return a
-     * condition that will not render (this).
-     *
-     * <p>This function DOES NOT automatically transform values to uppercase, so it potentially creates a
-     * case-sensitive query. For String conditions you can use {@link StringUtilities#mapToUpperCase(Function)}
-     * to add an uppercase transform after your mapping function.
-     *
-     * @param mapper a mapping function to apply to the value, if renderable
-     * @param <R> type of the new condition
-     * @return a new condition with the result of applying the mapper to the value of this condition,
-     *     if renderable, otherwise a condition that will not render.
-     */
     @Override
     public <R> IsInCaseInsensitive<R> map(Function<? super T, ? extends R> mapper) {
         return mapSupport(mapper, IsInCaseInsensitive::new, IsInCaseInsensitive::empty);
@@ -80,7 +68,6 @@ public class IsInCaseInsensitive<T> extends AbstractListValueCondition<T>
     }
 
     public static IsInCaseInsensitive<String> of(Collection<String> values) {
-        // Keep the null safe upper case utility for backwards compatibility in case someone passes in a null
-        return new IsInCaseInsensitive<>(values.stream().map(StringUtilities::safelyUpperCase).toList());
+        return new IsInCaseInsensitive<>(values);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInCaseInsensitiveWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInCaseInsensitiveWhenPresent.java
@@ -39,7 +39,7 @@ public class IsInCaseInsensitiveWhenPresent<T> extends AbstractListValueConditio
     }
 
     protected IsInCaseInsensitiveWhenPresent(Collection<T> values) {
-        super(values);
+        super(values.stream().filter(Objects::nonNull).map(StringUtilities::upperCaseIfPossible).toList());
     }
 
     @Override
@@ -53,19 +53,6 @@ public class IsInCaseInsensitiveWhenPresent<T> extends AbstractListValueConditio
                 IsInCaseInsensitiveWhenPresent::empty);
     }
 
-    /**
-     * If renderable, apply the mapping to the value and return a new condition with the new value. Else return a
-     * condition that will not render (this).
-     *
-     * <p>This function DOES NOT automatically transform values to uppercase, so it potentially creates a
-     * case-sensitive query. For String conditions you can use {@link StringUtilities#mapToUpperCase(Function)}
-     * to add an uppercase transform after your mapping function.
-     *
-     * @param mapper a mapping function to apply to the value, if renderable
-     * @param <R> type of the new condition
-     * @return a new condition with the result of applying the mapper to the value of this condition,
-     *     if renderable, otherwise a condition that will not render.
-     */
     @Override
     public <R> IsInCaseInsensitiveWhenPresent<R> map(Function<? super T, ? extends R> mapper) {
         return mapSupport(mapper, IsInCaseInsensitiveWhenPresent::new, IsInCaseInsensitiveWhenPresent::empty);
@@ -76,7 +63,6 @@ public class IsInCaseInsensitiveWhenPresent<T> extends AbstractListValueConditio
     }
 
     public static IsInCaseInsensitiveWhenPresent<String> of(Collection<@Nullable String> values) {
-        return new IsInCaseInsensitiveWhenPresent<>(
-                values.stream().filter(Objects::nonNull).map(String::toUpperCase).toList());
+        return new IsInCaseInsensitiveWhenPresent<>(values);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLikeCaseInsensitive.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLikeCaseInsensitive.java
@@ -44,7 +44,7 @@ public class IsLikeCaseInsensitive<T> extends AbstractSingleValueCondition<T>
     }
 
     protected IsLikeCaseInsensitive(T value) {
-        super(value);
+        super(StringUtilities.upperCaseIfPossible(value));
     }
 
     @Override
@@ -57,26 +57,12 @@ public class IsLikeCaseInsensitive<T> extends AbstractSingleValueCondition<T>
         return filterSupport(predicate, IsLikeCaseInsensitive::empty, this);
     }
 
-    /**
-     * If renderable, apply the mapping to the value and return a new condition with the new value. Else return a
-     * condition that will not render (this).
-     *
-     * <p>This function DOES NOT automatically transform values to uppercase, so it potentially creates a
-     * case-sensitive query. For String conditions you can use {@link StringUtilities#mapToUpperCase(Function)}
-     * to add an uppercase transform after your mapping function.
-     *
-     * @param mapper a mapping function to apply to the value, if renderable
-     * @param <R> type of the new condition
-     * @return a new condition with the result of applying the mapper to the value of this condition,
-     *     if renderable, otherwise a condition that will not render.
-     */
     @Override
     public <R> IsLikeCaseInsensitive<R> map(Function<? super T, ? extends R> mapper) {
         return mapSupport(mapper, IsLikeCaseInsensitive::new, IsLikeCaseInsensitive::empty);
     }
 
     public static IsLikeCaseInsensitive<String> of(String value) {
-        // Keep the null safe upper case utility for backwards compatibility in case someone passes in a null
-        return new IsLikeCaseInsensitive<>(StringUtilities.safelyUpperCase(value));
+        return new IsLikeCaseInsensitive<>(value);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInCaseInsensitive.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInCaseInsensitive.java
@@ -38,7 +38,7 @@ public class IsNotInCaseInsensitive<T> extends AbstractListValueCondition<T>
     }
 
     protected IsNotInCaseInsensitive(Collection<T> values) {
-        super(values);
+        super(values.stream().map(StringUtilities::upperCaseIfPossible).toList());
     }
 
     @Override
@@ -57,19 +57,6 @@ public class IsNotInCaseInsensitive<T> extends AbstractListValueCondition<T>
         return filterSupport(predicate, IsNotInCaseInsensitive::new, this, IsNotInCaseInsensitive::empty);
     }
 
-    /**
-     * If renderable, apply the mapping to the value and return a new condition with the new value. Else return a
-     * condition that will not render (this).
-     *
-     * <p>This function DOES NOT automatically transform values to uppercase, so it potentially creates a
-     * case-sensitive query. For String conditions you can use {@link StringUtilities#mapToUpperCase(Function)}
-     * to add an uppercase transform after your mapping function.
-     *
-     * @param mapper a mapping function to apply to the value, if renderable
-     * @param <R> type of the new condition
-     * @return a new condition with the result of applying the mapper to the value of this condition,
-     *     if renderable, otherwise a condition that will not render.
-     */
     @Override
     public <R> IsNotInCaseInsensitive<R> map(Function<? super T, ? extends R> mapper) {
         return mapSupport(mapper, IsNotInCaseInsensitive::new, IsNotInCaseInsensitive::empty);
@@ -80,7 +67,6 @@ public class IsNotInCaseInsensitive<T> extends AbstractListValueCondition<T>
     }
 
     public static IsNotInCaseInsensitive<String> of(Collection<String> values) {
-        // Keep the null safe upper case utility for backwards compatibility in case someone passes in a null
-        return new IsNotInCaseInsensitive<>(values.stream().map(StringUtilities::safelyUpperCase).toList());
+        return new IsNotInCaseInsensitive<>(values);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInCaseInsensitiveWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInCaseInsensitiveWhenPresent.java
@@ -39,7 +39,7 @@ public class IsNotInCaseInsensitiveWhenPresent<T> extends AbstractListValueCondi
     }
 
     protected IsNotInCaseInsensitiveWhenPresent(Collection<T> values) {
-        super(values);
+        super(values.stream().filter(Objects::nonNull).map(StringUtilities::upperCaseIfPossible).toList());
     }
 
     @Override
@@ -53,19 +53,6 @@ public class IsNotInCaseInsensitiveWhenPresent<T> extends AbstractListValueCondi
                 this, IsNotInCaseInsensitiveWhenPresent::empty);
     }
 
-    /**
-     * If renderable, apply the mapping to the value and return a new condition with the new value. Else return a
-     * condition that will not render (this).
-     *
-     * <p>This function DOES NOT automatically transform values to uppercase, so it potentially creates a
-     * case-sensitive query. For String conditions you can use {@link StringUtilities#mapToUpperCase(Function)}
-     * to add an uppercase transform after your mapping function.
-     *
-     * @param mapper a mapping function to apply to the value, if renderable
-     * @param <R> type of the new condition
-     * @return a new condition with the result of applying the mapper to the value of this condition,
-     *     if renderable, otherwise a condition that will not render.
-     */
     @Override
     public <R> IsNotInCaseInsensitiveWhenPresent<R> map(Function<? super T, ? extends R> mapper) {
         return mapSupport(mapper, IsNotInCaseInsensitiveWhenPresent::new, IsNotInCaseInsensitiveWhenPresent::empty);
@@ -76,7 +63,6 @@ public class IsNotInCaseInsensitiveWhenPresent<T> extends AbstractListValueCondi
     }
 
     public static IsNotInCaseInsensitiveWhenPresent<String> of(Collection<@Nullable String> values) {
-        return new IsNotInCaseInsensitiveWhenPresent<>(
-                values.stream().filter(Objects::nonNull).map(String::toUpperCase).toList());
+        return new IsNotInCaseInsensitiveWhenPresent<>(values);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotLikeCaseInsensitive.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotLikeCaseInsensitive.java
@@ -44,7 +44,7 @@ public class IsNotLikeCaseInsensitive<T> extends AbstractSingleValueCondition<T>
     }
 
     protected IsNotLikeCaseInsensitive(T value) {
-        super(value);
+        super(StringUtilities.upperCaseIfPossible(value));
     }
 
     @Override
@@ -57,26 +57,12 @@ public class IsNotLikeCaseInsensitive<T> extends AbstractSingleValueCondition<T>
         return filterSupport(predicate, IsNotLikeCaseInsensitive::empty, this);
     }
 
-    /**
-     * If renderable, apply the mapping to the value and return a new condition with the new value. Else return a
-     * condition that will not render (this).
-     *
-     * <p>This function DOES NOT automatically transform values to uppercase, so it potentially creates a
-     * case-sensitive query. For String conditions you can use {@link StringUtilities#mapToUpperCase(Function)}
-     * to add an uppercase transform after your mapping function.
-     *
-     * @param mapper a mapping function to apply to the value, if renderable
-     * @param <R> type of the new condition
-     * @return a new condition with the result of applying the mapper to the value of this condition,
-     *     if renderable, otherwise a condition that will not render.
-     */
     @Override
     public <R> IsNotLikeCaseInsensitive<R> map(Function<? super T, ? extends R> mapper) {
         return mapSupport(mapper, IsNotLikeCaseInsensitive::new, IsNotLikeCaseInsensitive::empty);
     }
 
     public static IsNotLikeCaseInsensitive<String> of(String value) {
-        // Keep the null safe upper case utility for backwards compatibility in case someone passes in a null
-        return new IsNotLikeCaseInsensitive<>(StringUtilities.safelyUpperCase(value));
+        return new IsNotLikeCaseInsensitive<>(value);
     }
 }

--- a/src/test/java/org/mybatis/dynamic/sql/util/StringUtilitiesTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/util/StringUtilitiesTest.java
@@ -38,4 +38,16 @@ class StringUtilitiesTest {
         String input = "USER%NAME%3";
         assertThat(StringUtilities.toCamelCase(input)).isEqualTo("userName3");
     }
+
+    @Test
+    void testUpperCaseInteger() {
+        Integer i = StringUtilities.upperCaseIfPossible(3);
+        assertThat(i).isEqualTo(3);
+    }
+
+    @Test
+    void testUpperCaseString() {
+        String i = StringUtilities.upperCaseIfPossible("fred");
+        assertThat(i).isEqualTo("FRED");
+    }
 }

--- a/src/test/java/org/mybatis/dynamic/sql/where/condition/FilterAndMapTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/where/condition/FilterAndMapTest.java
@@ -24,7 +24,6 @@ import java.util.Objects;
 
 import org.junit.jupiter.api.Test;
 import org.mybatis.dynamic.sql.SqlBuilder;
-import org.mybatis.dynamic.sql.util.StringUtilities;
 
 class FilterAndMapTest {
     @Test
@@ -544,30 +543,16 @@ class FilterAndMapTest {
     }
 
     @Test
-    void testIsInCaseInsensitiveWhenPresentMap() {
-        var cond = SqlBuilder.isInCaseInsensitiveWhenPresent("Fred", "Wilma");
-        var mapped = cond.map(s -> s + " Flintstone");
-        assertThat(mapped.values().toList()).containsExactly("FRED Flintstone", "WILMA Flintstone");
-    }
-
-    @Test
     void testIsInCaseInsensitiveWhenPresentMapCaseInsensitive() {
         var cond = SqlBuilder.isInCaseInsensitiveWhenPresent("Fred", "Wilma");
-        var mapped = cond.map(StringUtilities.mapToUpperCase(s -> s + " Flintstone"));
-        assertThat(mapped.values().toList()).containsExactly("FRED FLINTSTONE", "WILMA FLINTSTONE");
-    }
-
-    @Test
-    void testIsNotInCaseInsensitiveWhenPresentMap() {
-        var cond = SqlBuilder.isNotInCaseInsensitiveWhenPresent("Fred", "Wilma");
         var mapped = cond.map(s -> s + " Flintstone");
-        assertThat(mapped.values().toList()).containsExactly("FRED Flintstone", "WILMA Flintstone");
+        assertThat(mapped.values().toList()).containsExactly("FRED FLINTSTONE", "WILMA FLINTSTONE");
     }
 
     @Test
     void testIsNotInCaseInsensitiveWhenPresentMapCaseInsensitive() {
         var cond = SqlBuilder.isNotInCaseInsensitiveWhenPresent("Fred", "Wilma");
-        var mapped = cond.map(StringUtilities.mapToUpperCase(s -> s + " Flintstone"));
+        var mapped = cond.map(s -> s + " Flintstone");
         assertThat(mapped.values().toList()).containsExactly("FRED FLINTSTONE", "WILMA FLINTSTONE");
     }
 }


### PR DESCRIPTION
Make the case-insensitive conditions work as expected. With a map operation, the values will now be upper-cased if possible.