### PR TITLE
JSpecify Related Update: Properly handle nulls in the "when present" conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,8 @@ Runtime behavior changes:
 2. We have updated the "ParameterTypeConverter" used in Spring applications to maintain compatibility with Spring's
    "Converter" interface. The primary change is that the framework will no longer call a type converter if the
    input value is null. This should simplify the coding of converters and foster reuse with existing Spring converters.
+3. The "map" method on the "WhenPresent" conditions will accept a mapper function that may return a null value. The
+   conditions will now properly handle this outcome 
 
 ### Other important changes:
 

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,8 @@
 
     <sonar.sources>pom.xml,src/main/java,src/main/kotlin</sonar.sources>
     <sonar.tests>src/test/java,src/test/kotlin</sonar.tests>
+    <!-- setup sonar to run locally by default -->
+    <sonar.host.url>http://localhost:9000</sonar.host.url>
 
     <kotlin.code.style>official</kotlin.code.style>
     <test.containers.version>1.20.6</test.containers.version>

--- a/src/main/java/org/mybatis/dynamic/sql/AbstractListValueCondition.java
+++ b/src/main/java/org/mybatis/dynamic/sql/AbstractListValueCondition.java
@@ -23,6 +23,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.jspecify.annotations.NonNull;
 import org.mybatis.dynamic.sql.render.RenderedParameterInfo;
 import org.mybatis.dynamic.sql.render.RenderingContext;
 import org.mybatis.dynamic.sql.util.FragmentAndParameters;
@@ -113,7 +114,7 @@ public abstract class AbstractListValueCondition<T> implements RenderableConditi
          * @return this condition if renderable and the value matches the predicate, otherwise a condition
          *     that will not render.
          */
-        AbstractListValueCondition<T> filter(Predicate<? super T> predicate);
+        AbstractListValueCondition<T> filter(Predicate<? super @NonNull T> predicate);
     }
 
     /**
@@ -138,6 +139,6 @@ public abstract class AbstractListValueCondition<T> implements RenderableConditi
          * @return a new condition with the result of applying the mapper to the value of this condition,
          *     if renderable, otherwise a condition that will not render.
          */
-        <R> AbstractListValueCondition<R> map(Function<? super T, ? extends R> mapper);
+        <R> AbstractListValueCondition<R> map(Function<? super @NonNull T, ? extends R> mapper);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/AbstractNoValueCondition.java
+++ b/src/main/java/org/mybatis/dynamic/sql/AbstractNoValueCondition.java
@@ -60,7 +60,8 @@ public abstract class AbstractNoValueCondition<T> implements RenderableCondition
          * @param <S>
          *            condition type - not used except for compilation compliance
          *
-         * @return this condition if renderable and the supplier returns true, otherwise a condition that will not render.
+         * @return this condition if renderable and the supplier returns true, otherwise a condition that will not
+         *     render.
          */
         <S> AbstractNoValueCondition<S> filter(BooleanSupplier booleanSupplier);
     }

--- a/src/main/java/org/mybatis/dynamic/sql/AbstractSingleValueCondition.java
+++ b/src/main/java/org/mybatis/dynamic/sql/AbstractSingleValueCondition.java
@@ -21,6 +21,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
+import org.jspecify.annotations.NonNull;
 import org.mybatis.dynamic.sql.render.RenderedParameterInfo;
 import org.mybatis.dynamic.sql.render.RenderingContext;
 import org.mybatis.dynamic.sql.util.FragmentAndParameters;
@@ -88,7 +89,7 @@ public abstract class AbstractSingleValueCondition<T> implements RenderableCondi
          * @return this condition if renderable and the value matches the predicate, otherwise a condition
          *     that will not render.
          */
-        AbstractSingleValueCondition<T> filter(Predicate<? super T> predicate);
+        AbstractSingleValueCondition<T> filter(Predicate<? super @NonNull T> predicate);
     }
 
     /**
@@ -113,6 +114,6 @@ public abstract class AbstractSingleValueCondition<T> implements RenderableCondi
          * @return a new condition with the result of applying the mapper to the value of this condition,
          *     if renderable, otherwise a condition that will not render.
          */
-        <R> AbstractSingleValueCondition<R> map(Function<? super T, ? extends R> mapper);
+        <R> AbstractSingleValueCondition<R> map(Function<? super @NonNull T, ? extends R> mapper);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/AbstractTwoValueCondition.java
+++ b/src/main/java/org/mybatis/dynamic/sql/AbstractTwoValueCondition.java
@@ -23,6 +23,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
+import org.jspecify.annotations.NonNull;
 import org.mybatis.dynamic.sql.render.RenderedParameterInfo;
 import org.mybatis.dynamic.sql.render.RenderingContext;
 import org.mybatis.dynamic.sql.util.FragmentAndParameters;
@@ -110,7 +111,7 @@ public abstract class AbstractTwoValueCondition<T> implements RenderableConditio
          * @return this condition if renderable and the values match the predicate, otherwise a condition
          *     that will not render.
          */
-        AbstractTwoValueCondition<T> filter(BiPredicate<? super T, ? super T> predicate);
+        AbstractTwoValueCondition<T> filter(BiPredicate<? super @NonNull T, ? super @NonNull T> predicate);
 
         /**
          * If renderable and both values match the predicate, returns this condition. Else returns a condition
@@ -121,7 +122,7 @@ public abstract class AbstractTwoValueCondition<T> implements RenderableConditio
          * @return this condition if renderable and the values match the predicate, otherwise a condition
          *     that will not render.
          */
-        AbstractTwoValueCondition<T> filter(Predicate<? super T> predicate);
+        AbstractTwoValueCondition<T> filter(Predicate<? super @NonNull T> predicate);
     }
 
     /**
@@ -147,8 +148,8 @@ public abstract class AbstractTwoValueCondition<T> implements RenderableConditio
          * @return a new condition with the result of applying the mappers to the values of this condition,
          *     if renderable, otherwise a condition that will not render.
          */
-        <R> AbstractTwoValueCondition<R> map(Function<? super T, ? extends R> mapper1,
-                                             Function<? super T, ? extends R> mapper2);
+        <R> AbstractTwoValueCondition<R> map(Function<? super @NonNull T, ? extends R> mapper1,
+                                             Function<? super @NonNull T, ? extends R> mapper2);
 
         /**
          * If renderable, apply the mapping to both values and return a new condition with the new values. Else return a
@@ -159,6 +160,6 @@ public abstract class AbstractTwoValueCondition<T> implements RenderableConditio
          * @return a new condition with the result of applying the mappers to the values of this condition,
          *     if renderable, otherwise a condition that will not render.
          */
-        <R> AbstractTwoValueCondition<R> map(Function<? super T, ? extends R> mapper);
+        <R> AbstractTwoValueCondition<R> map(Function<? super @NonNull T, ? extends R> mapper);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/SqlBuilder.java
+++ b/src/main/java/org/mybatis/dynamic/sql/SqlBuilder.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Supplier;
 
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.mybatis.dynamic.sql.delete.DeleteDSL;
 import org.mybatis.dynamic.sql.delete.DeleteModel;
@@ -62,14 +63,18 @@ import org.mybatis.dynamic.sql.update.UpdateModel;
 import org.mybatis.dynamic.sql.util.Buildable;
 import org.mybatis.dynamic.sql.where.WhereDSL;
 import org.mybatis.dynamic.sql.where.condition.IsBetween;
+import org.mybatis.dynamic.sql.where.condition.IsBetweenWhenPresent;
 import org.mybatis.dynamic.sql.where.condition.IsEqualTo;
 import org.mybatis.dynamic.sql.where.condition.IsEqualToColumn;
+import org.mybatis.dynamic.sql.where.condition.IsEqualToWhenPresent;
 import org.mybatis.dynamic.sql.where.condition.IsEqualToWithSubselect;
 import org.mybatis.dynamic.sql.where.condition.IsGreaterThan;
 import org.mybatis.dynamic.sql.where.condition.IsGreaterThanColumn;
 import org.mybatis.dynamic.sql.where.condition.IsGreaterThanOrEqualTo;
 import org.mybatis.dynamic.sql.where.condition.IsGreaterThanOrEqualToColumn;
+import org.mybatis.dynamic.sql.where.condition.IsGreaterThanOrEqualToWhenPresent;
 import org.mybatis.dynamic.sql.where.condition.IsGreaterThanOrEqualToWithSubselect;
+import org.mybatis.dynamic.sql.where.condition.IsGreaterThanWhenPresent;
 import org.mybatis.dynamic.sql.where.condition.IsGreaterThanWithSubselect;
 import org.mybatis.dynamic.sql.where.condition.IsIn;
 import org.mybatis.dynamic.sql.where.condition.IsInCaseInsensitive;
@@ -80,13 +85,19 @@ import org.mybatis.dynamic.sql.where.condition.IsLessThan;
 import org.mybatis.dynamic.sql.where.condition.IsLessThanColumn;
 import org.mybatis.dynamic.sql.where.condition.IsLessThanOrEqualTo;
 import org.mybatis.dynamic.sql.where.condition.IsLessThanOrEqualToColumn;
+import org.mybatis.dynamic.sql.where.condition.IsLessThanOrEqualToWhenPresent;
 import org.mybatis.dynamic.sql.where.condition.IsLessThanOrEqualToWithSubselect;
+import org.mybatis.dynamic.sql.where.condition.IsLessThanWhenPresent;
 import org.mybatis.dynamic.sql.where.condition.IsLessThanWithSubselect;
 import org.mybatis.dynamic.sql.where.condition.IsLike;
 import org.mybatis.dynamic.sql.where.condition.IsLikeCaseInsensitive;
+import org.mybatis.dynamic.sql.where.condition.IsLikeCaseInsensitiveWhenPresent;
+import org.mybatis.dynamic.sql.where.condition.IsLikeWhenPresent;
 import org.mybatis.dynamic.sql.where.condition.IsNotBetween;
+import org.mybatis.dynamic.sql.where.condition.IsNotBetweenWhenPresent;
 import org.mybatis.dynamic.sql.where.condition.IsNotEqualTo;
 import org.mybatis.dynamic.sql.where.condition.IsNotEqualToColumn;
+import org.mybatis.dynamic.sql.where.condition.IsNotEqualToWhenPresent;
 import org.mybatis.dynamic.sql.where.condition.IsNotEqualToWithSubselect;
 import org.mybatis.dynamic.sql.where.condition.IsNotIn;
 import org.mybatis.dynamic.sql.where.condition.IsNotInCaseInsensitive;
@@ -95,6 +106,8 @@ import org.mybatis.dynamic.sql.where.condition.IsNotInWhenPresent;
 import org.mybatis.dynamic.sql.where.condition.IsNotInWithSubselect;
 import org.mybatis.dynamic.sql.where.condition.IsNotLike;
 import org.mybatis.dynamic.sql.where.condition.IsNotLikeCaseInsensitive;
+import org.mybatis.dynamic.sql.where.condition.IsNotLikeCaseInsensitiveWhenPresent;
+import org.mybatis.dynamic.sql.where.condition.IsNotLikeWhenPresent;
 import org.mybatis.dynamic.sql.where.condition.IsNotNull;
 import org.mybatis.dynamic.sql.where.condition.IsNull;
 
@@ -634,11 +647,11 @@ public interface SqlBuilder {
         return IsEqualToColumn.of(column);
     }
 
-    static <T> IsEqualTo<T> isEqualToWhenPresent(@Nullable T value) {
-        return value == null ? IsEqualTo.empty() : IsEqualTo.of(value);
+    static <T> IsEqualToWhenPresent<T> isEqualToWhenPresent(@Nullable T value) {
+        return IsEqualToWhenPresent.of(value);
     }
 
-    static <T> IsEqualTo<T> isEqualToWhenPresent(Supplier<@Nullable T> valueSupplier) {
+    static <T> IsEqualToWhenPresent<T> isEqualToWhenPresent(Supplier<@Nullable T> valueSupplier) {
         return isEqualToWhenPresent(valueSupplier.get());
     }
 
@@ -658,11 +671,11 @@ public interface SqlBuilder {
         return IsNotEqualToColumn.of(column);
     }
 
-    static <T> IsNotEqualTo<T> isNotEqualToWhenPresent(@Nullable T value) {
-        return value == null ? IsNotEqualTo.empty() : IsNotEqualTo.of(value);
+    static <T> IsNotEqualToWhenPresent<T> isNotEqualToWhenPresent(@Nullable T value) {
+        return IsNotEqualToWhenPresent.of(value);
     }
 
-    static <T> IsNotEqualTo<T> isNotEqualToWhenPresent(Supplier<@Nullable T> valueSupplier) {
+    static <T> IsNotEqualToWhenPresent<T> isNotEqualToWhenPresent(Supplier<@Nullable T> valueSupplier) {
         return isNotEqualToWhenPresent(valueSupplier.get());
     }
 
@@ -682,11 +695,11 @@ public interface SqlBuilder {
         return IsGreaterThanColumn.of(column);
     }
 
-    static <T> IsGreaterThan<T> isGreaterThanWhenPresent(@Nullable T value) {
-        return value == null ? IsGreaterThan.empty() : IsGreaterThan.of(value);
+    static <T> IsGreaterThanWhenPresent<T> isGreaterThanWhenPresent(@Nullable T value) {
+        return IsGreaterThanWhenPresent.of(value);
     }
 
-    static <T> IsGreaterThan<T> isGreaterThanWhenPresent(Supplier<@Nullable T> valueSupplier) {
+    static <T> IsGreaterThanWhenPresent<T> isGreaterThanWhenPresent(Supplier<@Nullable T> valueSupplier) {
         return isGreaterThanWhenPresent(valueSupplier.get());
     }
 
@@ -707,11 +720,12 @@ public interface SqlBuilder {
         return IsGreaterThanOrEqualToColumn.of(column);
     }
 
-    static <T> IsGreaterThanOrEqualTo<T> isGreaterThanOrEqualToWhenPresent(@Nullable T value) {
-        return value == null ? IsGreaterThanOrEqualTo.empty() : IsGreaterThanOrEqualTo.of(value);
+    static <T> IsGreaterThanOrEqualToWhenPresent<T> isGreaterThanOrEqualToWhenPresent(@Nullable T value) {
+        return IsGreaterThanOrEqualToWhenPresent.of(value);
     }
 
-    static <T> IsGreaterThanOrEqualTo<T> isGreaterThanOrEqualToWhenPresent(Supplier<@Nullable T> valueSupplier) {
+    static <T> IsGreaterThanOrEqualToWhenPresent<T> isGreaterThanOrEqualToWhenPresent(
+            Supplier<@Nullable T> valueSupplier) {
         return isGreaterThanOrEqualToWhenPresent(valueSupplier.get());
     }
 
@@ -731,11 +745,11 @@ public interface SqlBuilder {
         return IsLessThanColumn.of(column);
     }
 
-    static <T> IsLessThan<T> isLessThanWhenPresent(@Nullable T value) {
-        return value == null ? IsLessThan.empty() : IsLessThan.of(value);
+    static <T> IsLessThanWhenPresent<T> isLessThanWhenPresent(@Nullable T value) {
+        return IsLessThanWhenPresent.of(value);
     }
 
-    static <T> IsLessThan<T> isLessThanWhenPresent(Supplier<@Nullable T> valueSupplier) {
+    static <T> IsLessThanWhenPresent<T> isLessThanWhenPresent(Supplier<@Nullable T> valueSupplier) {
         return isLessThanWhenPresent(valueSupplier.get());
     }
 
@@ -755,20 +769,20 @@ public interface SqlBuilder {
         return IsLessThanOrEqualToColumn.of(column);
     }
 
-    static <T> IsLessThanOrEqualTo<T> isLessThanOrEqualToWhenPresent(@Nullable T value) {
-        return value == null ? IsLessThanOrEqualTo.empty() : IsLessThanOrEqualTo.of(value);
+    static <T> IsLessThanOrEqualToWhenPresent<T> isLessThanOrEqualToWhenPresent(@Nullable T value) {
+        return IsLessThanOrEqualToWhenPresent.of(value);
     }
 
-    static <T> IsLessThanOrEqualTo<T> isLessThanOrEqualToWhenPresent(Supplier<@Nullable T> valueSupplier) {
+    static <T> IsLessThanOrEqualToWhenPresent<T> isLessThanOrEqualToWhenPresent(Supplier<@Nullable T> valueSupplier) {
         return isLessThanOrEqualToWhenPresent(valueSupplier.get());
     }
 
     @SafeVarargs
-    static <T> IsIn<T> isIn(T... values) {
+    static <T> IsIn<T> isIn(@NonNull T... values) {
         return IsIn.of(values);
     }
 
-    static <T> IsIn<T> isIn(Collection<T> values) {
+    static <T> IsIn<T> isIn(Collection<@NonNull T> values) {
         return IsIn.of(values);
     }
 
@@ -782,15 +796,15 @@ public interface SqlBuilder {
     }
 
     static <T> IsInWhenPresent<T> isInWhenPresent(@Nullable Collection<@Nullable T> values) {
-        return values == null ? IsInWhenPresent.empty() : IsInWhenPresent.of(values);
+        return IsInWhenPresent.of(values);
     }
 
     @SafeVarargs
-    static <T> IsNotIn<T> isNotIn(T... values) {
+    static <T> IsNotIn<T> isNotIn(@NonNull T... values) {
         return IsNotIn.of(values);
     }
 
-    static <T> IsNotIn<T> isNotIn(Collection<T> values) {
+    static <T> IsNotIn<T> isNotIn(Collection<@NonNull T> values) {
         return IsNotIn.of(values);
     }
 
@@ -804,22 +818,22 @@ public interface SqlBuilder {
     }
 
     static <T> IsNotInWhenPresent<T> isNotInWhenPresent(@Nullable Collection<@Nullable T> values) {
-        return values == null ? IsNotInWhenPresent.empty() : IsNotInWhenPresent.of(values);
+        return IsNotInWhenPresent.of(values);
     }
 
     static <T> IsBetween.Builder<T> isBetween(T value1) {
         return IsBetween.isBetween(value1);
     }
 
-    static <T> IsBetween.Builder<T> isBetween(Supplier<T> valueSupplier1) {
+    static <T> IsBetween.Builder<T> isBetween(Supplier<@NonNull T> valueSupplier1) {
         return isBetween(valueSupplier1.get());
     }
 
-    static <T> IsBetween.WhenPresentBuilder<T> isBetweenWhenPresent(@Nullable T value1) {
-        return IsBetween.isBetweenWhenPresent(value1);
+    static <T> IsBetweenWhenPresent.Builder<T> isBetweenWhenPresent(@Nullable T value1) {
+        return IsBetweenWhenPresent.isBetweenWhenPresent(value1);
     }
 
-    static <T> IsBetween.WhenPresentBuilder<T> isBetweenWhenPresent(Supplier<@Nullable T> valueSupplier1) {
+    static <T> IsBetweenWhenPresent.Builder<T> isBetweenWhenPresent(Supplier<@Nullable T> valueSupplier1) {
         return isBetweenWhenPresent(valueSupplier1.get());
     }
 
@@ -827,15 +841,15 @@ public interface SqlBuilder {
         return IsNotBetween.isNotBetween(value1);
     }
 
-    static <T> IsNotBetween.Builder<T> isNotBetween(Supplier<T> valueSupplier1) {
+    static <T> IsNotBetween.Builder<T> isNotBetween(Supplier<@NonNull T> valueSupplier1) {
         return isNotBetween(valueSupplier1.get());
     }
 
-    static <T> IsNotBetween.WhenPresentBuilder<T> isNotBetweenWhenPresent(@Nullable T value1) {
-        return IsNotBetween.isNotBetweenWhenPresent(value1);
+    static <T> IsNotBetweenWhenPresent.Builder<T> isNotBetweenWhenPresent(@Nullable T value1) {
+        return IsNotBetweenWhenPresent.isNotBetweenWhenPresent(value1);
     }
 
-    static <T> IsNotBetween.WhenPresentBuilder<T> isNotBetweenWhenPresent(Supplier<@Nullable T> valueSupplier1) {
+    static <T> IsNotBetweenWhenPresent.Builder<T> isNotBetweenWhenPresent(Supplier<@Nullable T> valueSupplier1) {
         return isNotBetweenWhenPresent(valueSupplier1.get());
     }
 
@@ -848,11 +862,11 @@ public interface SqlBuilder {
         return isLike(valueSupplier.get());
     }
 
-    static <T> IsLike<T> isLikeWhenPresent(@Nullable T value) {
-        return value == null ? IsLike.empty() : IsLike.of(value);
+    static <T> IsLikeWhenPresent<T> isLikeWhenPresent(@Nullable T value) {
+        return IsLikeWhenPresent.of(value);
     }
 
-    static <T> IsLike<T> isLikeWhenPresent(Supplier<@Nullable T> valueSupplier) {
+    static <T> IsLikeWhenPresent<T> isLikeWhenPresent(Supplier<@Nullable T> valueSupplier) {
         return isLikeWhenPresent(valueSupplier.get());
     }
 
@@ -864,11 +878,11 @@ public interface SqlBuilder {
         return isNotLike(valueSupplier.get());
     }
 
-    static <T> IsNotLike<T> isNotLikeWhenPresent(@Nullable T value) {
-        return value == null ? IsNotLike.empty() : IsNotLike.of(value);
+    static <T> IsNotLikeWhenPresent<T> isNotLikeWhenPresent(@Nullable T value) {
+        return IsNotLikeWhenPresent.of(value);
     }
 
-    static <T> IsNotLike<T> isNotLikeWhenPresent(Supplier<@Nullable T> valueSupplier) {
+    static <T> IsNotLikeWhenPresent<T> isNotLikeWhenPresent(Supplier<@Nullable T> valueSupplier) {
         return isNotLikeWhenPresent(valueSupplier.get());
     }
 
@@ -890,11 +904,12 @@ public interface SqlBuilder {
         return isLikeCaseInsensitive(valueSupplier.get());
     }
 
-    static IsLikeCaseInsensitive<String> isLikeCaseInsensitiveWhenPresent(@Nullable String value) {
-        return value == null ? IsLikeCaseInsensitive.empty() : IsLikeCaseInsensitive.of(value);
+    static IsLikeCaseInsensitiveWhenPresent<String> isLikeCaseInsensitiveWhenPresent(@Nullable String value) {
+        return IsLikeCaseInsensitiveWhenPresent.of(value);
     }
 
-    static IsLikeCaseInsensitive<String> isLikeCaseInsensitiveWhenPresent(Supplier<@Nullable String> valueSupplier) {
+    static IsLikeCaseInsensitiveWhenPresent<String> isLikeCaseInsensitiveWhenPresent(
+            Supplier<@Nullable String> valueSupplier) {
         return isLikeCaseInsensitiveWhenPresent(valueSupplier.get());
     }
 
@@ -906,11 +921,11 @@ public interface SqlBuilder {
         return isNotLikeCaseInsensitive(valueSupplier.get());
     }
 
-    static IsNotLikeCaseInsensitive<String> isNotLikeCaseInsensitiveWhenPresent(@Nullable String value) {
-        return value == null ? IsNotLikeCaseInsensitive.empty() : IsNotLikeCaseInsensitive.of(value);
+    static IsNotLikeCaseInsensitiveWhenPresent<String> isNotLikeCaseInsensitiveWhenPresent(@Nullable String value) {
+        return IsNotLikeCaseInsensitiveWhenPresent.of(value);
     }
 
-    static IsNotLikeCaseInsensitive<String> isNotLikeCaseInsensitiveWhenPresent(
+    static IsNotLikeCaseInsensitiveWhenPresent<String> isNotLikeCaseInsensitiveWhenPresent(
             Supplier<@Nullable String> valueSupplier) {
         return isNotLikeCaseInsensitiveWhenPresent(valueSupplier.get());
     }
@@ -929,7 +944,7 @@ public interface SqlBuilder {
 
     static IsInCaseInsensitiveWhenPresent<String> isInCaseInsensitiveWhenPresent(
             @Nullable Collection<@Nullable String> values) {
-        return values == null ? IsInCaseInsensitiveWhenPresent.empty() : IsInCaseInsensitiveWhenPresent.of(values);
+        return IsInCaseInsensitiveWhenPresent.of(values);
     }
 
     static IsNotInCaseInsensitive<String> isNotInCaseInsensitive(String... values) {
@@ -946,8 +961,7 @@ public interface SqlBuilder {
 
     static IsNotInCaseInsensitiveWhenPresent<String> isNotInCaseInsensitiveWhenPresent(
             @Nullable Collection<@Nullable String> values) {
-        return values == null ? IsNotInCaseInsensitiveWhenPresent.empty() :
-                IsNotInCaseInsensitiveWhenPresent.of(values);
+        return IsNotInCaseInsensitiveWhenPresent.of(values);
     }
 
     // order by support

--- a/src/main/java/org/mybatis/dynamic/sql/delete/DeleteDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/delete/DeleteDSL.java
@@ -120,7 +120,7 @@ public class DeleteDSL<R> implements AbstractWhereStarter<DeleteDSL<R>.DeleteWhe
             return limitWhenPresent(limit);
         }
 
-        public DeleteDSL<R> limitWhenPresent(Long limit) {
+        public DeleteDSL<R> limitWhenPresent(@Nullable Long limit) {
             return DeleteDSL.this.limitWhenPresent(limit);
         }
 

--- a/src/main/java/org/mybatis/dynamic/sql/update/UpdateDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/update/UpdateDSL.java
@@ -202,7 +202,7 @@ public class UpdateDSL<R> implements AbstractWhereStarter<UpdateDSL<R>.UpdateWhe
             return limitWhenPresent(limit);
         }
 
-        public UpdateDSL<R> limitWhenPresent(Long limit) {
+        public UpdateDSL<R> limitWhenPresent(@Nullable Long limit) {
             return UpdateDSL.this.limitWhenPresent(limit);
         }
 

--- a/src/main/java/org/mybatis/dynamic/sql/util/mybatis3/CommonSelectMapper.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/mybatis3/CommonSelectMapper.java
@@ -50,7 +50,7 @@ public interface CommonSelectMapper {
     /**
      * Select a single row as a Map of values. The row may have any number of columns.
      * The Map key will be the column name as returned from the
-     * database (may be aliased if an alias is specified in the select statement). Map entries will be
+     * database (the key will be aliased if an alias is specified in the select statement). Map entries will be
      * of data types determined by the JDBC driver. MyBatis will call ResultSet.getObject() to retrieve
      * values from the ResultSet. Reference your JDBC driver documentation to learn about type mappings
      * for your specific database.
@@ -85,7 +85,7 @@ public interface CommonSelectMapper {
      * Select any number of rows and return a List of Maps containing row values (one Map for each row returned).
      * The rows may have any number of columns.
      * The Map key will be the column name as returned from the
-     * database (may be aliased if an alias is specified in the select statement). Map entries will be
+     * database (the key will be aliased if an alias is specified in the select statement). Map entries will be
      * of data types determined by the JDBC driver. MyBatis will call ResultSet.getObject() to retrieve
      * values from the ResultSet. Reference your JDBC driver documentation to learn about type mappings
      * for your specific database.

--- a/src/main/java/org/mybatis/dynamic/sql/util/mybatis3/CommonSelectMapper.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/mybatis3/CommonSelectMapper.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import java.util.function.Function;
 
 import org.apache.ibatis.annotations.SelectProvider;
+import org.jspecify.annotations.Nullable;
 import org.mybatis.dynamic.sql.select.render.SelectStatementProvider;
 import org.mybatis.dynamic.sql.util.SqlProviderAdapter;
 
@@ -58,7 +59,7 @@ public interface CommonSelectMapper {
      * @return A Map containing the row values.
      */
     @SelectProvider(type = SqlProviderAdapter.class, method = "select")
-    Map<String, Object> selectOneMappedRow(SelectStatementProvider selectStatement);
+    @Nullable Map<String, Object> selectOneMappedRow(SelectStatementProvider selectStatement);
 
     /**
      * Select a single row of values and then convert the values to a custom type. This is similar
@@ -74,9 +75,10 @@ public interface CommonSelectMapper {
      * @param <R> the datatype of the converted object
      * @return the converted object
      */
-    default <R> R selectOne(SelectStatementProvider selectStatement,
+    default <R> @Nullable R selectOne(SelectStatementProvider selectStatement,
                             Function<Map<String, Object>, R> rowMapper) {
-        return rowMapper.apply(selectOneMappedRow(selectStatement));
+        var result = selectOneMappedRow(selectStatement);
+        return result == null ? null : rowMapper.apply(result);
     }
 
     /**
@@ -122,7 +124,7 @@ public interface CommonSelectMapper {
      *     column is null
      */
     @SelectProvider(type = SqlProviderAdapter.class, method = "select")
-    BigDecimal selectOneBigDecimal(SelectStatementProvider selectStatement);
+    @Nullable BigDecimal selectOneBigDecimal(SelectStatementProvider selectStatement);
 
     /**
      * Retrieve a single {@link java.math.BigDecimal} from a result set. The result set must have
@@ -157,7 +159,7 @@ public interface CommonSelectMapper {
      *     column is null
      */
     @SelectProvider(type = SqlProviderAdapter.class, method = "select")
-    Double selectOneDouble(SelectStatementProvider selectStatement);
+    @Nullable Double selectOneDouble(SelectStatementProvider selectStatement);
 
     /**
      * Retrieve a single {@link java.lang.Double} from a result set. The result set must have
@@ -192,7 +194,7 @@ public interface CommonSelectMapper {
      *     column is null
      */
     @SelectProvider(type = SqlProviderAdapter.class, method = "select")
-    Integer selectOneInteger(SelectStatementProvider selectStatement);
+    @Nullable Integer selectOneInteger(SelectStatementProvider selectStatement);
 
     /**
      * Retrieve a single {@link java.lang.Integer} from a result set. The result set must have
@@ -227,7 +229,7 @@ public interface CommonSelectMapper {
      *     column is null
      */
     @SelectProvider(type = SqlProviderAdapter.class, method = "select")
-    Long selectOneLong(SelectStatementProvider selectStatement);
+    @Nullable Long selectOneLong(SelectStatementProvider selectStatement);
 
     /**
      * Retrieve a single {@link java.lang.Long} from a result set. The result set must have
@@ -262,7 +264,7 @@ public interface CommonSelectMapper {
      *     column is null
      */
     @SelectProvider(type = SqlProviderAdapter.class, method = "select")
-    String selectOneString(SelectStatementProvider selectStatement);
+    @Nullable String selectOneString(SelectStatementProvider selectStatement);
 
     /**
      * Retrieve a single {@link java.lang.String} from a result set. The result set must have

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/AndGatherer.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/AndGatherer.java
@@ -17,6 +17,8 @@ package org.mybatis.dynamic.sql.where.condition;
 
 import java.util.function.Supplier;
 
+import org.jspecify.annotations.NonNull;
+
 /**
  * Utility class supporting the "and" part of a between condition. This class supports builders, so it is mutable.
  *
@@ -38,7 +40,7 @@ public abstract class AndGatherer<T, R> {
         return build(value2);
     }
 
-    public R and(Supplier<T> valueSupplier2) {
+    public R and(Supplier<@NonNull T> valueSupplier2) {
         return and(valueSupplier2.get());
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsBetween.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsBetween.java
@@ -20,9 +20,10 @@ import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.NonNull;
 import org.mybatis.dynamic.sql.AbstractTwoValueCondition;
 
-public class IsBetween<T> extends AbstractTwoValueCondition<T>
+public class IsBetween<T> extends AbstractTwoValueCondition<@NonNull T>
         implements AbstractTwoValueCondition.Filterable<T>, AbstractTwoValueCondition.Mappable<T> {
     private static final IsBetween<?> EMPTY = new IsBetween<Object>(-1, -1) {
         @Override
@@ -62,22 +63,23 @@ public class IsBetween<T> extends AbstractTwoValueCondition<T>
     }
 
     @Override
-    public IsBetween<T> filter(BiPredicate<? super T, ? super T> predicate) {
+    public IsBetween<T> filter(BiPredicate<? super @NonNull T, ? super @NonNull T> predicate) {
         return filterSupport(predicate, IsBetween::empty, this);
     }
 
     @Override
-    public IsBetween<T> filter(Predicate<? super T> predicate) {
+    public IsBetween<T> filter(Predicate<? super @NonNull T> predicate) {
         return filterSupport(predicate, IsBetween::empty, this);
     }
 
     @Override
-    public <R> IsBetween<R> map(Function<? super T, ? extends R> mapper1, Function<? super T, ? extends R> mapper2) {
+    public <R> IsBetween<R> map(Function<? super @NonNull T, ? extends @NonNull R> mapper1,
+                                Function<? super @NonNull T, ? extends @NonNull R> mapper2) {
         return mapSupport(mapper1, mapper2, IsBetween::new, IsBetween::empty);
     }
 
     @Override
-    public <R> IsBetween<R> map(Function<? super T, ? extends R> mapper) {
+    public <R> IsBetween<R> map(Function<? super @NonNull T, ? extends @NonNull R> mapper) {
         return map(mapper, mapper);
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsBetween.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsBetween.java
@@ -20,7 +20,6 @@ import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-import org.jspecify.annotations.Nullable;
 import org.mybatis.dynamic.sql.AbstractTwoValueCondition;
 
 public class IsBetween<T> extends AbstractTwoValueCondition<T>
@@ -86,10 +85,6 @@ public class IsBetween<T> extends AbstractTwoValueCondition<T>
         return new Builder<>(value1);
     }
 
-    public static <T> WhenPresentBuilder<T> isBetweenWhenPresent(@Nullable T value1) {
-        return new WhenPresentBuilder<>(value1);
-    }
-
     public static class Builder<T> extends AndGatherer<T, IsBetween<T>> {
         private Builder(T value1) {
             super(value1);
@@ -98,21 +93,6 @@ public class IsBetween<T> extends AbstractTwoValueCondition<T>
         @Override
         protected IsBetween<T> build(T value2) {
             return new IsBetween<>(value1, value2);
-        }
-    }
-
-    public static class WhenPresentBuilder<T> extends AndWhenPresentGatherer<T, IsBetween<T>> {
-        private WhenPresentBuilder(@Nullable T value1) {
-            super(value1);
-        }
-
-        @Override
-        protected IsBetween<T> build(@Nullable T value2) {
-            if (value1 == null || value2 == null) {
-                return empty();
-            } else {
-                return new IsBetween<>(value1, value2);
-            }
         }
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsBetweenWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsBetweenWhenPresent.java
@@ -103,7 +103,7 @@ public class IsBetweenWhenPresent<T> extends AbstractTwoValueCondition<T>
 
         @Override
         protected IsBetweenWhenPresent<T> build(@Nullable T value2) {
-            return IsBetweenWhenPresent.of(value1, value2);
+            return of(value1, value2);
         }
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsBetweenWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsBetweenWhenPresent.java
@@ -20,6 +20,7 @@ import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.mybatis.dynamic.sql.AbstractTwoValueCondition;
 
@@ -63,23 +64,23 @@ public class IsBetweenWhenPresent<T> extends AbstractTwoValueCondition<T>
     }
 
     @Override
-    public IsBetweenWhenPresent<T> filter(BiPredicate<? super T, ? super T> predicate) {
+    public IsBetweenWhenPresent<T> filter(BiPredicate<? super @NonNull T, ? super @NonNull T> predicate) {
         return filterSupport(predicate, IsBetweenWhenPresent::empty, this);
     }
 
     @Override
-    public IsBetweenWhenPresent<T> filter(Predicate<? super T> predicate) {
+    public IsBetweenWhenPresent<T> filter(Predicate<? super @NonNull T> predicate) {
         return filterSupport(predicate, IsBetweenWhenPresent::empty, this);
     }
 
     @Override
-    public <R> IsBetweenWhenPresent<R> map(Function<? super T, ? extends @Nullable R> mapper1,
-                                           Function<? super T, ? extends @Nullable R> mapper2) {
+    public <R> IsBetweenWhenPresent<R> map(Function<? super @NonNull T, ? extends @Nullable R> mapper1,
+                                           Function<? super @NonNull T, ? extends @Nullable R> mapper2) {
         return mapSupport(mapper1, mapper2, IsBetweenWhenPresent::of, IsBetweenWhenPresent::empty);
     }
 
     @Override
-    public <R> IsBetweenWhenPresent<R> map(Function<? super T, ? extends @Nullable R> mapper) {
+    public <R> IsBetweenWhenPresent<R> map(Function<? super @NonNull T, ? extends @Nullable R> mapper) {
         return map(mapper, mapper);
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsBetweenWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsBetweenWhenPresent.java
@@ -20,11 +20,12 @@ import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.Nullable;
 import org.mybatis.dynamic.sql.AbstractTwoValueCondition;
 
-public class IsNotBetween<T> extends AbstractTwoValueCondition<T>
+public class IsBetweenWhenPresent<T> extends AbstractTwoValueCondition<T>
         implements AbstractTwoValueCondition.Filterable<T>, AbstractTwoValueCondition.Mappable<T> {
-    private static final IsNotBetween<?> EMPTY = new IsNotBetween<Object>(-1, -1) {
+    private static final IsBetweenWhenPresent<?> EMPTY = new IsBetweenWhenPresent<Object>(-1, -1) {
         @Override
         public Object value1() {
             throw new NoSuchElementException("No value present"); //$NON-NLS-1$
@@ -41,19 +42,19 @@ public class IsNotBetween<T> extends AbstractTwoValueCondition<T>
         }
     };
 
-    public static <T> IsNotBetween<T> empty() {
+    public static <T> IsBetweenWhenPresent<T> empty() {
         @SuppressWarnings("unchecked")
-        IsNotBetween<T> t = (IsNotBetween<T>) EMPTY;
+        IsBetweenWhenPresent<T> t = (IsBetweenWhenPresent<T>) EMPTY;
         return t;
     }
 
-    protected IsNotBetween(T value1, T value2) {
+    protected IsBetweenWhenPresent(T value1, T value2) {
         super(value1, value2);
     }
 
     @Override
     public String operator1() {
-        return "not between"; //$NON-NLS-1$
+        return "between"; //$NON-NLS-1$
     }
 
     @Override
@@ -62,39 +63,46 @@ public class IsNotBetween<T> extends AbstractTwoValueCondition<T>
     }
 
     @Override
-    public IsNotBetween<T> filter(BiPredicate<? super T, ? super T> predicate) {
-        return filterSupport(predicate, IsNotBetween::empty, this);
+    public IsBetweenWhenPresent<T> filter(BiPredicate<? super T, ? super T> predicate) {
+        return filterSupport(predicate, IsBetweenWhenPresent::empty, this);
     }
 
     @Override
-    public IsNotBetween<T> filter(Predicate<? super T> predicate) {
-        return filterSupport(predicate, IsNotBetween::empty, this);
+    public IsBetweenWhenPresent<T> filter(Predicate<? super T> predicate) {
+        return filterSupport(predicate, IsBetweenWhenPresent::empty, this);
     }
 
     @Override
-    public <R> IsNotBetween<R> map(Function<? super T, ? extends R> mapper1,
-            Function<? super T, ? extends R> mapper2) {
-        return mapSupport(mapper1, mapper2, IsNotBetween::new, IsNotBetween::empty);
+    public <R> IsBetweenWhenPresent<R> map(Function<? super T, ? extends @Nullable R> mapper1,
+                                           Function<? super T, ? extends @Nullable R> mapper2) {
+        return mapSupport(mapper1, mapper2, IsBetweenWhenPresent::of, IsBetweenWhenPresent::empty);
     }
 
     @Override
-    public <R> IsNotBetween<R> map(Function<? super T, ? extends R> mapper) {
+    public <R> IsBetweenWhenPresent<R> map(Function<? super T, ? extends @Nullable R> mapper) {
         return map(mapper, mapper);
     }
 
-    public static <T> Builder<T> isNotBetween(T value1) {
+    public static <T> IsBetweenWhenPresent<T> of(@Nullable T value1, @Nullable T value2) {
+        if (value1 == null || value2 == null) {
+            return empty();
+        } else {
+            return new IsBetweenWhenPresent<>(value1, value2);
+        }
+    }
+
+    public static <T> Builder<T> isBetweenWhenPresent(@Nullable T value1) {
         return new Builder<>(value1);
     }
 
-    public static class Builder<T> extends AndGatherer<T, IsNotBetween<T>> {
-
-        private Builder(T value1) {
+    public static class Builder<T> extends AndWhenPresentGatherer<T, IsBetweenWhenPresent<T>> {
+        private Builder(@Nullable T value1) {
             super(value1);
         }
 
         @Override
-        protected IsNotBetween<T> build(T value2) {
-            return new IsNotBetween<>(value1, value2);
+        protected IsBetweenWhenPresent<T> build(@Nullable T value2) {
+            return IsBetweenWhenPresent.of(value1, value2);
         }
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsEqualTo.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsEqualTo.java
@@ -19,6 +19,7 @@ import java.util.NoSuchElementException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.NonNull;
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 
 public class IsEqualTo<T> extends AbstractSingleValueCondition<T>
@@ -56,12 +57,12 @@ public class IsEqualTo<T> extends AbstractSingleValueCondition<T>
     }
 
     @Override
-    public IsEqualTo<T> filter(Predicate<? super T> predicate) {
+    public IsEqualTo<T> filter(Predicate<? super @NonNull T> predicate) {
         return filterSupport(predicate, IsEqualTo::empty, this);
     }
 
     @Override
-    public <R> IsEqualTo<R> map(Function<? super T, ? extends R> mapper) {
+    public <R> IsEqualTo<R> map(Function<? super @NonNull T, ? extends @NonNull R> mapper) {
         return mapSupport(mapper, IsEqualTo::new, IsEqualTo::empty);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsEqualToWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsEqualToWhenPresent.java
@@ -19,6 +19,7 @@ import java.util.NoSuchElementException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 
@@ -61,12 +62,12 @@ public class IsEqualToWhenPresent<T> extends AbstractSingleValueCondition<T>
     }
 
     @Override
-    public IsEqualToWhenPresent<T> filter(Predicate<? super T> predicate) {
+    public IsEqualToWhenPresent<T> filter(Predicate<? super @NonNull T> predicate) {
         return filterSupport(predicate, IsEqualToWhenPresent::empty, this);
     }
 
     @Override
-    public <R> IsEqualToWhenPresent<R> map(Function<? super T, ? extends @Nullable R> mapper) {
+    public <R> IsEqualToWhenPresent<R> map(Function<? super @NonNull T, ? extends @Nullable R> mapper) {
         return mapSupport(mapper, IsEqualToWhenPresent::of, IsEqualToWhenPresent::empty);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsEqualToWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsEqualToWhenPresent.java
@@ -19,15 +19,15 @@ import java.util.NoSuchElementException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.Nullable;
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
-import org.mybatis.dynamic.sql.util.StringUtilities;
 
-public class IsNotLikeCaseInsensitive<T> extends AbstractSingleValueCondition<T>
-        implements CaseInsensitiveRenderableCondition<T>, AbstractSingleValueCondition.Filterable<T>,
-        AbstractSingleValueCondition.Mappable<T> {
-    private static final IsNotLikeCaseInsensitive<?> EMPTY = new IsNotLikeCaseInsensitive<>("") { //$NON-NLS-1$
+public class IsEqualToWhenPresent<T> extends AbstractSingleValueCondition<T>
+        implements AbstractSingleValueCondition.Filterable<T>, AbstractSingleValueCondition.Mappable<T> {
+
+    private static final IsEqualToWhenPresent<?> EMPTY = new IsEqualToWhenPresent<Object>(-1) {
         @Override
-        public String value() {
+        public Object value() {
             throw new NoSuchElementException("No value present"); //$NON-NLS-1$
         }
 
@@ -37,32 +37,36 @@ public class IsNotLikeCaseInsensitive<T> extends AbstractSingleValueCondition<T>
         }
     };
 
-    public static <T> IsNotLikeCaseInsensitive<T> empty() {
+    public static <T> IsEqualToWhenPresent<T> empty() {
         @SuppressWarnings("unchecked")
-        IsNotLikeCaseInsensitive<T> t = (IsNotLikeCaseInsensitive<T>) EMPTY;
+        IsEqualToWhenPresent<T> t = (IsEqualToWhenPresent<T>) EMPTY;
         return t;
     }
 
-    protected IsNotLikeCaseInsensitive(T value) {
-        super(StringUtilities.upperCaseIfPossible(value));
+    protected IsEqualToWhenPresent(T value) {
+        super(value);
     }
 
     @Override
     public String operator() {
-        return "not like"; //$NON-NLS-1$
+        return "="; //$NON-NLS-1$
+    }
+
+    public static <T> IsEqualToWhenPresent<T> of(@Nullable T value) {
+        if (value == null) {
+            return empty();
+        } else {
+            return new IsEqualToWhenPresent<>(value);
+        }
     }
 
     @Override
-    public IsNotLikeCaseInsensitive<T> filter(Predicate<? super T> predicate) {
-        return filterSupport(predicate, IsNotLikeCaseInsensitive::empty, this);
+    public IsEqualToWhenPresent<T> filter(Predicate<? super T> predicate) {
+        return filterSupport(predicate, IsEqualToWhenPresent::empty, this);
     }
 
     @Override
-    public <R> IsNotLikeCaseInsensitive<R> map(Function<? super T, ? extends R> mapper) {
-        return mapSupport(mapper, IsNotLikeCaseInsensitive::new, IsNotLikeCaseInsensitive::empty);
-    }
-
-    public static <T> IsNotLikeCaseInsensitive<T> of(T value) {
-        return new IsNotLikeCaseInsensitive<>(value);
+    public <R> IsEqualToWhenPresent<R> map(Function<? super T, ? extends @Nullable R> mapper) {
+        return mapSupport(mapper, IsEqualToWhenPresent::of, IsEqualToWhenPresent::empty);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThan.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThan.java
@@ -19,6 +19,7 @@ import java.util.NoSuchElementException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.NonNull;
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 
 public class IsGreaterThan<T> extends AbstractSingleValueCondition<T>
@@ -55,12 +56,12 @@ public class IsGreaterThan<T> extends AbstractSingleValueCondition<T>
     }
 
     @Override
-    public IsGreaterThan<T> filter(Predicate<? super T> predicate) {
+    public IsGreaterThan<T> filter(Predicate<? super @NonNull T> predicate) {
         return filterSupport(predicate, IsGreaterThan::empty, this);
     }
 
     @Override
-    public <R> IsGreaterThan<R> map(Function<? super T, ? extends R> mapper) {
+    public <R> IsGreaterThan<R> map(Function<? super @NonNull T, ? extends @NonNull R> mapper) {
         return mapSupport(mapper, IsGreaterThan::new, IsGreaterThan::empty);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThanOrEqualTo.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThanOrEqualTo.java
@@ -19,6 +19,7 @@ import java.util.NoSuchElementException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.NonNull;
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 
 public class IsGreaterThanOrEqualTo<T> extends AbstractSingleValueCondition<T>
@@ -55,12 +56,12 @@ public class IsGreaterThanOrEqualTo<T> extends AbstractSingleValueCondition<T>
     }
 
     @Override
-    public IsGreaterThanOrEqualTo<T> filter(Predicate<? super T> predicate) {
+    public IsGreaterThanOrEqualTo<T> filter(Predicate<? super @NonNull T> predicate) {
         return filterSupport(predicate, IsGreaterThanOrEqualTo::empty, this);
     }
 
     @Override
-    public <R> IsGreaterThanOrEqualTo<R> map(Function<? super T, ? extends R> mapper) {
+    public <R> IsGreaterThanOrEqualTo<R> map(Function<? super @NonNull T, ? extends @NonNull R> mapper) {
         return mapSupport(mapper, IsGreaterThanOrEqualTo::new, IsGreaterThanOrEqualTo::empty);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThanOrEqualToWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThanOrEqualToWhenPresent.java
@@ -1,0 +1,71 @@
+/*
+ *    Copyright 2016-2025 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.dynamic.sql.where.condition;
+
+import java.util.NoSuchElementException;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.jspecify.annotations.Nullable;
+import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
+
+public class IsGreaterThanOrEqualToWhenPresent<T> extends AbstractSingleValueCondition<T>
+        implements AbstractSingleValueCondition.Filterable<T>, AbstractSingleValueCondition.Mappable<T> {
+    private static final IsGreaterThanOrEqualToWhenPresent<?> EMPTY = new IsGreaterThanOrEqualToWhenPresent<Object>(-1) {
+        @Override
+        public Object value() {
+            throw new NoSuchElementException("No value present"); //$NON-NLS-1$
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return true;
+        }
+    };
+
+    public static <T> IsGreaterThanOrEqualToWhenPresent<T> empty() {
+        @SuppressWarnings("unchecked")
+        IsGreaterThanOrEqualToWhenPresent<T> t = (IsGreaterThanOrEqualToWhenPresent<T>) EMPTY;
+        return t;
+    }
+
+    protected IsGreaterThanOrEqualToWhenPresent(T value) {
+        super(value);
+    }
+
+    @Override
+    public String operator() {
+        return ">="; //$NON-NLS-1$
+    }
+
+    public static <T> IsGreaterThanOrEqualToWhenPresent<T> of(@Nullable T value) {
+        if (value == null) {
+            return empty();
+        } else {
+            return new IsGreaterThanOrEqualToWhenPresent<>(value);
+        }
+    }
+
+    @Override
+    public IsGreaterThanOrEqualToWhenPresent<T> filter(Predicate<? super T> predicate) {
+        return filterSupport(predicate, IsGreaterThanOrEqualToWhenPresent::empty, this);
+    }
+
+    @Override
+    public <R> IsGreaterThanOrEqualToWhenPresent<R> map(Function<? super T, ? extends @Nullable R> mapper) {
+        return mapSupport(mapper, IsGreaterThanOrEqualToWhenPresent::of, IsGreaterThanOrEqualToWhenPresent::empty);
+    }
+}

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThanOrEqualToWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThanOrEqualToWhenPresent.java
@@ -25,7 +25,8 @@ import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 
 public class IsGreaterThanOrEqualToWhenPresent<T> extends AbstractSingleValueCondition<T>
         implements AbstractSingleValueCondition.Filterable<T>, AbstractSingleValueCondition.Mappable<T> {
-    private static final IsGreaterThanOrEqualToWhenPresent<?> EMPTY = new IsGreaterThanOrEqualToWhenPresent<Object>(-1) {
+    private static final IsGreaterThanOrEqualToWhenPresent<?> EMPTY =
+            new IsGreaterThanOrEqualToWhenPresent<Object>(-1) {
         @Override
         public Object value() {
             throw new NoSuchElementException("No value present"); //$NON-NLS-1$

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThanOrEqualToWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThanOrEqualToWhenPresent.java
@@ -19,6 +19,7 @@ import java.util.NoSuchElementException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 
@@ -60,12 +61,12 @@ public class IsGreaterThanOrEqualToWhenPresent<T> extends AbstractSingleValueCon
     }
 
     @Override
-    public IsGreaterThanOrEqualToWhenPresent<T> filter(Predicate<? super T> predicate) {
+    public IsGreaterThanOrEqualToWhenPresent<T> filter(Predicate<? super @NonNull T> predicate) {
         return filterSupport(predicate, IsGreaterThanOrEqualToWhenPresent::empty, this);
     }
 
     @Override
-    public <R> IsGreaterThanOrEqualToWhenPresent<R> map(Function<? super T, ? extends @Nullable R> mapper) {
+    public <R> IsGreaterThanOrEqualToWhenPresent<R> map(Function<? super @NonNull T, ? extends @Nullable R> mapper) {
         return mapSupport(mapper, IsGreaterThanOrEqualToWhenPresent::of, IsGreaterThanOrEqualToWhenPresent::empty);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThanWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThanWhenPresent.java
@@ -19,15 +19,14 @@ import java.util.NoSuchElementException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.Nullable;
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
-import org.mybatis.dynamic.sql.util.StringUtilities;
 
-public class IsNotLikeCaseInsensitive<T> extends AbstractSingleValueCondition<T>
-        implements CaseInsensitiveRenderableCondition<T>, AbstractSingleValueCondition.Filterable<T>,
-        AbstractSingleValueCondition.Mappable<T> {
-    private static final IsNotLikeCaseInsensitive<?> EMPTY = new IsNotLikeCaseInsensitive<>("") { //$NON-NLS-1$
+public class IsGreaterThanWhenPresent<T> extends AbstractSingleValueCondition<T>
+        implements AbstractSingleValueCondition.Filterable<T>, AbstractSingleValueCondition.Mappable<T> {
+    private static final IsGreaterThanWhenPresent<?> EMPTY = new IsGreaterThanWhenPresent<Object>(-1) {
         @Override
-        public String value() {
+        public Object value() {
             throw new NoSuchElementException("No value present"); //$NON-NLS-1$
         }
 
@@ -37,32 +36,36 @@ public class IsNotLikeCaseInsensitive<T> extends AbstractSingleValueCondition<T>
         }
     };
 
-    public static <T> IsNotLikeCaseInsensitive<T> empty() {
+    public static <T> IsGreaterThanWhenPresent<T> empty() {
         @SuppressWarnings("unchecked")
-        IsNotLikeCaseInsensitive<T> t = (IsNotLikeCaseInsensitive<T>) EMPTY;
+        IsGreaterThanWhenPresent<T> t = (IsGreaterThanWhenPresent<T>) EMPTY;
         return t;
     }
 
-    protected IsNotLikeCaseInsensitive(T value) {
-        super(StringUtilities.upperCaseIfPossible(value));
+    protected IsGreaterThanWhenPresent(T value) {
+        super(value);
     }
 
     @Override
     public String operator() {
-        return "not like"; //$NON-NLS-1$
+        return ">"; //$NON-NLS-1$
+    }
+
+    public static <T> IsGreaterThanWhenPresent<T> of(@Nullable T value) {
+        if (value == null) {
+            return empty();
+        } else {
+            return new IsGreaterThanWhenPresent<>(value);
+        }
     }
 
     @Override
-    public IsNotLikeCaseInsensitive<T> filter(Predicate<? super T> predicate) {
-        return filterSupport(predicate, IsNotLikeCaseInsensitive::empty, this);
+    public IsGreaterThanWhenPresent<T> filter(Predicate<? super T> predicate) {
+        return filterSupport(predicate, IsGreaterThanWhenPresent::empty, this);
     }
 
     @Override
-    public <R> IsNotLikeCaseInsensitive<R> map(Function<? super T, ? extends R> mapper) {
-        return mapSupport(mapper, IsNotLikeCaseInsensitive::new, IsNotLikeCaseInsensitive::empty);
-    }
-
-    public static <T> IsNotLikeCaseInsensitive<T> of(T value) {
-        return new IsNotLikeCaseInsensitive<>(value);
+    public <R> IsGreaterThanWhenPresent<R> map(Function<? super T, ? extends @Nullable R> mapper) {
+        return mapSupport(mapper, IsGreaterThanWhenPresent::of, IsGreaterThanWhenPresent::empty);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThanWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsGreaterThanWhenPresent.java
@@ -19,6 +19,7 @@ import java.util.NoSuchElementException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 
@@ -60,12 +61,12 @@ public class IsGreaterThanWhenPresent<T> extends AbstractSingleValueCondition<T>
     }
 
     @Override
-    public IsGreaterThanWhenPresent<T> filter(Predicate<? super T> predicate) {
+    public IsGreaterThanWhenPresent<T> filter(Predicate<? super @NonNull T> predicate) {
         return filterSupport(predicate, IsGreaterThanWhenPresent::empty, this);
     }
 
     @Override
-    public <R> IsGreaterThanWhenPresent<R> map(Function<? super T, ? extends @Nullable R> mapper) {
+    public <R> IsGreaterThanWhenPresent<R> map(Function<? super @NonNull T, ? extends @Nullable R> mapper) {
         return mapSupport(mapper, IsGreaterThanWhenPresent::of, IsGreaterThanWhenPresent::empty);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsIn.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsIn.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.NonNull;
 import org.mybatis.dynamic.sql.AbstractListValueCondition;
 import org.mybatis.dynamic.sql.render.RenderingContext;
 import org.mybatis.dynamic.sql.util.Validator;
@@ -51,12 +52,12 @@ public class IsIn<T> extends AbstractListValueCondition<T>
     }
 
     @Override
-    public IsIn<T> filter(Predicate<? super T> predicate) {
+    public IsIn<T> filter(Predicate<? super @NonNull T> predicate) {
         return filterSupport(predicate, IsIn::new, this, IsIn::empty);
     }
 
     @Override
-    public <R> IsIn<R> map(Function<? super T, ? extends R> mapper) {
+    public <R> IsIn<R> map(Function<? super @NonNull T, ? extends @NonNull R> mapper) {
         return mapSupport(mapper, IsIn::new, IsIn::empty);
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsIn.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsIn.java
@@ -27,7 +27,7 @@ import org.mybatis.dynamic.sql.render.RenderingContext;
 import org.mybatis.dynamic.sql.util.Validator;
 
 public class IsIn<T> extends AbstractListValueCondition<T>
-        implements AbstractListValueCondition.Filterable<T>, AbstractListValueCondition.Mappable<T>{
+        implements AbstractListValueCondition.Filterable<T>, AbstractListValueCondition.Mappable<T> {
     private static final IsIn<?> EMPTY = new IsIn<>(Collections.emptyList());
 
     public static <T> IsIn<T> empty() {

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInCaseInsensitive.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInCaseInsensitive.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.NonNull;
 import org.mybatis.dynamic.sql.AbstractListValueCondition;
 import org.mybatis.dynamic.sql.render.RenderingContext;
 import org.mybatis.dynamic.sql.util.StringUtilities;
@@ -53,12 +54,12 @@ public class IsInCaseInsensitive<T> extends AbstractListValueCondition<T>
     }
 
     @Override
-    public IsInCaseInsensitive<T> filter(Predicate<? super T> predicate) {
+    public IsInCaseInsensitive<T> filter(Predicate<? super @NonNull T> predicate) {
         return filterSupport(predicate, IsInCaseInsensitive::new, this, IsInCaseInsensitive::empty);
     }
 
     @Override
-    public <R> IsInCaseInsensitive<R> map(Function<? super T, ? extends R> mapper) {
+    public <R> IsInCaseInsensitive<R> map(Function<? super @NonNull T, ? extends @NonNull R> mapper) {
         return mapSupport(mapper, IsInCaseInsensitive::new, IsInCaseInsensitive::empty);
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInCaseInsensitive.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInCaseInsensitive.java
@@ -62,11 +62,12 @@ public class IsInCaseInsensitive<T> extends AbstractListValueCondition<T>
         return mapSupport(mapper, IsInCaseInsensitive::new, IsInCaseInsensitive::empty);
     }
 
-    public static IsInCaseInsensitive<String> of(String... values) {
+    @SafeVarargs
+    public static <T> IsInCaseInsensitive<T> of(T... values) {
         return of(Arrays.asList(values));
     }
 
-    public static IsInCaseInsensitive<String> of(Collection<String> values) {
+    public static <T> IsInCaseInsensitive<T> of(Collection<T> values) {
         return new IsInCaseInsensitive<>(values);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInCaseInsensitiveWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInCaseInsensitiveWhenPresent.java
@@ -54,15 +54,20 @@ public class IsInCaseInsensitiveWhenPresent<T> extends AbstractListValueConditio
     }
 
     @Override
-    public <R> IsInCaseInsensitiveWhenPresent<R> map(Function<? super T, ? extends R> mapper) {
+    public <R> IsInCaseInsensitiveWhenPresent<R> map(Function<? super T, ? extends @Nullable R> mapper) {
         return mapSupport(mapper, IsInCaseInsensitiveWhenPresent::new, IsInCaseInsensitiveWhenPresent::empty);
     }
 
-    public static IsInCaseInsensitiveWhenPresent<String> of(@Nullable String... values) {
+    @SafeVarargs
+    public static <T> IsInCaseInsensitiveWhenPresent<T> of(@Nullable T... values) {
         return of(Arrays.asList(values));
     }
 
-    public static IsInCaseInsensitiveWhenPresent<String> of(Collection<@Nullable String> values) {
-        return new IsInCaseInsensitiveWhenPresent<>(values);
+    public static <T> IsInCaseInsensitiveWhenPresent<T> of(@Nullable Collection<@Nullable T> values) {
+        if (values == null || values.isEmpty()) {
+            return empty();
+        } else {
+            return new IsInCaseInsensitiveWhenPresent<>(values);
+        }
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInCaseInsensitiveWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInCaseInsensitiveWhenPresent.java
@@ -22,6 +22,7 @@ import java.util.function.Function;
 import java.util.Objects;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.mybatis.dynamic.sql.AbstractListValueCondition;
 import org.mybatis.dynamic.sql.util.StringUtilities;
@@ -48,13 +49,13 @@ public class IsInCaseInsensitiveWhenPresent<T> extends AbstractListValueConditio
     }
 
     @Override
-    public IsInCaseInsensitiveWhenPresent<T> filter(Predicate<? super T> predicate) {
+    public IsInCaseInsensitiveWhenPresent<T> filter(Predicate<? super @NonNull T> predicate) {
         return filterSupport(predicate, IsInCaseInsensitiveWhenPresent::new, this,
                 IsInCaseInsensitiveWhenPresent::empty);
     }
 
     @Override
-    public <R> IsInCaseInsensitiveWhenPresent<R> map(Function<? super T, ? extends @Nullable R> mapper) {
+    public <R> IsInCaseInsensitiveWhenPresent<R> map(Function<? super @NonNull T, ? extends @Nullable R> mapper) {
         return mapSupport(mapper, IsInCaseInsensitiveWhenPresent::new, IsInCaseInsensitiveWhenPresent::empty);
     }
 
@@ -64,7 +65,7 @@ public class IsInCaseInsensitiveWhenPresent<T> extends AbstractListValueConditio
     }
 
     public static <T> IsInCaseInsensitiveWhenPresent<T> of(@Nullable Collection<@Nullable T> values) {
-        if (values == null || values.isEmpty()) {
+        if (values == null) {
             return empty();
         } else {
             return new IsInCaseInsensitiveWhenPresent<>(values);

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInCaseInsensitiveWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInCaseInsensitiveWhenPresent.java
@@ -18,8 +18,8 @@ package org.mybatis.dynamic.sql.where.condition;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.function.Function;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import org.jspecify.annotations.NonNull;

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInWhenPresent.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.mybatis.dynamic.sql.AbstractListValueCondition;
 
@@ -45,12 +46,12 @@ public class IsInWhenPresent<T> extends AbstractListValueCondition<T>
     }
 
     @Override
-    public IsInWhenPresent<T> filter(Predicate<? super T> predicate) {
+    public IsInWhenPresent<T> filter(Predicate<? super @NonNull T> predicate) {
         return filterSupport(predicate, IsInWhenPresent::new, this, IsInWhenPresent::empty);
     }
 
     @Override
-    public <R> IsInWhenPresent<R> map(Function<? super T, ? extends @Nullable R> mapper) {
+    public <R> IsInWhenPresent<R> map(Function<? super @NonNull T, ? extends @Nullable R> mapper) {
         return mapSupport(mapper, IsInWhenPresent::of, IsInWhenPresent::empty);
     }
 
@@ -60,7 +61,7 @@ public class IsInWhenPresent<T> extends AbstractListValueCondition<T>
     }
 
     public static <T> IsInWhenPresent<T> of(@Nullable Collection<@Nullable T> values) {
-        if (values == null || values.isEmpty()) {
+        if (values == null) {
             return empty();
         } else {
             return new IsInWhenPresent<>(values);

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInWhenPresent.java
@@ -27,7 +27,7 @@ import org.jspecify.annotations.Nullable;
 import org.mybatis.dynamic.sql.AbstractListValueCondition;
 
 public class IsInWhenPresent<T> extends AbstractListValueCondition<T>
-        implements AbstractListValueCondition.Filterable<T>, AbstractListValueCondition.Mappable<T>{
+        implements AbstractListValueCondition.Filterable<T>, AbstractListValueCondition.Mappable<T> {
     private static final IsInWhenPresent<?> EMPTY = new IsInWhenPresent<>(Collections.emptyList());
 
     public static <T> IsInWhenPresent<T> empty() {

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsInWhenPresent.java
@@ -50,8 +50,8 @@ public class IsInWhenPresent<T> extends AbstractListValueCondition<T>
     }
 
     @Override
-    public <R> IsInWhenPresent<R> map(Function<? super T, ? extends R> mapper) {
-        return mapSupport(mapper, IsInWhenPresent::new, IsInWhenPresent::empty);
+    public <R> IsInWhenPresent<R> map(Function<? super T, ? extends @Nullable R> mapper) {
+        return mapSupport(mapper, IsInWhenPresent::of, IsInWhenPresent::empty);
     }
 
     @SafeVarargs
@@ -59,7 +59,11 @@ public class IsInWhenPresent<T> extends AbstractListValueCondition<T>
         return of(Arrays.asList(values));
     }
 
-    public static <T> IsInWhenPresent<T> of(Collection<@Nullable T> values) {
-        return new IsInWhenPresent<>(values);
+    public static <T> IsInWhenPresent<T> of(@Nullable Collection<@Nullable T> values) {
+        if (values == null || values.isEmpty()) {
+            return empty();
+        } else {
+            return new IsInWhenPresent<>(values);
+        }
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThan.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThan.java
@@ -19,6 +19,7 @@ import java.util.NoSuchElementException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.NonNull;
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 
 public class IsLessThan<T> extends AbstractSingleValueCondition<T>
@@ -56,12 +57,12 @@ public class IsLessThan<T> extends AbstractSingleValueCondition<T>
     }
 
     @Override
-    public IsLessThan<T> filter(Predicate<? super T> predicate) {
+    public IsLessThan<T> filter(Predicate<? super @NonNull T> predicate) {
         return filterSupport(predicate, IsLessThan::empty, this);
     }
 
     @Override
-    public <R> IsLessThan<R> map(Function<? super T, ? extends R> mapper) {
+    public <R> IsLessThan<R> map(Function<? super @NonNull T, ? extends @NonNull R> mapper) {
         return mapSupport(mapper, IsLessThan::new, IsLessThan::empty);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThanOrEqualTo.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThanOrEqualTo.java
@@ -19,6 +19,7 @@ import java.util.NoSuchElementException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.NonNull;
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 
 public class IsLessThanOrEqualTo<T> extends AbstractSingleValueCondition<T>
@@ -55,12 +56,12 @@ public class IsLessThanOrEqualTo<T> extends AbstractSingleValueCondition<T>
     }
 
     @Override
-    public IsLessThanOrEqualTo<T> filter(Predicate<? super T> predicate) {
+    public IsLessThanOrEqualTo<T> filter(Predicate<? super @NonNull T> predicate) {
         return filterSupport(predicate, IsLessThanOrEqualTo::empty, this);
     }
 
     @Override
-    public <R> IsLessThanOrEqualTo<R> map(Function<? super T, ? extends R> mapper) {
+    public <R> IsLessThanOrEqualTo<R> map(Function<? super @NonNull T, ? extends @NonNull R> mapper) {
         return mapSupport(mapper, IsLessThanOrEqualTo::new, IsLessThanOrEqualTo::empty);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThanOrEqualToWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThanOrEqualToWhenPresent.java
@@ -19,6 +19,7 @@ import java.util.NoSuchElementException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 
@@ -60,12 +61,12 @@ public class IsLessThanOrEqualToWhenPresent<T> extends AbstractSingleValueCondit
     }
 
     @Override
-    public IsLessThanOrEqualToWhenPresent<T> filter(Predicate<? super T> predicate) {
+    public IsLessThanOrEqualToWhenPresent<T> filter(Predicate<? super @NonNull T> predicate) {
         return filterSupport(predicate, IsLessThanOrEqualToWhenPresent::empty, this);
     }
 
     @Override
-    public <R> IsLessThanOrEqualToWhenPresent<R> map(Function<? super T, ? extends @Nullable R> mapper) {
+    public <R> IsLessThanOrEqualToWhenPresent<R> map(Function<? super @NonNull T, ? extends @Nullable R> mapper) {
         return mapSupport(mapper, IsLessThanOrEqualToWhenPresent::of, IsLessThanOrEqualToWhenPresent::empty);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThanOrEqualToWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThanOrEqualToWhenPresent.java
@@ -1,0 +1,71 @@
+/*
+ *    Copyright 2016-2025 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.dynamic.sql.where.condition;
+
+import java.util.NoSuchElementException;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.jspecify.annotations.Nullable;
+import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
+
+public class IsLessThanOrEqualToWhenPresent<T> extends AbstractSingleValueCondition<T>
+        implements AbstractSingleValueCondition.Filterable<T>, AbstractSingleValueCondition.Mappable<T> {
+    private static final IsLessThanOrEqualToWhenPresent<?> EMPTY = new IsLessThanOrEqualToWhenPresent<Object>(-1) {
+        @Override
+        public Object value() {
+            throw new NoSuchElementException("No value present"); //$NON-NLS-1$
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return true;
+        }
+    };
+
+    public static <T> IsLessThanOrEqualToWhenPresent<T> empty() {
+        @SuppressWarnings("unchecked")
+        IsLessThanOrEqualToWhenPresent<T> t = (IsLessThanOrEqualToWhenPresent<T>) EMPTY;
+        return t;
+    }
+
+    protected IsLessThanOrEqualToWhenPresent(T value) {
+        super(value);
+    }
+
+    @Override
+    public String operator() {
+        return "<="; //$NON-NLS-1$
+    }
+
+    public static <T> IsLessThanOrEqualToWhenPresent<T> of(@Nullable T value) {
+        if (value == null) {
+            return empty();
+        } else {
+            return new IsLessThanOrEqualToWhenPresent<>(value);
+        }
+    }
+
+    @Override
+    public IsLessThanOrEqualToWhenPresent<T> filter(Predicate<? super T> predicate) {
+        return filterSupport(predicate, IsLessThanOrEqualToWhenPresent::empty, this);
+    }
+
+    @Override
+    public <R> IsLessThanOrEqualToWhenPresent<R> map(Function<? super T, ? extends @Nullable R> mapper) {
+        return mapSupport(mapper, IsLessThanOrEqualToWhenPresent::of, IsLessThanOrEqualToWhenPresent::empty);
+    }
+}

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThanWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThanWhenPresent.java
@@ -19,15 +19,15 @@ import java.util.NoSuchElementException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.Nullable;
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
-import org.mybatis.dynamic.sql.util.StringUtilities;
 
-public class IsNotLikeCaseInsensitive<T> extends AbstractSingleValueCondition<T>
-        implements CaseInsensitiveRenderableCondition<T>, AbstractSingleValueCondition.Filterable<T>,
-        AbstractSingleValueCondition.Mappable<T> {
-    private static final IsNotLikeCaseInsensitive<?> EMPTY = new IsNotLikeCaseInsensitive<>("") { //$NON-NLS-1$
+public class IsLessThanWhenPresent<T> extends AbstractSingleValueCondition<T>
+        implements AbstractSingleValueCondition.Filterable<T>, AbstractSingleValueCondition.Mappable<T> {
+
+    private static final IsLessThanWhenPresent<?> EMPTY = new IsLessThanWhenPresent<Object>(-1) {
         @Override
-        public String value() {
+        public Object value() {
             throw new NoSuchElementException("No value present"); //$NON-NLS-1$
         }
 
@@ -37,32 +37,36 @@ public class IsNotLikeCaseInsensitive<T> extends AbstractSingleValueCondition<T>
         }
     };
 
-    public static <T> IsNotLikeCaseInsensitive<T> empty() {
+    public static <T> IsLessThanWhenPresent<T> empty() {
         @SuppressWarnings("unchecked")
-        IsNotLikeCaseInsensitive<T> t = (IsNotLikeCaseInsensitive<T>) EMPTY;
+        IsLessThanWhenPresent<T> t = (IsLessThanWhenPresent<T>) EMPTY;
         return t;
     }
 
-    protected IsNotLikeCaseInsensitive(T value) {
-        super(StringUtilities.upperCaseIfPossible(value));
+    protected IsLessThanWhenPresent(T value) {
+        super(value);
     }
 
     @Override
     public String operator() {
-        return "not like"; //$NON-NLS-1$
+        return "<"; //$NON-NLS-1$
+    }
+
+    public static <T> IsLessThanWhenPresent<T> of(@Nullable T value) {
+        if (value == null) {
+            return empty();
+        } else {
+            return new IsLessThanWhenPresent<>(value);
+        }
     }
 
     @Override
-    public IsNotLikeCaseInsensitive<T> filter(Predicate<? super T> predicate) {
-        return filterSupport(predicate, IsNotLikeCaseInsensitive::empty, this);
+    public IsLessThanWhenPresent<T> filter(Predicate<? super T> predicate) {
+        return filterSupport(predicate, IsLessThanWhenPresent::empty, this);
     }
 
     @Override
-    public <R> IsNotLikeCaseInsensitive<R> map(Function<? super T, ? extends R> mapper) {
-        return mapSupport(mapper, IsNotLikeCaseInsensitive::new, IsNotLikeCaseInsensitive::empty);
-    }
-
-    public static <T> IsNotLikeCaseInsensitive<T> of(T value) {
-        return new IsNotLikeCaseInsensitive<>(value);
+    public <R> IsLessThanWhenPresent<R> map(Function<? super T, ? extends @Nullable R> mapper) {
+        return mapSupport(mapper, IsLessThanWhenPresent::of, IsLessThanWhenPresent::empty);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThanWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLessThanWhenPresent.java
@@ -19,6 +19,7 @@ import java.util.NoSuchElementException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 
@@ -61,12 +62,12 @@ public class IsLessThanWhenPresent<T> extends AbstractSingleValueCondition<T>
     }
 
     @Override
-    public IsLessThanWhenPresent<T> filter(Predicate<? super T> predicate) {
+    public IsLessThanWhenPresent<T> filter(Predicate<? super @NonNull T> predicate) {
         return filterSupport(predicate, IsLessThanWhenPresent::empty, this);
     }
 
     @Override
-    public <R> IsLessThanWhenPresent<R> map(Function<? super T, ? extends @Nullable R> mapper) {
+    public <R> IsLessThanWhenPresent<R> map(Function<? super @NonNull T, ? extends @Nullable R> mapper) {
         return mapSupport(mapper, IsLessThanWhenPresent::of, IsLessThanWhenPresent::empty);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLike.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLike.java
@@ -19,6 +19,7 @@ import java.util.NoSuchElementException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.NonNull;
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 
 public class IsLike<T> extends AbstractSingleValueCondition<T>
@@ -56,12 +57,12 @@ public class IsLike<T> extends AbstractSingleValueCondition<T>
     }
 
     @Override
-    public IsLike<T> filter(Predicate<? super T> predicate) {
+    public IsLike<T> filter(Predicate<? super @NonNull T> predicate) {
         return filterSupport(predicate, IsLike::empty, this);
     }
 
     @Override
-    public <R> IsLike<R> map(Function<? super T, ? extends R> mapper) {
+    public <R> IsLike<R> map(Function<? super @NonNull T, ? extends @NonNull R> mapper) {
         return mapSupport(mapper, IsLike::new, IsLike::empty);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLikeCaseInsensitive.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLikeCaseInsensitive.java
@@ -62,7 +62,7 @@ public class IsLikeCaseInsensitive<T> extends AbstractSingleValueCondition<T>
         return mapSupport(mapper, IsLikeCaseInsensitive::new, IsLikeCaseInsensitive::empty);
     }
 
-    public static IsLikeCaseInsensitive<String> of(String value) {
+    public static <T> IsLikeCaseInsensitive<T> of(T value) {
         return new IsLikeCaseInsensitive<>(value);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLikeCaseInsensitive.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLikeCaseInsensitive.java
@@ -19,6 +19,7 @@ import java.util.NoSuchElementException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.NonNull;
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 import org.mybatis.dynamic.sql.util.StringUtilities;
 
@@ -53,12 +54,12 @@ public class IsLikeCaseInsensitive<T> extends AbstractSingleValueCondition<T>
     }
 
     @Override
-    public IsLikeCaseInsensitive<T> filter(Predicate<? super T> predicate) {
+    public IsLikeCaseInsensitive<T> filter(Predicate<? super @NonNull T> predicate) {
         return filterSupport(predicate, IsLikeCaseInsensitive::empty, this);
     }
 
     @Override
-    public <R> IsLikeCaseInsensitive<R> map(Function<? super T, ? extends R> mapper) {
+    public <R> IsLikeCaseInsensitive<R> map(Function<? super @NonNull T, ? extends @NonNull R> mapper) {
         return mapSupport(mapper, IsLikeCaseInsensitive::new, IsLikeCaseInsensitive::empty);
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLikeCaseInsensitiveWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLikeCaseInsensitiveWhenPresent.java
@@ -19,6 +19,7 @@ import java.util.NoSuchElementException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 import org.mybatis.dynamic.sql.util.StringUtilities;
@@ -54,12 +55,12 @@ public class IsLikeCaseInsensitiveWhenPresent<T> extends AbstractSingleValueCond
     }
 
     @Override
-    public IsLikeCaseInsensitiveWhenPresent<T> filter(Predicate<? super T> predicate) {
+    public IsLikeCaseInsensitiveWhenPresent<T> filter(Predicate<? super @NonNull T> predicate) {
         return filterSupport(predicate, IsLikeCaseInsensitiveWhenPresent::empty, this);
     }
 
     @Override
-    public <R> IsLikeCaseInsensitiveWhenPresent<R> map(Function<? super T, ? extends @Nullable R> mapper) {
+    public <R> IsLikeCaseInsensitiveWhenPresent<R> map(Function<? super @NonNull T, ? extends @Nullable R> mapper) {
         return mapSupport(mapper, IsLikeCaseInsensitiveWhenPresent::of, IsLikeCaseInsensitiveWhenPresent::empty);
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLikeCaseInsensitiveWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLikeCaseInsensitiveWhenPresent.java
@@ -27,7 +27,8 @@ import org.mybatis.dynamic.sql.util.StringUtilities;
 public class IsLikeCaseInsensitiveWhenPresent<T> extends AbstractSingleValueCondition<T>
         implements CaseInsensitiveRenderableCondition<T>, AbstractSingleValueCondition.Filterable<T>,
         AbstractSingleValueCondition.Mappable<T> {
-    private static final IsLikeCaseInsensitiveWhenPresent<?> EMPTY = new IsLikeCaseInsensitiveWhenPresent<>("") { //$NON-NLS-1$
+    private static final IsLikeCaseInsensitiveWhenPresent<?> EMPTY =
+            new IsLikeCaseInsensitiveWhenPresent<>("") { //$NON-NLS-1$
         @Override
         public String value() {
             throw new NoSuchElementException("No value present"); //$NON-NLS-1$

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLikeCaseInsensitiveWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLikeCaseInsensitiveWhenPresent.java
@@ -19,13 +19,14 @@ import java.util.NoSuchElementException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.Nullable;
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 import org.mybatis.dynamic.sql.util.StringUtilities;
 
-public class IsNotLikeCaseInsensitive<T> extends AbstractSingleValueCondition<T>
+public class IsLikeCaseInsensitiveWhenPresent<T> extends AbstractSingleValueCondition<T>
         implements CaseInsensitiveRenderableCondition<T>, AbstractSingleValueCondition.Filterable<T>,
         AbstractSingleValueCondition.Mappable<T> {
-    private static final IsNotLikeCaseInsensitive<?> EMPTY = new IsNotLikeCaseInsensitive<>("") { //$NON-NLS-1$
+    private static final IsLikeCaseInsensitiveWhenPresent<?> EMPTY = new IsLikeCaseInsensitiveWhenPresent<>("") { //$NON-NLS-1$
         @Override
         public String value() {
             throw new NoSuchElementException("No value present"); //$NON-NLS-1$
@@ -37,32 +38,36 @@ public class IsNotLikeCaseInsensitive<T> extends AbstractSingleValueCondition<T>
         }
     };
 
-    public static <T> IsNotLikeCaseInsensitive<T> empty() {
+    public static <T> IsLikeCaseInsensitiveWhenPresent<T> empty() {
         @SuppressWarnings("unchecked")
-        IsNotLikeCaseInsensitive<T> t = (IsNotLikeCaseInsensitive<T>) EMPTY;
+        IsLikeCaseInsensitiveWhenPresent<T> t = (IsLikeCaseInsensitiveWhenPresent<T>) EMPTY;
         return t;
     }
 
-    protected IsNotLikeCaseInsensitive(T value) {
+    protected IsLikeCaseInsensitiveWhenPresent(T value) {
         super(StringUtilities.upperCaseIfPossible(value));
     }
 
     @Override
     public String operator() {
-        return "not like"; //$NON-NLS-1$
+        return "like"; //$NON-NLS-1$
     }
 
     @Override
-    public IsNotLikeCaseInsensitive<T> filter(Predicate<? super T> predicate) {
-        return filterSupport(predicate, IsNotLikeCaseInsensitive::empty, this);
+    public IsLikeCaseInsensitiveWhenPresent<T> filter(Predicate<? super T> predicate) {
+        return filterSupport(predicate, IsLikeCaseInsensitiveWhenPresent::empty, this);
     }
 
     @Override
-    public <R> IsNotLikeCaseInsensitive<R> map(Function<? super T, ? extends R> mapper) {
-        return mapSupport(mapper, IsNotLikeCaseInsensitive::new, IsNotLikeCaseInsensitive::empty);
+    public <R> IsLikeCaseInsensitiveWhenPresent<R> map(Function<? super T, ? extends @Nullable R> mapper) {
+        return mapSupport(mapper, IsLikeCaseInsensitiveWhenPresent::of, IsLikeCaseInsensitiveWhenPresent::empty);
     }
 
-    public static <T> IsNotLikeCaseInsensitive<T> of(T value) {
-        return new IsNotLikeCaseInsensitive<>(value);
+    public static <T> IsLikeCaseInsensitiveWhenPresent<T> of(@Nullable T value) {
+        if (value == null) {
+            return empty();
+        } else {
+            return new IsLikeCaseInsensitiveWhenPresent<>(value);
+        }
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLikeWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLikeWhenPresent.java
@@ -19,15 +19,15 @@ import java.util.NoSuchElementException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.Nullable;
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
-import org.mybatis.dynamic.sql.util.StringUtilities;
 
-public class IsNotLikeCaseInsensitive<T> extends AbstractSingleValueCondition<T>
-        implements CaseInsensitiveRenderableCondition<T>, AbstractSingleValueCondition.Filterable<T>,
-        AbstractSingleValueCondition.Mappable<T> {
-    private static final IsNotLikeCaseInsensitive<?> EMPTY = new IsNotLikeCaseInsensitive<>("") { //$NON-NLS-1$
+public class IsLikeWhenPresent<T> extends AbstractSingleValueCondition<T>
+        implements AbstractSingleValueCondition.Filterable<T>, AbstractSingleValueCondition.Mappable<T> {
+
+    private static final IsLikeWhenPresent<?> EMPTY = new IsLikeWhenPresent<Object>(-1) {
         @Override
-        public String value() {
+        public Object value() {
             throw new NoSuchElementException("No value present"); //$NON-NLS-1$
         }
 
@@ -37,32 +37,36 @@ public class IsNotLikeCaseInsensitive<T> extends AbstractSingleValueCondition<T>
         }
     };
 
-    public static <T> IsNotLikeCaseInsensitive<T> empty() {
+    public static <T> IsLikeWhenPresent<T> empty() {
         @SuppressWarnings("unchecked")
-        IsNotLikeCaseInsensitive<T> t = (IsNotLikeCaseInsensitive<T>) EMPTY;
+        IsLikeWhenPresent<T> t = (IsLikeWhenPresent<T>) EMPTY;
         return t;
     }
 
-    protected IsNotLikeCaseInsensitive(T value) {
-        super(StringUtilities.upperCaseIfPossible(value));
+    protected IsLikeWhenPresent(T value) {
+        super(value);
     }
 
     @Override
     public String operator() {
-        return "not like"; //$NON-NLS-1$
+        return "like"; //$NON-NLS-1$
+    }
+
+    public static <T> IsLikeWhenPresent<T> of(@Nullable T value) {
+        if (value == null) {
+            return empty();
+        } else {
+            return new IsLikeWhenPresent<>(value);
+        }
     }
 
     @Override
-    public IsNotLikeCaseInsensitive<T> filter(Predicate<? super T> predicate) {
-        return filterSupport(predicate, IsNotLikeCaseInsensitive::empty, this);
+    public IsLikeWhenPresent<T> filter(Predicate<? super T> predicate) {
+        return filterSupport(predicate, IsLikeWhenPresent::empty, this);
     }
 
     @Override
-    public <R> IsNotLikeCaseInsensitive<R> map(Function<? super T, ? extends R> mapper) {
-        return mapSupport(mapper, IsNotLikeCaseInsensitive::new, IsNotLikeCaseInsensitive::empty);
-    }
-
-    public static <T> IsNotLikeCaseInsensitive<T> of(T value) {
-        return new IsNotLikeCaseInsensitive<>(value);
+    public <R> IsLikeWhenPresent<R> map(Function<? super T, ? extends @Nullable R> mapper) {
+        return mapSupport(mapper, IsLikeWhenPresent::of, IsLikeWhenPresent::empty);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLikeWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsLikeWhenPresent.java
@@ -19,6 +19,7 @@ import java.util.NoSuchElementException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 
@@ -61,12 +62,12 @@ public class IsLikeWhenPresent<T> extends AbstractSingleValueCondition<T>
     }
 
     @Override
-    public IsLikeWhenPresent<T> filter(Predicate<? super T> predicate) {
+    public IsLikeWhenPresent<T> filter(Predicate<? super @NonNull T> predicate) {
         return filterSupport(predicate, IsLikeWhenPresent::empty, this);
     }
 
     @Override
-    public <R> IsLikeWhenPresent<R> map(Function<? super T, ? extends @Nullable R> mapper) {
+    public <R> IsLikeWhenPresent<R> map(Function<? super @NonNull T, ? extends @Nullable R> mapper) {
         return mapSupport(mapper, IsLikeWhenPresent::of, IsLikeWhenPresent::empty);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotBetween.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotBetween.java
@@ -20,6 +20,7 @@ import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.NonNull;
 import org.mybatis.dynamic.sql.AbstractTwoValueCondition;
 
 public class IsNotBetween<T> extends AbstractTwoValueCondition<T>
@@ -62,23 +63,23 @@ public class IsNotBetween<T> extends AbstractTwoValueCondition<T>
     }
 
     @Override
-    public IsNotBetween<T> filter(BiPredicate<? super T, ? super T> predicate) {
+    public IsNotBetween<T> filter(BiPredicate<? super @NonNull T, ? super @NonNull T> predicate) {
         return filterSupport(predicate, IsNotBetween::empty, this);
     }
 
     @Override
-    public IsNotBetween<T> filter(Predicate<? super T> predicate) {
+    public IsNotBetween<T> filter(Predicate<? super @NonNull T> predicate) {
         return filterSupport(predicate, IsNotBetween::empty, this);
     }
 
     @Override
-    public <R> IsNotBetween<R> map(Function<? super T, ? extends R> mapper1,
-            Function<? super T, ? extends R> mapper2) {
+    public <R> IsNotBetween<R> map(Function<? super @NonNull T, ? extends @NonNull R> mapper1,
+            Function<? super @NonNull T, ? extends @NonNull R> mapper2) {
         return mapSupport(mapper1, mapper2, IsNotBetween::new, IsNotBetween::empty);
     }
 
     @Override
-    public <R> IsNotBetween<R> map(Function<? super T, ? extends R> mapper) {
+    public <R> IsNotBetween<R> map(Function<? super @NonNull T, ? extends @NonNull R> mapper) {
         return map(mapper, mapper);
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotBetweenWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotBetweenWhenPresent.java
@@ -20,11 +20,12 @@ import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.Nullable;
 import org.mybatis.dynamic.sql.AbstractTwoValueCondition;
 
-public class IsNotBetween<T> extends AbstractTwoValueCondition<T>
+public class IsNotBetweenWhenPresent<T> extends AbstractTwoValueCondition<T>
         implements AbstractTwoValueCondition.Filterable<T>, AbstractTwoValueCondition.Mappable<T> {
-    private static final IsNotBetween<?> EMPTY = new IsNotBetween<Object>(-1, -1) {
+    private static final IsNotBetweenWhenPresent<?> EMPTY = new IsNotBetweenWhenPresent<Object>(-1, -1) {
         @Override
         public Object value1() {
             throw new NoSuchElementException("No value present"); //$NON-NLS-1$
@@ -41,13 +42,13 @@ public class IsNotBetween<T> extends AbstractTwoValueCondition<T>
         }
     };
 
-    public static <T> IsNotBetween<T> empty() {
+    public static <T> IsNotBetweenWhenPresent<T> empty() {
         @SuppressWarnings("unchecked")
-        IsNotBetween<T> t = (IsNotBetween<T>) EMPTY;
+        IsNotBetweenWhenPresent<T> t = (IsNotBetweenWhenPresent<T>) EMPTY;
         return t;
     }
 
-    protected IsNotBetween(T value1, T value2) {
+    protected IsNotBetweenWhenPresent(T value1, T value2) {
         super(value1, value2);
     }
 
@@ -62,39 +63,47 @@ public class IsNotBetween<T> extends AbstractTwoValueCondition<T>
     }
 
     @Override
-    public IsNotBetween<T> filter(BiPredicate<? super T, ? super T> predicate) {
-        return filterSupport(predicate, IsNotBetween::empty, this);
+    public IsNotBetweenWhenPresent<T> filter(BiPredicate<? super T, ? super T> predicate) {
+        return filterSupport(predicate, IsNotBetweenWhenPresent::empty, this);
     }
 
     @Override
-    public IsNotBetween<T> filter(Predicate<? super T> predicate) {
-        return filterSupport(predicate, IsNotBetween::empty, this);
+    public IsNotBetweenWhenPresent<T> filter(Predicate<? super T> predicate) {
+        return filterSupport(predicate, IsNotBetweenWhenPresent::empty, this);
     }
 
     @Override
-    public <R> IsNotBetween<R> map(Function<? super T, ? extends R> mapper1,
-            Function<? super T, ? extends R> mapper2) {
-        return mapSupport(mapper1, mapper2, IsNotBetween::new, IsNotBetween::empty);
+    public <R> IsNotBetweenWhenPresent<R> map(Function<? super T, ? extends @Nullable R> mapper1,
+                                              Function<? super T, ? extends @Nullable R> mapper2) {
+        return mapSupport(mapper1, mapper2, IsNotBetweenWhenPresent::of, IsNotBetweenWhenPresent::empty);
     }
 
     @Override
-    public <R> IsNotBetween<R> map(Function<? super T, ? extends R> mapper) {
+    public <R> IsNotBetweenWhenPresent<R> map(Function<? super T, ? extends @Nullable R> mapper) {
         return map(mapper, mapper);
     }
 
-    public static <T> Builder<T> isNotBetween(T value1) {
+    public static <T> IsNotBetweenWhenPresent<T> of(@Nullable T value1, @Nullable T value2) {
+        if (value1 == null || value2 == null) {
+            return empty();
+        } else {
+            return new IsNotBetweenWhenPresent<>(value1, value2);
+        }
+    }
+
+    public static <T> Builder<T> isNotBetweenWhenPresent(@Nullable T value1) {
         return new Builder<>(value1);
     }
 
-    public static class Builder<T> extends AndGatherer<T, IsNotBetween<T>> {
+    public static class Builder<T> extends AndWhenPresentGatherer<T, IsNotBetweenWhenPresent<T>> {
 
-        private Builder(T value1) {
+        private Builder(@Nullable T value1) {
             super(value1);
         }
 
         @Override
-        protected IsNotBetween<T> build(T value2) {
-            return new IsNotBetween<>(value1, value2);
+        protected IsNotBetweenWhenPresent<T> build(@Nullable T value2) {
+            return IsNotBetweenWhenPresent.of(value1, value2);
         }
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotBetweenWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotBetweenWhenPresent.java
@@ -20,6 +20,7 @@ import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.mybatis.dynamic.sql.AbstractTwoValueCondition;
 
@@ -63,23 +64,23 @@ public class IsNotBetweenWhenPresent<T> extends AbstractTwoValueCondition<T>
     }
 
     @Override
-    public IsNotBetweenWhenPresent<T> filter(BiPredicate<? super T, ? super T> predicate) {
+    public IsNotBetweenWhenPresent<T> filter(BiPredicate<? super @NonNull T, ? super @NonNull T> predicate) {
         return filterSupport(predicate, IsNotBetweenWhenPresent::empty, this);
     }
 
     @Override
-    public IsNotBetweenWhenPresent<T> filter(Predicate<? super T> predicate) {
+    public IsNotBetweenWhenPresent<T> filter(Predicate<? super @NonNull T> predicate) {
         return filterSupport(predicate, IsNotBetweenWhenPresent::empty, this);
     }
 
     @Override
-    public <R> IsNotBetweenWhenPresent<R> map(Function<? super T, ? extends @Nullable R> mapper1,
-                                              Function<? super T, ? extends @Nullable R> mapper2) {
+    public <R> IsNotBetweenWhenPresent<R> map(Function<? super @NonNull T, ? extends @Nullable R> mapper1,
+                                              Function<? super @NonNull T, ? extends @Nullable R> mapper2) {
         return mapSupport(mapper1, mapper2, IsNotBetweenWhenPresent::of, IsNotBetweenWhenPresent::empty);
     }
 
     @Override
-    public <R> IsNotBetweenWhenPresent<R> map(Function<? super T, ? extends @Nullable R> mapper) {
+    public <R> IsNotBetweenWhenPresent<R> map(Function<? super @NonNull T, ? extends @Nullable R> mapper) {
         return map(mapper, mapper);
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotBetweenWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotBetweenWhenPresent.java
@@ -104,7 +104,7 @@ public class IsNotBetweenWhenPresent<T> extends AbstractTwoValueCondition<T>
 
         @Override
         protected IsNotBetweenWhenPresent<T> build(@Nullable T value2) {
-            return IsNotBetweenWhenPresent.of(value1, value2);
+            return of(value1, value2);
         }
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotEqualTo.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotEqualTo.java
@@ -19,6 +19,7 @@ import java.util.NoSuchElementException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.NonNull;
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 
 public class IsNotEqualTo<T> extends AbstractSingleValueCondition<T>
@@ -55,12 +56,12 @@ public class IsNotEqualTo<T> extends AbstractSingleValueCondition<T>
     }
 
     @Override
-    public IsNotEqualTo<T> filter(Predicate<? super T> predicate) {
+    public IsNotEqualTo<T> filter(Predicate<? super @NonNull T> predicate) {
         return filterSupport(predicate, IsNotEqualTo::empty, this);
     }
 
     @Override
-    public <R> IsNotEqualTo<R> map(Function<? super T, ? extends R> mapper) {
+    public <R> IsNotEqualTo<R> map(Function<? super @NonNull T, ? extends @NonNull R> mapper) {
         return mapSupport(mapper, IsNotEqualTo::new, IsNotEqualTo::empty);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotEqualToWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotEqualToWhenPresent.java
@@ -19,15 +19,14 @@ import java.util.NoSuchElementException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.Nullable;
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
-import org.mybatis.dynamic.sql.util.StringUtilities;
 
-public class IsNotLikeCaseInsensitive<T> extends AbstractSingleValueCondition<T>
-        implements CaseInsensitiveRenderableCondition<T>, AbstractSingleValueCondition.Filterable<T>,
-        AbstractSingleValueCondition.Mappable<T> {
-    private static final IsNotLikeCaseInsensitive<?> EMPTY = new IsNotLikeCaseInsensitive<>("") { //$NON-NLS-1$
+public class IsNotEqualToWhenPresent<T> extends AbstractSingleValueCondition<T>
+        implements AbstractSingleValueCondition.Filterable<T>, AbstractSingleValueCondition.Mappable<T> {
+    private static final IsNotEqualToWhenPresent<?> EMPTY = new IsNotEqualToWhenPresent<Object>(-1) {
         @Override
-        public String value() {
+        public Object value() {
             throw new NoSuchElementException("No value present"); //$NON-NLS-1$
         }
 
@@ -37,32 +36,36 @@ public class IsNotLikeCaseInsensitive<T> extends AbstractSingleValueCondition<T>
         }
     };
 
-    public static <T> IsNotLikeCaseInsensitive<T> empty() {
+    public static <T> IsNotEqualToWhenPresent<T> empty() {
         @SuppressWarnings("unchecked")
-        IsNotLikeCaseInsensitive<T> t = (IsNotLikeCaseInsensitive<T>) EMPTY;
+        IsNotEqualToWhenPresent<T> t = (IsNotEqualToWhenPresent<T>) EMPTY;
         return t;
     }
 
-    protected IsNotLikeCaseInsensitive(T value) {
-        super(StringUtilities.upperCaseIfPossible(value));
+    protected IsNotEqualToWhenPresent(T value) {
+        super(value);
     }
 
     @Override
     public String operator() {
-        return "not like"; //$NON-NLS-1$
+        return "<>"; //$NON-NLS-1$
+    }
+
+    public static <T> IsNotEqualToWhenPresent<T> of(@Nullable T value) {
+        if (value == null) {
+            return empty();
+        } else {
+            return new IsNotEqualToWhenPresent<>(value);
+        }
     }
 
     @Override
-    public IsNotLikeCaseInsensitive<T> filter(Predicate<? super T> predicate) {
-        return filterSupport(predicate, IsNotLikeCaseInsensitive::empty, this);
+    public IsNotEqualToWhenPresent<T> filter(Predicate<? super T> predicate) {
+        return filterSupport(predicate, IsNotEqualToWhenPresent::empty, this);
     }
 
     @Override
-    public <R> IsNotLikeCaseInsensitive<R> map(Function<? super T, ? extends R> mapper) {
-        return mapSupport(mapper, IsNotLikeCaseInsensitive::new, IsNotLikeCaseInsensitive::empty);
-    }
-
-    public static <T> IsNotLikeCaseInsensitive<T> of(T value) {
-        return new IsNotLikeCaseInsensitive<>(value);
+    public <R> IsNotEqualToWhenPresent<R> map(Function<? super T, ? extends @Nullable R> mapper) {
+        return mapSupport(mapper, IsNotEqualToWhenPresent::of, IsNotEqualToWhenPresent::empty);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotEqualToWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotEqualToWhenPresent.java
@@ -19,6 +19,7 @@ import java.util.NoSuchElementException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 
@@ -60,12 +61,12 @@ public class IsNotEqualToWhenPresent<T> extends AbstractSingleValueCondition<T>
     }
 
     @Override
-    public IsNotEqualToWhenPresent<T> filter(Predicate<? super T> predicate) {
+    public IsNotEqualToWhenPresent<T> filter(Predicate<? super @NonNull T> predicate) {
         return filterSupport(predicate, IsNotEqualToWhenPresent::empty, this);
     }
 
     @Override
-    public <R> IsNotEqualToWhenPresent<R> map(Function<? super T, ? extends @Nullable R> mapper) {
+    public <R> IsNotEqualToWhenPresent<R> map(Function<? super @NonNull T, ? extends @Nullable R> mapper) {
         return mapSupport(mapper, IsNotEqualToWhenPresent::of, IsNotEqualToWhenPresent::empty);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotIn.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotIn.java
@@ -27,7 +27,7 @@ import org.mybatis.dynamic.sql.render.RenderingContext;
 import org.mybatis.dynamic.sql.util.Validator;
 
 public class IsNotIn<T> extends AbstractListValueCondition<T>
-        implements AbstractListValueCondition.Filterable<T>, AbstractListValueCondition.Mappable<T>{
+        implements AbstractListValueCondition.Filterable<T>, AbstractListValueCondition.Mappable<T> {
     private static final IsNotIn<?> EMPTY = new IsNotIn<>(Collections.emptyList());
 
     public static <T> IsNotIn<T> empty() {

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotIn.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotIn.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.NonNull;
 import org.mybatis.dynamic.sql.AbstractListValueCondition;
 import org.mybatis.dynamic.sql.render.RenderingContext;
 import org.mybatis.dynamic.sql.util.Validator;
@@ -51,12 +52,12 @@ public class IsNotIn<T> extends AbstractListValueCondition<T>
     }
 
     @Override
-    public IsNotIn<T> filter(Predicate<? super T> predicate) {
+    public IsNotIn<T> filter(Predicate<? super @NonNull T> predicate) {
         return filterSupport(predicate, IsNotIn::new, this, IsNotIn::empty);
     }
 
     @Override
-    public <R> IsNotIn<R> map(Function<? super T, ? extends R> mapper) {
+    public <R> IsNotIn<R> map(Function<? super @NonNull T, ? extends @NonNull R> mapper) {
         return mapSupport(mapper, IsNotIn::new, IsNotIn::empty);
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInCaseInsensitive.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInCaseInsensitive.java
@@ -62,11 +62,12 @@ public class IsNotInCaseInsensitive<T> extends AbstractListValueCondition<T>
         return mapSupport(mapper, IsNotInCaseInsensitive::new, IsNotInCaseInsensitive::empty);
     }
 
-    public static IsNotInCaseInsensitive<String> of(String... values) {
+    @SafeVarargs
+    public static <T> IsNotInCaseInsensitive<T> of(T... values) {
         return of(Arrays.asList(values));
     }
 
-    public static IsNotInCaseInsensitive<String> of(Collection<String> values) {
+    public static <T> IsNotInCaseInsensitive<T> of(Collection<T> values) {
         return new IsNotInCaseInsensitive<>(values);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInCaseInsensitive.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInCaseInsensitive.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.NonNull;
 import org.mybatis.dynamic.sql.AbstractListValueCondition;
 import org.mybatis.dynamic.sql.render.RenderingContext;
 import org.mybatis.dynamic.sql.util.StringUtilities;
@@ -53,12 +54,12 @@ public class IsNotInCaseInsensitive<T> extends AbstractListValueCondition<T>
     }
 
     @Override
-    public IsNotInCaseInsensitive<T> filter(Predicate<? super T> predicate) {
+    public IsNotInCaseInsensitive<T> filter(Predicate<? super @NonNull T> predicate) {
         return filterSupport(predicate, IsNotInCaseInsensitive::new, this, IsNotInCaseInsensitive::empty);
     }
 
     @Override
-    public <R> IsNotInCaseInsensitive<R> map(Function<? super T, ? extends R> mapper) {
+    public <R> IsNotInCaseInsensitive<R> map(Function<? super @NonNull T, ? extends @NonNull R> mapper) {
         return mapSupport(mapper, IsNotInCaseInsensitive::new, IsNotInCaseInsensitive::empty);
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInCaseInsensitiveWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInCaseInsensitiveWhenPresent.java
@@ -54,15 +54,20 @@ public class IsNotInCaseInsensitiveWhenPresent<T> extends AbstractListValueCondi
     }
 
     @Override
-    public <R> IsNotInCaseInsensitiveWhenPresent<R> map(Function<? super T, ? extends R> mapper) {
+    public <R> IsNotInCaseInsensitiveWhenPresent<R> map(Function<? super T, ? extends @Nullable R> mapper) {
         return mapSupport(mapper, IsNotInCaseInsensitiveWhenPresent::new, IsNotInCaseInsensitiveWhenPresent::empty);
     }
 
-    public static IsNotInCaseInsensitiveWhenPresent<String> of(@Nullable String... values) {
+    @SafeVarargs
+    public static <T> IsNotInCaseInsensitiveWhenPresent<T> of(@Nullable T... values) {
         return of(Arrays.asList(values));
     }
 
-    public static IsNotInCaseInsensitiveWhenPresent<String> of(Collection<@Nullable String> values) {
-        return new IsNotInCaseInsensitiveWhenPresent<>(values);
+    public static <T> IsNotInCaseInsensitiveWhenPresent<T> of(@Nullable Collection<@Nullable T> values) {
+        if (values == null || values.isEmpty()) {
+            return empty();
+        } else {
+            return new IsNotInCaseInsensitiveWhenPresent<>(values);
+        }
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInCaseInsensitiveWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInCaseInsensitiveWhenPresent.java
@@ -22,6 +22,7 @@ import java.util.function.Function;
 import java.util.Objects;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.mybatis.dynamic.sql.AbstractListValueCondition;
 import org.mybatis.dynamic.sql.util.StringUtilities;
@@ -48,13 +49,13 @@ public class IsNotInCaseInsensitiveWhenPresent<T> extends AbstractListValueCondi
     }
 
     @Override
-    public IsNotInCaseInsensitiveWhenPresent<T> filter(Predicate<? super T> predicate) {
+    public IsNotInCaseInsensitiveWhenPresent<T> filter(Predicate<? super @NonNull T> predicate) {
         return filterSupport(predicate, IsNotInCaseInsensitiveWhenPresent::new,
                 this, IsNotInCaseInsensitiveWhenPresent::empty);
     }
 
     @Override
-    public <R> IsNotInCaseInsensitiveWhenPresent<R> map(Function<? super T, ? extends @Nullable R> mapper) {
+    public <R> IsNotInCaseInsensitiveWhenPresent<R> map(Function<? super @NonNull T, ? extends @Nullable R> mapper) {
         return mapSupport(mapper, IsNotInCaseInsensitiveWhenPresent::new, IsNotInCaseInsensitiveWhenPresent::empty);
     }
 
@@ -64,7 +65,7 @@ public class IsNotInCaseInsensitiveWhenPresent<T> extends AbstractListValueCondi
     }
 
     public static <T> IsNotInCaseInsensitiveWhenPresent<T> of(@Nullable Collection<@Nullable T> values) {
-        if (values == null || values.isEmpty()) {
+        if (values == null) {
             return empty();
         } else {
             return new IsNotInCaseInsensitiveWhenPresent<>(values);

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInCaseInsensitiveWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInCaseInsensitiveWhenPresent.java
@@ -18,8 +18,8 @@ package org.mybatis.dynamic.sql.where.condition;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.function.Function;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import org.jspecify.annotations.NonNull;

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInWhenPresent.java
@@ -27,7 +27,7 @@ import org.jspecify.annotations.Nullable;
 import org.mybatis.dynamic.sql.AbstractListValueCondition;
 
 public class IsNotInWhenPresent<T> extends AbstractListValueCondition<T>
-        implements AbstractListValueCondition.Filterable<T>, AbstractListValueCondition.Mappable<T>{
+        implements AbstractListValueCondition.Filterable<T>, AbstractListValueCondition.Mappable<T> {
     private static final IsNotInWhenPresent<?> EMPTY = new IsNotInWhenPresent<>(Collections.emptyList());
 
     public static <T> IsNotInWhenPresent<T> empty() {

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInWhenPresent.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.mybatis.dynamic.sql.AbstractListValueCondition;
 
@@ -45,12 +46,12 @@ public class IsNotInWhenPresent<T> extends AbstractListValueCondition<T>
     }
 
     @Override
-    public IsNotInWhenPresent<T> filter(Predicate<? super T> predicate) {
+    public IsNotInWhenPresent<T> filter(Predicate<? super @NonNull T> predicate) {
         return filterSupport(predicate, IsNotInWhenPresent::new, this, IsNotInWhenPresent::empty);
     }
 
     @Override
-    public <R> IsNotInWhenPresent<R> map(Function<? super T, ? extends @Nullable R> mapper) {
+    public <R> IsNotInWhenPresent<R> map(Function<? super @NonNull T, ? extends @Nullable R> mapper) {
         return mapSupport(mapper, IsNotInWhenPresent::new, IsNotInWhenPresent::empty);
     }
 
@@ -60,7 +61,7 @@ public class IsNotInWhenPresent<T> extends AbstractListValueCondition<T>
     }
 
     public static <T> IsNotInWhenPresent<T> of(@Nullable Collection<@Nullable T> values) {
-        if (values == null || values.isEmpty()) {
+        if (values == null) {
             return empty();
         } else {
             return new IsNotInWhenPresent<>(values);

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotInWhenPresent.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.Nullable;
 import org.mybatis.dynamic.sql.AbstractListValueCondition;
 
 public class IsNotInWhenPresent<T> extends AbstractListValueCondition<T>
@@ -49,16 +50,20 @@ public class IsNotInWhenPresent<T> extends AbstractListValueCondition<T>
     }
 
     @Override
-    public <R> IsNotInWhenPresent<R> map(Function<? super T, ? extends R> mapper) {
+    public <R> IsNotInWhenPresent<R> map(Function<? super T, ? extends @Nullable R> mapper) {
         return mapSupport(mapper, IsNotInWhenPresent::new, IsNotInWhenPresent::empty);
     }
 
     @SafeVarargs
-    public static <T> IsNotInWhenPresent<T> of(T... values) {
+    public static <T> IsNotInWhenPresent<T> of(@Nullable T... values) {
         return of(Arrays.asList(values));
     }
 
-    public static <T> IsNotInWhenPresent<T> of(Collection<T> values) {
-        return new IsNotInWhenPresent<>(values);
+    public static <T> IsNotInWhenPresent<T> of(@Nullable Collection<@Nullable T> values) {
+        if (values == null || values.isEmpty()) {
+            return empty();
+        } else {
+            return new IsNotInWhenPresent<>(values);
+        }
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotLike.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotLike.java
@@ -19,6 +19,7 @@ import java.util.NoSuchElementException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.NonNull;
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 
 public class IsNotLike<T> extends AbstractSingleValueCondition<T>
@@ -55,12 +56,12 @@ public class IsNotLike<T> extends AbstractSingleValueCondition<T>
     }
 
     @Override
-    public IsNotLike<T> filter(Predicate<? super T> predicate) {
+    public IsNotLike<T> filter(Predicate<? super @NonNull T> predicate) {
         return filterSupport(predicate, IsNotLike::empty, this);
     }
 
     @Override
-    public <R> IsNotLike<R> map(Function<? super T, ? extends R> mapper) {
+    public <R> IsNotLike<R> map(Function<? super @NonNull T, ? extends @NonNull R> mapper) {
         return mapSupport(mapper, IsNotLike::new, IsNotLike::empty);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotLikeCaseInsensitive.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotLikeCaseInsensitive.java
@@ -19,6 +19,7 @@ import java.util.NoSuchElementException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.NonNull;
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 import org.mybatis.dynamic.sql.util.StringUtilities;
 
@@ -53,12 +54,12 @@ public class IsNotLikeCaseInsensitive<T> extends AbstractSingleValueCondition<T>
     }
 
     @Override
-    public IsNotLikeCaseInsensitive<T> filter(Predicate<? super T> predicate) {
+    public IsNotLikeCaseInsensitive<T> filter(Predicate<? super @NonNull T> predicate) {
         return filterSupport(predicate, IsNotLikeCaseInsensitive::empty, this);
     }
 
     @Override
-    public <R> IsNotLikeCaseInsensitive<R> map(Function<? super T, ? extends R> mapper) {
+    public <R> IsNotLikeCaseInsensitive<R> map(Function<? super @NonNull T, ? extends @NonNull R> mapper) {
         return mapSupport(mapper, IsNotLikeCaseInsensitive::new, IsNotLikeCaseInsensitive::empty);
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotLikeCaseInsensitiveWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotLikeCaseInsensitiveWhenPresent.java
@@ -19,6 +19,7 @@ import java.util.NoSuchElementException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 import org.mybatis.dynamic.sql.util.StringUtilities;
@@ -54,12 +55,12 @@ public class IsNotLikeCaseInsensitiveWhenPresent<T> extends AbstractSingleValueC
     }
 
     @Override
-    public IsNotLikeCaseInsensitiveWhenPresent<T> filter(Predicate<? super T> predicate) {
+    public IsNotLikeCaseInsensitiveWhenPresent<T> filter(Predicate<? super @NonNull T> predicate) {
         return filterSupport(predicate, IsNotLikeCaseInsensitiveWhenPresent::empty, this);
     }
 
     @Override
-    public <R> IsNotLikeCaseInsensitiveWhenPresent<R> map(Function<? super T, ? extends @Nullable R> mapper) {
+    public <R> IsNotLikeCaseInsensitiveWhenPresent<R> map(Function<? super @NonNull T, ? extends @Nullable R> mapper) {
         return mapSupport(mapper, IsNotLikeCaseInsensitiveWhenPresent::of, IsNotLikeCaseInsensitiveWhenPresent::empty);
     }
 

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotLikeCaseInsensitiveWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotLikeCaseInsensitiveWhenPresent.java
@@ -27,7 +27,8 @@ import org.mybatis.dynamic.sql.util.StringUtilities;
 public class IsNotLikeCaseInsensitiveWhenPresent<T> extends AbstractSingleValueCondition<T>
         implements CaseInsensitiveRenderableCondition<T>, AbstractSingleValueCondition.Filterable<T>,
         AbstractSingleValueCondition.Mappable<T> {
-    private static final IsNotLikeCaseInsensitiveWhenPresent<?> EMPTY = new IsNotLikeCaseInsensitiveWhenPresent<>("") { //$NON-NLS-1$
+    private static final IsNotLikeCaseInsensitiveWhenPresent<?> EMPTY =
+            new IsNotLikeCaseInsensitiveWhenPresent<>("") { //$NON-NLS-1$
         @Override
         public String value() {
             throw new NoSuchElementException("No value present"); //$NON-NLS-1$

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotLikeCaseInsensitiveWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotLikeCaseInsensitiveWhenPresent.java
@@ -19,13 +19,14 @@ import java.util.NoSuchElementException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.Nullable;
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 import org.mybatis.dynamic.sql.util.StringUtilities;
 
-public class IsNotLikeCaseInsensitive<T> extends AbstractSingleValueCondition<T>
+public class IsNotLikeCaseInsensitiveWhenPresent<T> extends AbstractSingleValueCondition<T>
         implements CaseInsensitiveRenderableCondition<T>, AbstractSingleValueCondition.Filterable<T>,
         AbstractSingleValueCondition.Mappable<T> {
-    private static final IsNotLikeCaseInsensitive<?> EMPTY = new IsNotLikeCaseInsensitive<>("") { //$NON-NLS-1$
+    private static final IsNotLikeCaseInsensitiveWhenPresent<?> EMPTY = new IsNotLikeCaseInsensitiveWhenPresent<>("") { //$NON-NLS-1$
         @Override
         public String value() {
             throw new NoSuchElementException("No value present"); //$NON-NLS-1$
@@ -37,13 +38,13 @@ public class IsNotLikeCaseInsensitive<T> extends AbstractSingleValueCondition<T>
         }
     };
 
-    public static <T> IsNotLikeCaseInsensitive<T> empty() {
+    public static <T> IsNotLikeCaseInsensitiveWhenPresent<T> empty() {
         @SuppressWarnings("unchecked")
-        IsNotLikeCaseInsensitive<T> t = (IsNotLikeCaseInsensitive<T>) EMPTY;
+        IsNotLikeCaseInsensitiveWhenPresent<T> t = (IsNotLikeCaseInsensitiveWhenPresent<T>) EMPTY;
         return t;
     }
 
-    protected IsNotLikeCaseInsensitive(T value) {
+    protected IsNotLikeCaseInsensitiveWhenPresent(T value) {
         super(StringUtilities.upperCaseIfPossible(value));
     }
 
@@ -53,16 +54,20 @@ public class IsNotLikeCaseInsensitive<T> extends AbstractSingleValueCondition<T>
     }
 
     @Override
-    public IsNotLikeCaseInsensitive<T> filter(Predicate<? super T> predicate) {
-        return filterSupport(predicate, IsNotLikeCaseInsensitive::empty, this);
+    public IsNotLikeCaseInsensitiveWhenPresent<T> filter(Predicate<? super T> predicate) {
+        return filterSupport(predicate, IsNotLikeCaseInsensitiveWhenPresent::empty, this);
     }
 
     @Override
-    public <R> IsNotLikeCaseInsensitive<R> map(Function<? super T, ? extends R> mapper) {
-        return mapSupport(mapper, IsNotLikeCaseInsensitive::new, IsNotLikeCaseInsensitive::empty);
+    public <R> IsNotLikeCaseInsensitiveWhenPresent<R> map(Function<? super T, ? extends @Nullable R> mapper) {
+        return mapSupport(mapper, IsNotLikeCaseInsensitiveWhenPresent::of, IsNotLikeCaseInsensitiveWhenPresent::empty);
     }
 
-    public static <T> IsNotLikeCaseInsensitive<T> of(T value) {
-        return new IsNotLikeCaseInsensitive<>(value);
+    public static <T> IsNotLikeCaseInsensitiveWhenPresent<T> of(@Nullable T value) {
+        if (value == null) {
+            return empty();
+        } else {
+            return new IsNotLikeCaseInsensitiveWhenPresent<>(value);
+        }
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotLikeWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotLikeWhenPresent.java
@@ -19,15 +19,14 @@ import java.util.NoSuchElementException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.Nullable;
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
-import org.mybatis.dynamic.sql.util.StringUtilities;
 
-public class IsNotLikeCaseInsensitive<T> extends AbstractSingleValueCondition<T>
-        implements CaseInsensitiveRenderableCondition<T>, AbstractSingleValueCondition.Filterable<T>,
-        AbstractSingleValueCondition.Mappable<T> {
-    private static final IsNotLikeCaseInsensitive<?> EMPTY = new IsNotLikeCaseInsensitive<>("") { //$NON-NLS-1$
+public class IsNotLikeWhenPresent<T> extends AbstractSingleValueCondition<T>
+        implements AbstractSingleValueCondition.Filterable<T>, AbstractSingleValueCondition.Mappable<T> {
+    private static final IsNotLikeWhenPresent<?> EMPTY = new IsNotLikeWhenPresent<Object>(-1) {
         @Override
-        public String value() {
+        public Object value() {
             throw new NoSuchElementException("No value present"); //$NON-NLS-1$
         }
 
@@ -37,14 +36,14 @@ public class IsNotLikeCaseInsensitive<T> extends AbstractSingleValueCondition<T>
         }
     };
 
-    public static <T> IsNotLikeCaseInsensitive<T> empty() {
+    public static <T> IsNotLikeWhenPresent<T> empty() {
         @SuppressWarnings("unchecked")
-        IsNotLikeCaseInsensitive<T> t = (IsNotLikeCaseInsensitive<T>) EMPTY;
+        IsNotLikeWhenPresent<T> t = (IsNotLikeWhenPresent<T>) EMPTY;
         return t;
     }
 
-    protected IsNotLikeCaseInsensitive(T value) {
-        super(StringUtilities.upperCaseIfPossible(value));
+    protected IsNotLikeWhenPresent(T value) {
+        super(value);
     }
 
     @Override
@@ -52,17 +51,21 @@ public class IsNotLikeCaseInsensitive<T> extends AbstractSingleValueCondition<T>
         return "not like"; //$NON-NLS-1$
     }
 
-    @Override
-    public IsNotLikeCaseInsensitive<T> filter(Predicate<? super T> predicate) {
-        return filterSupport(predicate, IsNotLikeCaseInsensitive::empty, this);
+    public static <T> IsNotLikeWhenPresent<T> of(@Nullable T value) {
+        if (value == null) {
+            return empty();
+        } else {
+            return new IsNotLikeWhenPresent<>(value);
+        }
     }
 
     @Override
-    public <R> IsNotLikeCaseInsensitive<R> map(Function<? super T, ? extends R> mapper) {
-        return mapSupport(mapper, IsNotLikeCaseInsensitive::new, IsNotLikeCaseInsensitive::empty);
+    public IsNotLikeWhenPresent<T> filter(Predicate<? super T> predicate) {
+        return filterSupport(predicate, IsNotLikeWhenPresent::empty, this);
     }
 
-    public static <T> IsNotLikeCaseInsensitive<T> of(T value) {
-        return new IsNotLikeCaseInsensitive<>(value);
+    @Override
+    public <R> IsNotLikeWhenPresent<R> map(Function<? super T, ? extends @Nullable R> mapper) {
+        return mapSupport(mapper, IsNotLikeWhenPresent::of, IsNotLikeWhenPresent::empty);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotLikeWhenPresent.java
+++ b/src/main/java/org/mybatis/dynamic/sql/where/condition/IsNotLikeWhenPresent.java
@@ -19,6 +19,7 @@ import java.util.NoSuchElementException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.mybatis.dynamic.sql.AbstractSingleValueCondition;
 
@@ -60,12 +61,12 @@ public class IsNotLikeWhenPresent<T> extends AbstractSingleValueCondition<T>
     }
 
     @Override
-    public IsNotLikeWhenPresent<T> filter(Predicate<? super T> predicate) {
+    public IsNotLikeWhenPresent<T> filter(Predicate<? super @NonNull T> predicate) {
         return filterSupport(predicate, IsNotLikeWhenPresent::empty, this);
     }
 
     @Override
-    public <R> IsNotLikeWhenPresent<R> map(Function<? super T, ? extends @Nullable R> mapper) {
+    public <R> IsNotLikeWhenPresent<R> map(Function<? super @NonNull T, ? extends @Nullable R> mapper) {
         return mapSupport(mapper, IsNotLikeWhenPresent::of, IsNotLikeWhenPresent::empty);
     }
 }

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/elements/SqlElements.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/elements/SqlElements.kt
@@ -51,14 +51,18 @@ import org.mybatis.dynamic.sql.util.kotlin.GroupingCriteriaReceiver
 import org.mybatis.dynamic.sql.util.kotlin.KotlinSubQueryBuilder
 import org.mybatis.dynamic.sql.util.kotlin.invalidIfNull
 import org.mybatis.dynamic.sql.where.condition.IsBetween
+import org.mybatis.dynamic.sql.where.condition.IsBetweenWhenPresent
 import org.mybatis.dynamic.sql.where.condition.IsEqualTo
 import org.mybatis.dynamic.sql.where.condition.IsEqualToColumn
+import org.mybatis.dynamic.sql.where.condition.IsEqualToWhenPresent
 import org.mybatis.dynamic.sql.where.condition.IsEqualToWithSubselect
 import org.mybatis.dynamic.sql.where.condition.IsGreaterThan
 import org.mybatis.dynamic.sql.where.condition.IsGreaterThanColumn
 import org.mybatis.dynamic.sql.where.condition.IsGreaterThanOrEqualTo
 import org.mybatis.dynamic.sql.where.condition.IsGreaterThanOrEqualToColumn
+import org.mybatis.dynamic.sql.where.condition.IsGreaterThanOrEqualToWhenPresent
 import org.mybatis.dynamic.sql.where.condition.IsGreaterThanOrEqualToWithSubselect
+import org.mybatis.dynamic.sql.where.condition.IsGreaterThanWhenPresent
 import org.mybatis.dynamic.sql.where.condition.IsGreaterThanWithSubselect
 import org.mybatis.dynamic.sql.where.condition.IsIn
 import org.mybatis.dynamic.sql.where.condition.IsInCaseInsensitive
@@ -69,13 +73,19 @@ import org.mybatis.dynamic.sql.where.condition.IsLessThan
 import org.mybatis.dynamic.sql.where.condition.IsLessThanColumn
 import org.mybatis.dynamic.sql.where.condition.IsLessThanOrEqualTo
 import org.mybatis.dynamic.sql.where.condition.IsLessThanOrEqualToColumn
+import org.mybatis.dynamic.sql.where.condition.IsLessThanOrEqualToWhenPresent
 import org.mybatis.dynamic.sql.where.condition.IsLessThanOrEqualToWithSubselect
+import org.mybatis.dynamic.sql.where.condition.IsLessThanWhenPresent
 import org.mybatis.dynamic.sql.where.condition.IsLessThanWithSubselect
 import org.mybatis.dynamic.sql.where.condition.IsLike
 import org.mybatis.dynamic.sql.where.condition.IsLikeCaseInsensitive
+import org.mybatis.dynamic.sql.where.condition.IsLikeCaseInsensitiveWhenPresent
+import org.mybatis.dynamic.sql.where.condition.IsLikeWhenPresent
 import org.mybatis.dynamic.sql.where.condition.IsNotBetween
+import org.mybatis.dynamic.sql.where.condition.IsNotBetweenWhenPresent
 import org.mybatis.dynamic.sql.where.condition.IsNotEqualTo
 import org.mybatis.dynamic.sql.where.condition.IsNotEqualToColumn
+import org.mybatis.dynamic.sql.where.condition.IsNotEqualToWhenPresent
 import org.mybatis.dynamic.sql.where.condition.IsNotEqualToWithSubselect
 import org.mybatis.dynamic.sql.where.condition.IsNotIn
 import org.mybatis.dynamic.sql.where.condition.IsNotInCaseInsensitive
@@ -84,6 +94,8 @@ import org.mybatis.dynamic.sql.where.condition.IsNotInWhenPresent
 import org.mybatis.dynamic.sql.where.condition.IsNotInWithSubselect
 import org.mybatis.dynamic.sql.where.condition.IsNotLike
 import org.mybatis.dynamic.sql.where.condition.IsNotLikeCaseInsensitive
+import org.mybatis.dynamic.sql.where.condition.IsNotLikeCaseInsensitiveWhenPresent
+import org.mybatis.dynamic.sql.where.condition.IsNotLikeWhenPresent
 import org.mybatis.dynamic.sql.where.condition.IsNotNull
 import org.mybatis.dynamic.sql.where.condition.IsNull
 
@@ -216,7 +228,7 @@ fun <T : Any> isEqualTo(subQuery: KotlinSubQueryBuilder.() -> Unit): IsEqualToWi
 
 fun <T : Any> isEqualTo(column: BasicColumn): IsEqualToColumn<T> = SqlBuilder.isEqualTo(column)
 
-fun <T : Any> isEqualToWhenPresent(value: T?): IsEqualTo<T> = SqlBuilder.isEqualToWhenPresent(value)
+fun <T : Any> isEqualToWhenPresent(value: T?): IsEqualToWhenPresent<T> = SqlBuilder.isEqualToWhenPresent(value)
 
 fun <T : Any> isNotEqualTo(value: T): IsNotEqualTo<T> = SqlBuilder.isNotEqualTo(value)
 
@@ -225,7 +237,8 @@ fun <T : Any> isNotEqualTo(subQuery: KotlinSubQueryBuilder.() -> Unit): IsNotEqu
 
 fun <T : Any> isNotEqualTo(column: BasicColumn): IsNotEqualToColumn<T> = SqlBuilder.isNotEqualTo(column)
 
-fun <T : Any> isNotEqualToWhenPresent(value: T?): IsNotEqualTo<T> = SqlBuilder.isNotEqualToWhenPresent(value)
+fun <T : Any> isNotEqualToWhenPresent(value: T?): IsNotEqualToWhenPresent<T> =
+    SqlBuilder.isNotEqualToWhenPresent(value)
 
 fun <T : Any> isGreaterThan(value: T): IsGreaterThan<T> = SqlBuilder.isGreaterThan(value)
 
@@ -234,7 +247,8 @@ fun <T : Any> isGreaterThan(subQuery: KotlinSubQueryBuilder.() -> Unit): IsGreat
 
 fun <T : Any> isGreaterThan(column: BasicColumn): IsGreaterThanColumn<T> = SqlBuilder.isGreaterThan(column)
 
-fun <T : Any> isGreaterThanWhenPresent(value: T?): IsGreaterThan<T> = SqlBuilder.isGreaterThanWhenPresent(value)
+fun <T : Any> isGreaterThanWhenPresent(value: T?): IsGreaterThanWhenPresent<T> =
+    SqlBuilder.isGreaterThanWhenPresent(value)
 
 fun <T : Any> isGreaterThanOrEqualTo(value: T): IsGreaterThanOrEqualTo<T> = SqlBuilder.isGreaterThanOrEqualTo(value)
 
@@ -244,7 +258,7 @@ fun <T : Any> isGreaterThanOrEqualTo(subQuery: KotlinSubQueryBuilder.() -> Unit)
 fun <T : Any> isGreaterThanOrEqualTo(column: BasicColumn): IsGreaterThanOrEqualToColumn<T> =
     SqlBuilder.isGreaterThanOrEqualTo(column)
 
-fun <T : Any> isGreaterThanOrEqualToWhenPresent(value: T?): IsGreaterThanOrEqualTo<T> =
+fun <T : Any> isGreaterThanOrEqualToWhenPresent(value: T?): IsGreaterThanOrEqualToWhenPresent<T> =
     SqlBuilder.isGreaterThanOrEqualToWhenPresent(value)
 
 fun <T : Any> isLessThan(value: T): IsLessThan<T> = SqlBuilder.isLessThan(value)
@@ -254,7 +268,7 @@ fun <T : Any> isLessThan(subQuery: KotlinSubQueryBuilder.() -> Unit): IsLessThan
 
 fun <T : Any> isLessThan(column: BasicColumn): IsLessThanColumn<T> = SqlBuilder.isLessThan(column)
 
-fun <T : Any> isLessThanWhenPresent(value: T?): IsLessThan<T> = SqlBuilder.isLessThanWhenPresent(value)
+fun <T : Any> isLessThanWhenPresent(value: T?): IsLessThanWhenPresent<T> = SqlBuilder.isLessThanWhenPresent(value)
 
 fun <T : Any> isLessThanOrEqualTo(value: T): IsLessThanOrEqualTo<T> = SqlBuilder.isLessThanOrEqualTo(value)
 
@@ -263,7 +277,7 @@ fun <T : Any> isLessThanOrEqualTo(subQuery: KotlinSubQueryBuilder.() -> Unit): I
 
 fun <T : Any> isLessThanOrEqualTo(column: BasicColumn): IsLessThanOrEqualToColumn<T> = SqlBuilder.isLessThanOrEqualTo(column)
 
-fun <T : Any> isLessThanOrEqualToWhenPresent(value: T?): IsLessThanOrEqualTo<T> =
+fun <T : Any> isLessThanOrEqualToWhenPresent(value: T?): IsLessThanOrEqualToWhenPresent<T> =
     SqlBuilder.isLessThanOrEqualToWhenPresent(value)
 
 fun <T : Any> isIn(vararg values: T): IsIn<T> = isIn(values.asList())
@@ -312,11 +326,11 @@ fun <T : Any> isNotBetweenWhenPresent(value1: T?): NotBetweenWhenPresentBuilder<
 // for string columns, but generic for columns with type handlers
 fun <T : Any> isLike(value: T): IsLike<T> = SqlBuilder.isLike(value)
 
-fun <T : Any> isLikeWhenPresent(value: T?): IsLike<T> = SqlBuilder.isLikeWhenPresent(value)
+fun <T : Any> isLikeWhenPresent(value: T?): IsLikeWhenPresent<T> = SqlBuilder.isLikeWhenPresent(value)
 
 fun <T : Any> isNotLike(value: T): IsNotLike<T> = SqlBuilder.isNotLike(value)
 
-fun <T : Any> isNotLikeWhenPresent(value: T?): IsNotLike<T> = SqlBuilder.isNotLikeWhenPresent(value)
+fun <T : Any> isNotLikeWhenPresent(value: T?): IsNotLikeWhenPresent<T> = SqlBuilder.isNotLikeWhenPresent(value)
 
 // shortcuts for booleans
 fun isTrue(): IsEqualTo<Boolean> = isEqualTo(true)
@@ -326,12 +340,12 @@ fun isFalse(): IsEqualTo<Boolean> = isEqualTo(false)
 // conditions for strings only
 fun isLikeCaseInsensitive(value: String): IsLikeCaseInsensitive<String> = SqlBuilder.isLikeCaseInsensitive(value)
 
-fun isLikeCaseInsensitiveWhenPresent(value: String?): IsLikeCaseInsensitive<String> =
+fun isLikeCaseInsensitiveWhenPresent(value: String?): IsLikeCaseInsensitiveWhenPresent<String> =
     SqlBuilder.isLikeCaseInsensitiveWhenPresent(value)
 
 fun isNotLikeCaseInsensitive(value: String): IsNotLikeCaseInsensitive<String> = SqlBuilder.isNotLikeCaseInsensitive(value)
 
-fun isNotLikeCaseInsensitiveWhenPresent(value: String?): IsNotLikeCaseInsensitive<String> =
+fun isNotLikeCaseInsensitiveWhenPresent(value: String?): IsNotLikeCaseInsensitiveWhenPresent<String> =
     SqlBuilder.isNotLikeCaseInsensitiveWhenPresent(value)
 
 fun isInCaseInsensitive(vararg values: String): IsInCaseInsensitive<String> = isInCaseInsensitive(values.asList())
@@ -400,7 +414,7 @@ class BetweenBuilder<T : Any>(private val value1: T) {
 }
 
 class BetweenWhenPresentBuilder<T : Any>(private val value1: T?) {
-    fun and(value2: T?): IsBetween<T> {
+    fun and(value2: T?): IsBetweenWhenPresent<T> {
         return SqlBuilder.isBetweenWhenPresent<T>(value1).and(value2)
     }
 }
@@ -410,7 +424,7 @@ class NotBetweenBuilder<T : Any>(private val value1: T) {
 }
 
 class NotBetweenWhenPresentBuilder<T : Any>(private val value1: T?) {
-    fun and(value2: T?): IsNotBetween<T> {
+    fun and(value2: T?): IsNotBetweenWhenPresent<T> {
         return SqlBuilder.isNotBetweenWhenPresent<T>(value1).and(value2)
     }
 }

--- a/src/site/markdown/docs/conditions.md
+++ b/src/site/markdown/docs/conditions.md
@@ -166,8 +166,8 @@ table lists the optional conditions and shows how to use them:
 | Null                      | where(id, isNull().filter(BooleanSupplier)                             | The condition will render if BooleanSupplier.getAsBoolean() returns true                                                                           |
 
 ### "When Present" Condition Builders
-The library supplies several methods that supply conditions to be used in the common case of checking for null
-values. The table below lists the rendering rules for each of these "when present" condition builder methods.
+The library supplies conditions for use in the common case of checking for null
+values. The table below lists the rendering rules for each of these "when present" conditions.
 
 | Condition                 | Example                                           | Rendering Rules                                               |
 |---------------------------|---------------------------------------------------|---------------------------------------------------------------|
@@ -184,12 +184,18 @@ values. The table below lists the rendering rules for each of these "when presen
 | Not Like                  | where(id, isNotLikeWhenPresent(x))                | The condition will render if x is non-null                    |
 | Not Like Case Insensitive | where(id, isNotLikeCaseInsensitiveWhenPresent(x)) | The condition will render if x is non-null                    |
 
-Note that these methods simply apply a "NotNull" filter to a  condition. For example:
+With our adoption of JSpecify, it is now considered a misuse of the library to pass a null value into a condition
+unless the condition is one of the "when present" conditions. If you previously wrote code like this:
 
 ```java
-// the following two lines are functionally equivalent
-... where (id, isEqualToWhenPresent(x)) ...
 ... where (id, isEqualTo(x).filter(Objects::nonNull)) ...
+```
+
+Starting in version 2.0.0 of the library, you will now see IDE warnings related to nullability. You should change it
+to this:
+
+```java
+... where (id, isEqualToWhenPresent(x)) ...
 ```
 
 ### Optionality with the "In" Conditions

--- a/src/test/java/examples/animal/data/AnimalDataTest.java
+++ b/src/test/java/examples/animal/data/AnimalDataTest.java
@@ -33,7 +33,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 
 import org.apache.ibatis.datasource.unpooled.UnpooledDataSource;
@@ -717,7 +716,7 @@ class AnimalDataTest {
 
         SelectModel selectModel = select(id, animalName, bodyWeight, brainWeight)
                 .from(animalData)
-                .where(id, isInWhenPresent(inValues).filter(Objects::nonNull).filter(i -> i != 22))
+                .where(id, isInWhenPresent(inValues).filter(i -> i != 22))
                 .build();
 
         assertThatExceptionOfType(NonRenderingWhereClauseException.class).isThrownBy(() ->
@@ -744,7 +743,7 @@ class AnimalDataTest {
 
             SelectStatementProvider selectStatement = select(id, animalName, bodyWeight, brainWeight)
                     .from(animalData)
-                    .where(animalName, isInCaseInsensitive("yellow-bellied marmot", "verbet", null))
+                    .where(animalName, isInCaseInsensitiveWhenPresent("yellow-bellied marmot", "verbet", null))
                     .build()
                     .render(RenderingStrategies.MYBATIS3);
 
@@ -792,12 +791,13 @@ class AnimalDataTest {
 
             SelectStatementProvider selectStatement = select(id, animalName, bodyWeight, brainWeight)
                     .from(animalData)
-                    .where(animalName, isNotInCaseInsensitive((String)null))
+                    .where(animalName, isNotInCaseInsensitiveWhenPresent((String) null))
+                    .configureStatement(c -> c.setNonRenderingWhereClauseAllowed(true))
                     .build()
                     .render(RenderingStrategies.MYBATIS3);
 
             List<AnimalData> animals = mapper.selectMany(selectStatement);
-            assertThat(animals).isEmpty();
+            assertThat(animals).hasSize(65);
         }
     }
 
@@ -825,7 +825,7 @@ class AnimalDataTest {
         SelectModel selectModel = select(id, animalName, bodyWeight, brainWeight)
                 .from(animalData)
                 .where(id, isNotInWhenPresent(null, 22, null)
-                        .filter(Objects::nonNull).filter(i -> i != 22))
+                        .filter(i -> i != 22))
                 .build();
 
         assertThatExceptionOfType(NonRenderingWhereClauseException.class).isThrownBy(() ->

--- a/src/test/java/examples/animal/data/CommonSelectMapperTest.java
+++ b/src/test/java/examples/animal/data/CommonSelectMapperTest.java
@@ -106,10 +106,26 @@ class CommonSelectMapperTest {
 
             AnimalData animal = mapper.selectOne(selectStatement, rowMapper);
 
+            assertThat(animal).isNotNull();
             assertThat(animal.getId()).isEqualTo(1);
             assertThat(animal.getAnimalName()).isEqualTo("Lesser short-tailed shrew");
             assertThat(animal.getBodyWeight()).isEqualTo(0.14);
             assertThat(animal.getBrainWeight()).isEqualTo(0.005);
+        }
+    }
+
+    @Test
+    void testGeneralSelectOneWithRowMapperAndNullRow() {
+        try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+            CommonSelectMapper mapper = sqlSession.getMapper(CommonSelectMapper.class);
+            SelectStatementProvider selectStatement = select(id, animalName, bodyWeight, brainWeight)
+                    .from(animalData)
+                    .where(id, isEqualTo(-237))
+                    .build()
+                    .render(RenderingStrategies.MYBATIS3);
+
+            AnimalData animal = mapper.selectOne(selectStatement, rowMapper);
+            assertThat(animal).isNull();
         }
     }
 

--- a/src/test/java/examples/complexquery/ComplexQueryTest.java
+++ b/src/test/java/examples/complexquery/ComplexQueryTest.java
@@ -22,8 +22,7 @@ import static examples.complexquery.PersonDynamicSqlSupport.person;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mybatis.dynamic.sql.SqlBuilder.*;
 
-import java.util.Objects;
-
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.mybatis.dynamic.sql.render.RenderingStrategies;
 import org.mybatis.dynamic.sql.select.QueryExpressionDSL;
@@ -107,18 +106,17 @@ class ComplexQueryTest {
         assertThat(selectStatement.getParameters()).containsEntry("p1", 50L);
     }
 
-    SelectStatementProvider search(Integer targetId, String fName, String lName) {
+    SelectStatementProvider search(@Nullable Integer targetId, @Nullable String fName, @Nullable String lName) {
         QueryExpressionDSL<SelectModel>.QueryExpressionWhereBuilder builder = select(id, firstName, lastName)
                 .from(person)
                 .where()
                 .configureStatement(c -> c.setNonRenderingWhereClauseAllowed(true));
 
         if (targetId != null) {
-            builder
-                .and(id, isEqualTo(targetId));
+            builder.and(id, isEqualTo(targetId));
         } else {
             builder
-                .and(firstName, isLike(fName).filter(Objects::nonNull).map(s -> "%" + s + "%"))
+                .and(firstName, isLikeWhenPresent(fName).map(s -> "%" + s + "%"))
                 .and(lastName, isLikeWhenPresent(lName).map(this::addWildcards));
         }
 

--- a/src/test/java/examples/emptywhere/EmptyWhereTest.java
+++ b/src/test/java/examples/emptywhere/EmptyWhereTest.java
@@ -20,7 +20,8 @@ import static examples.emptywhere.PersonDynamicSqlSupport.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mybatis.dynamic.sql.SqlBuilder.*;
 
-import java.util.*;
+import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
@@ -93,8 +94,8 @@ class EmptyWhereTest {
         DeleteDSL<DeleteModel>.DeleteWhereBuilder builder = deleteFrom(person)
                 .where(id, isEqualTo(3));
 
-        builder.and(firstName, isEqualTo(fName).filter(Objects::nonNull));
-        builder.and(PersonDynamicSqlSupport.lastName, isEqualTo(lName).filter(Objects::nonNull));
+        builder.and(firstName, isEqualTo(fName));
+        builder.and(PersonDynamicSqlSupport.lastName, isEqualTo(lName));
 
         DeleteStatementProvider deleteStatement = builder.build().render(RenderingStrategies.MYBATIS3);
 
@@ -112,8 +113,8 @@ class EmptyWhereTest {
         DeleteDSL<DeleteModel>.DeleteWhereBuilder builder = deleteFrom(person)
                 .where();
 
-        builder.and(firstName, isEqualTo(variation.firstName).filter(Objects::nonNull));
-        builder.or(PersonDynamicSqlSupport.lastName, isEqualTo(variation.lastName).filter(Objects::nonNull));
+        builder.and(firstName, isEqualToWhenPresent(variation.firstName));
+        builder.or(PersonDynamicSqlSupport.lastName, isEqualToWhenPresent(variation.lastName));
         builder.configureStatement(c -> c.setNonRenderingWhereClauseAllowed(true));
 
         DeleteStatementProvider deleteStatement = builder.build().render(RenderingStrategies.MYBATIS3);
@@ -132,8 +133,8 @@ class EmptyWhereTest {
                 .from(person)
                 .where(id, isEqualTo(3));
 
-        builder.and(firstName, isEqualTo(fName).filter(Objects::nonNull));
-        builder.and(PersonDynamicSqlSupport.lastName, isEqualTo(lName).filter(Objects::nonNull));
+        builder.and(firstName, isEqualTo(fName));
+        builder.and(PersonDynamicSqlSupport.lastName, isEqualTo(lName));
 
         SelectStatementProvider selectStatement = builder.build().render(RenderingStrategies.MYBATIS3);
 
@@ -153,8 +154,8 @@ class EmptyWhereTest {
                 .from(person)
                 .where();
 
-        builder.and(firstName, isEqualTo(variation.firstName).filter(Objects::nonNull));
-        builder.or(PersonDynamicSqlSupport.lastName, isEqualTo(variation.lastName).filter(Objects::nonNull));
+        builder.and(firstName, isEqualToWhenPresent(variation.firstName));
+        builder.or(PersonDynamicSqlSupport.lastName, isEqualToWhenPresent(variation.lastName));
         builder.configureStatement(c -> c.setNonRenderingWhereClauseAllowed(true));
 
         SelectStatementProvider selectStatement = builder.build().render(RenderingStrategies.MYBATIS3);
@@ -173,8 +174,8 @@ class EmptyWhereTest {
                 .from(person).join(order).on(person.id, isEqualTo(order.personId))
                 .where(id, isEqualTo(3));
 
-        builder.and(firstName, isEqualTo(fName).filter(Objects::nonNull));
-        builder.and(PersonDynamicSqlSupport.lastName, isEqualTo(lName).filter(Objects::nonNull));
+        builder.and(firstName, isEqualTo(fName));
+        builder.and(PersonDynamicSqlSupport.lastName, isEqualTo(lName));
 
         SelectStatementProvider selectStatement = builder.build().render(RenderingStrategies.MYBATIS3);
 
@@ -195,8 +196,8 @@ class EmptyWhereTest {
                 .from(person).join(order).on(person.id, isEqualTo(order.personId))
                 .where();
 
-        builder.and(firstName, isEqualTo(variation.firstName).filter(Objects::nonNull));
-        builder.or(PersonDynamicSqlSupport.lastName, isEqualTo(variation.lastName).filter(Objects::nonNull));
+        builder.and(firstName, isEqualToWhenPresent(variation.firstName));
+        builder.or(PersonDynamicSqlSupport.lastName, isEqualToWhenPresent(variation.lastName));
         builder.configureStatement(c -> c.setNonRenderingWhereClauseAllowed(true));
 
         SelectStatementProvider selectStatement = builder.build().render(RenderingStrategies.MYBATIS3);
@@ -218,8 +219,8 @@ class EmptyWhereTest {
                 .set(id).equalTo(3)
                 .where(id, isEqualTo(3));
 
-        builder.and(firstName, isEqualTo(fName).filter(Objects::nonNull));
-        builder.and(PersonDynamicSqlSupport.lastName, isEqualTo(lName).filter(Objects::nonNull));
+        builder.and(firstName, isEqualTo(fName));
+        builder.and(PersonDynamicSqlSupport.lastName, isEqualTo(lName));
 
         UpdateStatementProvider updateStatement = builder.build().render(RenderingStrategies.MYBATIS3);
 
@@ -239,8 +240,8 @@ class EmptyWhereTest {
                 .set(id).equalTo(3)
                 .where();
 
-        builder.and(firstName, isEqualTo(variation.firstName).filter(Objects::nonNull));
-        builder.or(PersonDynamicSqlSupport.lastName, isEqualTo(variation.lastName).filter(Objects::nonNull));
+        builder.and(firstName, isEqualToWhenPresent(variation.firstName));
+        builder.or(PersonDynamicSqlSupport.lastName, isEqualToWhenPresent(variation.lastName));
         builder.configureStatement(c -> c.setNonRenderingWhereClauseAllowed(true));
 
         UpdateStatementProvider updateStatement = builder.build().render(RenderingStrategies.MYBATIS3);
@@ -259,8 +260,8 @@ class EmptyWhereTest {
 
         WhereDSL.StandaloneWhereFinisher builder = where(id, isEqualTo(3));
 
-        builder.and(firstName, isEqualTo(fName).filter(Objects::nonNull));
-        builder.and(PersonDynamicSqlSupport.lastName, isEqualTo(lName).filter(Objects::nonNull));
+        builder.and(firstName, isEqualTo(fName));
+        builder.and(PersonDynamicSqlSupport.lastName, isEqualTo(lName));
 
         Optional<WhereClauseProvider> whereClause = builder.build().render(RenderingStrategies.MYBATIS3);
 
@@ -278,8 +279,8 @@ class EmptyWhereTest {
     void testWhereVariations(Variation variation) {
         WhereDSL.StandaloneWhereFinisher builder = where();
 
-        builder.and(firstName, isEqualTo(variation.firstName).filter(Objects::nonNull));
-        builder.or(PersonDynamicSqlSupport.lastName, isEqualTo(variation.lastName).filter(Objects::nonNull));
+        builder.and(firstName, isEqualToWhenPresent(variation.firstName));
+        builder.or(PersonDynamicSqlSupport.lastName, isEqualToWhenPresent(variation.lastName));
         builder.configureStatement(c -> c.setNonRenderingWhereClauseAllowed(true));
 
         Optional<WhereClauseProvider> whereClause = builder.build().render(RenderingStrategies.MYBATIS3);

--- a/src/test/java/examples/simple/PersonMapperTest.java
+++ b/src/test/java/examples/simple/PersonMapperTest.java
@@ -36,7 +36,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
 import org.apache.ibatis.datasource.unpooled.UnpooledDataSource;
@@ -146,7 +145,7 @@ class PersonMapperTest {
             PersonMapper mapper = session.getMapper(PersonMapper.class);
 
             List<PersonRecord> rows = mapper.select(c ->
-                    c.where(id, isEqualTo((String) null).filter(Objects::nonNull).map(Integer::parseInt))
+                    c.where(id, isEqualToWhenPresent((String) null).map(Integer::parseInt))
                             .or(occupation, isNull()));
 
             assertThat(rows).hasSize(2);

--- a/src/test/java/issues/gh105/Issue105Test.java
+++ b/src/test/java/issues/gh105/Issue105Test.java
@@ -520,22 +520,6 @@ class Issue105Test {
     }
 
     @Test
-    void testBetweenTransformWithNull() {
-
-        SelectStatementProvider selectStatement = select(id, firstName, lastName)
-                .from(person)
-                .where(age, isBetweenWhenPresent(1).and((Integer) null).map(i1 -> i1 + 1,  i2 -> i2 + 2))
-                .configureStatement(c -> c.setNonRenderingWhereClauseAllowed(true))
-                .build()
-                .render(RenderingStrategies.MYBATIS3);
-
-        String expected = "select person_id, first_name, last_name"
-                + " from Person";
-
-        assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
-    }
-
-    @Test
     void testBetweenWhenPresentTransformWithNull() {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
@@ -552,59 +536,11 @@ class Issue105Test {
     }
 
     @Test
-    void testEqualTransformWithNull() {
-
-        SelectStatementProvider selectStatement = select(id, firstName, lastName)
-                .from(person)
-                .where(age, isEqualToWhenPresent((Integer) null).map(i -> i + 1))
-                .configureStatement(c -> c.setNonRenderingWhereClauseAllowed(true))
-                .build()
-                .render(RenderingStrategies.MYBATIS3);
-
-        String expected = "select person_id, first_name, last_name"
-                + " from Person";
-
-        assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
-    }
-
-    @Test
     void testEqualWhenPresentTransformWithNull() {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
                 .where(age, isEqualToWhenPresent((Integer) null).map(i -> i + 1))
-                .configureStatement(c -> c.setNonRenderingWhereClauseAllowed(true))
-                .build()
-                .render(RenderingStrategies.MYBATIS3);
-
-        String expected = "select person_id, first_name, last_name"
-                + " from Person";
-
-        assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
-    }
-
-    @Test
-    void testGreaterThanTransformWithNull() {
-
-        SelectStatementProvider selectStatement = select(id, firstName, lastName)
-                .from(person)
-                .where(age, isGreaterThanWhenPresent((Integer) null).map(i -> i + 1))
-                .configureStatement(c -> c.setNonRenderingWhereClauseAllowed(true))
-                .build()
-                .render(RenderingStrategies.MYBATIS3);
-
-        String expected = "select person_id, first_name, last_name"
-                + " from Person";
-
-        assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
-    }
-
-    @Test
-    void testGreaterThanOrEqualTransformWithNull() {
-
-        SelectStatementProvider selectStatement = select(id, firstName, lastName)
-                .from(person)
-                .where(age, isGreaterThanOrEqualToWhenPresent((Integer) null).map(i -> i + 1))
                 .configureStatement(c -> c.setNonRenderingWhereClauseAllowed(true))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
@@ -648,38 +584,6 @@ class Issue105Test {
     }
 
     @Test
-    void testLessThanTransformWithNull() {
-
-        SelectStatementProvider selectStatement = select(id, firstName, lastName)
-                .from(person)
-                .where(age, isLessThanWhenPresent((Integer) null).map(i -> i + 1))
-                .configureStatement(c -> c.setNonRenderingWhereClauseAllowed(true))
-                .build()
-                .render(RenderingStrategies.MYBATIS3);
-
-        String expected = "select person_id, first_name, last_name"
-                + " from Person";
-
-        assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
-    }
-
-    @Test
-    void testLessThanOrEqualTransformWithNull() {
-
-        SelectStatementProvider selectStatement = select(id, firstName, lastName)
-                .from(person)
-                .where(age, isLessThanOrEqualToWhenPresent((Integer) null).map(i -> i + 1))
-                .configureStatement(c -> c.setNonRenderingWhereClauseAllowed(true))
-                .build()
-                .render(RenderingStrategies.MYBATIS3);
-
-        String expected = "select person_id, first_name, last_name"
-                + " from Person";
-
-        assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
-    }
-
-    @Test
     void testLessThanOrEqualWhenPresentTransformWithNull() {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
@@ -701,38 +605,6 @@ class Issue105Test {
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
                 .where(age, isLessThanWhenPresent((Integer) null).map(i -> i + 1))
-                .configureStatement(c -> c.setNonRenderingWhereClauseAllowed(true))
-                .build()
-                .render(RenderingStrategies.MYBATIS3);
-
-        String expected = "select person_id, first_name, last_name"
-                + " from Person";
-
-        assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
-    }
-
-    @Test
-    void testLikeTransformWithNull() {
-
-        SelectStatementProvider selectStatement = select(id, firstName, lastName)
-                .from(person)
-                .where(firstName, isLikeWhenPresent((String) null).map(SearchUtils::addWildcards))
-                .configureStatement(c -> c.setNonRenderingWhereClauseAllowed(true))
-                .build()
-                .render(RenderingStrategies.MYBATIS3);
-
-        String expected = "select person_id, first_name, last_name"
-                + " from Person";
-
-        assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
-    }
-
-    @Test
-    void testLikeCaseInsensitiveTransformWithNull() {
-
-        SelectStatementProvider selectStatement = select(id, firstName, lastName)
-                .from(person)
-                .where(firstName, isLikeCaseInsensitiveWhenPresent((String) null).map(SearchUtils::addWildcards))
                 .configureStatement(c -> c.setNonRenderingWhereClauseAllowed(true))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
@@ -808,59 +680,11 @@ class Issue105Test {
     }
 
     @Test
-    void testNotEqualTransformWithNull() {
-
-        SelectStatementProvider selectStatement = select(id, firstName, lastName)
-                .from(person)
-                .where(age, isNotEqualToWhenPresent((Integer) null).map(i -> i + 1))
-                .configureStatement(c -> c.setNonRenderingWhereClauseAllowed(true))
-                .build()
-                .render(RenderingStrategies.MYBATIS3);
-
-        String expected = "select person_id, first_name, last_name"
-                + " from Person";
-
-        assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
-    }
-
-    @Test
     void testNotEqualWhenPresentTransformWithNull() {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
                 .where(age, isNotEqualToWhenPresent((Integer) null).map(i -> i + 1))
-                .configureStatement(c -> c.setNonRenderingWhereClauseAllowed(true))
-                .build()
-                .render(RenderingStrategies.MYBATIS3);
-
-        String expected = "select person_id, first_name, last_name"
-                + " from Person";
-
-        assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
-    }
-
-    @Test
-    void testNotLikeTransformWithNull() {
-
-        SelectStatementProvider selectStatement = select(id, firstName, lastName)
-                .from(person)
-                .where(firstName, isNotLikeWhenPresent((String) null).map(SearchUtils::addWildcards))
-                .configureStatement(c -> c.setNonRenderingWhereClauseAllowed(true))
-                .build()
-                .render(RenderingStrategies.MYBATIS3);
-
-        String expected = "select person_id, first_name, last_name"
-                + " from Person";
-
-        assertThat(selectStatement.getSelectStatement()).isEqualTo(expected);
-    }
-
-    @Test
-    void testNotLikeCaseInsensitiveTransformWithNull() {
-
-        SelectStatementProvider selectStatement = select(id, firstName, lastName)
-                .from(person)
-                .where(firstName, isNotLikeCaseInsensitiveWhenPresent((String) null).map(SearchUtils::addWildcards))
                 .configureStatement(c -> c.setNonRenderingWhereClauseAllowed(true))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);

--- a/src/test/java/issues/gh105/Issue105Test.java
+++ b/src/test/java/issues/gh105/Issue105Test.java
@@ -19,12 +19,9 @@ import static issues.gh105.PersonDynamicSqlSupport.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mybatis.dynamic.sql.SqlBuilder.*;
 
-import java.util.Objects;
-
 import org.junit.jupiter.api.Test;
 import org.mybatis.dynamic.sql.render.RenderingStrategies;
 import org.mybatis.dynamic.sql.select.render.SelectStatementProvider;
-import org.mybatis.dynamic.sql.util.Predicates;
 
 class Issue105Test {
 
@@ -35,8 +32,8 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(firstName, isLike(fName).filter(Objects::nonNull).map(s -> "%" + s + "%"))
-                .and(lastName, isLike(lName).filter(Objects::nonNull).map(s -> "%" + s + "%"))
+                .where(firstName, isLike(fName).map(s -> "%" + s + "%"))
+                .and(lastName, isLike(lName).map(s -> "%" + s + "%"))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -57,8 +54,8 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(firstName, isLike(fName).filter(Objects::nonNull).map(SearchUtils::addWildcards))
-                .and(lastName, isLike(lName).filter(Objects::nonNull).map(SearchUtils::addWildcards))
+                .where(firstName, isLikeWhenPresent(fName).map(SearchUtils::addWildcards))
+                .and(lastName, isLike(lName).map(SearchUtils::addWildcards))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -77,8 +74,8 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(firstName, isLike(fName).filter(Objects::nonNull).map(SearchUtils::addWildcards))
-                .and(lastName, isLike(lName).filter(Objects::nonNull).map(SearchUtils::addWildcards))
+                .where(firstName, isLike(fName).map(SearchUtils::addWildcards))
+                .and(lastName, isLikeWhenPresent(lName).map(SearchUtils::addWildcards))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
 
@@ -97,8 +94,8 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(firstName, isLike(fName).filter(Objects::nonNull).map(SearchUtils::addWildcards))
-                .and(lastName, isLike(lName).filter(Objects::nonNull).map(SearchUtils::addWildcards))
+                .where(firstName, isLikeWhenPresent(fName).map(SearchUtils::addWildcards))
+                .and(lastName, isLikeWhenPresent(lName).map(SearchUtils::addWildcards))
                 .configureStatement(c -> c.setNonRenderingWhereClauseAllowed(true))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
@@ -527,7 +524,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(age, isBetween(1).and((Integer) null).filter(Predicates.bothPresent()).map(i1 -> i1 + 1,  i2 -> i2 + 2))
+                .where(age, isBetweenWhenPresent(1).and((Integer) null).map(i1 -> i1 + 1,  i2 -> i2 + 2))
                 .configureStatement(c -> c.setNonRenderingWhereClauseAllowed(true))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
@@ -559,7 +556,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(age, isEqualTo((Integer) null).filter(Objects::nonNull).map(i -> i + 1))
+                .where(age, isEqualToWhenPresent((Integer) null).map(i -> i + 1))
                 .configureStatement(c -> c.setNonRenderingWhereClauseAllowed(true))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
@@ -591,7 +588,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(age, isGreaterThan((Integer) null).filter(Objects::nonNull).map(i -> i + 1))
+                .where(age, isGreaterThanWhenPresent((Integer) null).map(i -> i + 1))
                 .configureStatement(c -> c.setNonRenderingWhereClauseAllowed(true))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
@@ -607,7 +604,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(age, isGreaterThanOrEqualTo((Integer) null).filter(Objects::nonNull).map(i -> i + 1))
+                .where(age, isGreaterThanOrEqualToWhenPresent((Integer) null).map(i -> i + 1))
                 .configureStatement(c -> c.setNonRenderingWhereClauseAllowed(true))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
@@ -655,7 +652,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(age, isLessThan((Integer) null).filter(Objects::nonNull).map(i -> i + 1))
+                .where(age, isLessThanWhenPresent((Integer) null).map(i -> i + 1))
                 .configureStatement(c -> c.setNonRenderingWhereClauseAllowed(true))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
@@ -671,7 +668,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(age, isLessThanOrEqualTo((Integer) null).filter(Objects::nonNull).map(i -> i + 1))
+                .where(age, isLessThanOrEqualToWhenPresent((Integer) null).map(i -> i + 1))
                 .configureStatement(c -> c.setNonRenderingWhereClauseAllowed(true))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
@@ -719,7 +716,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(firstName, isLike((String) null).filter(Objects::nonNull).map(SearchUtils::addWildcards))
+                .where(firstName, isLikeWhenPresent((String) null).map(SearchUtils::addWildcards))
                 .configureStatement(c -> c.setNonRenderingWhereClauseAllowed(true))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
@@ -735,7 +732,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(firstName, isLikeCaseInsensitive((String) null).filter(Objects::nonNull).map(SearchUtils::addWildcards))
+                .where(firstName, isLikeCaseInsensitiveWhenPresent((String) null).map(SearchUtils::addWildcards))
                 .configureStatement(c -> c.setNonRenderingWhereClauseAllowed(true))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
@@ -783,7 +780,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(age, isNotBetween((Integer) null).and(10).filter(Predicates.bothPresent()).map(i1 -> i1 + 1,  i2 -> i2 + 2))
+                .where(age, isNotBetweenWhenPresent((Integer) null).and(10).map(i1 -> i1 + 1,  i2 -> i2 + 2))
                 .configureStatement(c -> c.setNonRenderingWhereClauseAllowed(true))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
@@ -815,7 +812,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(age, isNotEqualTo((Integer) null).filter(Objects::nonNull).map(i -> i + 1))
+                .where(age, isNotEqualToWhenPresent((Integer) null).map(i -> i + 1))
                 .configureStatement(c -> c.setNonRenderingWhereClauseAllowed(true))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
@@ -847,7 +844,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(firstName, isNotLike((String) null).filter(Objects::nonNull).map(SearchUtils::addWildcards))
+                .where(firstName, isNotLikeWhenPresent((String) null).map(SearchUtils::addWildcards))
                 .configureStatement(c -> c.setNonRenderingWhereClauseAllowed(true))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);
@@ -863,7 +860,7 @@ class Issue105Test {
 
         SelectStatementProvider selectStatement = select(id, firstName, lastName)
                 .from(person)
-                .where(firstName, isNotLikeCaseInsensitive((String) null).filter(Objects::nonNull).map(SearchUtils::addWildcards))
+                .where(firstName, isNotLikeCaseInsensitiveWhenPresent((String) null).map(SearchUtils::addWildcards))
                 .configureStatement(c -> c.setNonRenderingWhereClauseAllowed(true))
                 .build()
                 .render(RenderingStrategies.MYBATIS3);

--- a/src/test/java/org/mybatis/dynamic/sql/util/PredicatesTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/util/PredicatesTest.java
@@ -1,0 +1,42 @@
+/*
+ *    Copyright 2016-2025 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.dynamic.sql.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class PredicatesTest {
+    @Test
+    void testFirstNull() {
+        assertThat(Predicates.bothPresent().test(null, 1)).isFalse();
+    }
+
+    @Test
+    void testSecondNull() {
+        assertThat(Predicates.bothPresent().test(1, null)).isFalse();
+    }
+
+    @Test
+    void testBothNull() {
+        assertThat(Predicates.bothPresent().test(null, null)).isFalse();
+    }
+
+    @Test
+    void testNeitherNull() {
+        assertThat(Predicates.bothPresent().test(1, 1)).isTrue();
+    }
+}

--- a/src/test/java/org/mybatis/dynamic/sql/where/condition/FilterAndMapTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/where/condition/FilterAndMapTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Objects;
 
 import org.junit.jupiter.api.Test;
 import org.mybatis.dynamic.sql.SqlBuilder;
@@ -34,16 +33,8 @@ class FilterAndMapTest {
     }
 
     @Test
-    void testTypeConversionWithNullThrowsException() {
-        var cond = SqlBuilder.isEqualTo((String) null);
-        assertThatExceptionOfType(NumberFormatException.class).isThrownBy(() ->
-                cond.map(Integer::parseInt)
-        );
-    }
-
-    @Test
     void testTypeConversionWithNullAndFilterDoesNotThrowException() {
-        var cond = SqlBuilder.isEqualTo((String) null).filter(Objects::nonNull).map(Integer::parseInt);
+        var cond = SqlBuilder.isEqualToWhenPresent((String) null).map(Integer::parseInt);
         assertThat(cond.isEmpty()).isTrue();
     }
 
@@ -479,17 +470,17 @@ class FilterAndMapTest {
 
     @Test
     void testBetweenUnRenderableFirstNullFilterShouldReturnSameObject() {
-        IsBetween<Integer> cond = SqlBuilder.isBetween((Integer) null).and(4).filter(Objects::nonNull);
+        IsBetweenWhenPresent<Integer> cond = SqlBuilder.isBetweenWhenPresent((Integer) null).and(4);
         assertThat(cond.isEmpty()).isTrue();
-        IsBetween<Integer> filtered = cond.filter(v -> true);
+        IsBetweenWhenPresent<Integer> filtered = cond.filter(v -> true);
         assertThat(cond).isSameAs(filtered);
     }
 
     @Test
     void testBetweenUnRenderableSecondNullFilterShouldReturnSameObject() {
-        IsBetween<Integer> cond = SqlBuilder.isBetween(3).and((Integer) null).filter(Objects::nonNull);
+        IsBetweenWhenPresent<Integer> cond = SqlBuilder.isBetweenWhenPresent(3).and((Integer) null);
         assertThat(cond.isEmpty()).isTrue();
-        IsBetween<Integer> filtered = cond.filter(v -> true);
+        IsBetweenWhenPresent<Integer> filtered = cond.filter(v -> true);
         assertThat(cond).isSameAs(filtered);
     }
 
@@ -511,17 +502,17 @@ class FilterAndMapTest {
 
     @Test
     void testNotBetweenUnRenderableFirstNullFilterShouldReturnSameObject() {
-        IsNotBetween<Integer> cond = SqlBuilder.isNotBetween((Integer) null).and(4).filter(Objects::nonNull);
+        IsNotBetweenWhenPresent<Integer> cond = SqlBuilder.isNotBetweenWhenPresent((Integer) null).and(4);
         assertThat(cond.isEmpty()).isTrue();
-        IsNotBetween<Integer> filtered = cond.filter(v -> true);
+        IsNotBetweenWhenPresent<Integer> filtered = cond.filter(v -> true);
         assertThat(cond).isSameAs(filtered);
     }
 
     @Test
     void testNotBetweenUnRenderableSecondNullFilterShouldReturnSameObject() {
-        IsNotBetween<Integer> cond = SqlBuilder.isNotBetween(3).and((Integer) null).filter(Objects::nonNull);
+        IsNotBetweenWhenPresent<Integer> cond = SqlBuilder.isNotBetweenWhenPresent(3).and((Integer) null);
         assertThat(cond.isEmpty()).isTrue();
-        IsNotBetween<Integer> filtered = cond.filter(v -> true);
+        IsNotBetweenWhenPresent<Integer> filtered = cond.filter(v -> true);
         assertThat(cond).isSameAs(filtered);
     }
 

--- a/src/test/java/org/mybatis/dynamic/sql/where/condition/FilterAndMapTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/where/condition/FilterAndMapTest.java
@@ -20,8 +20,12 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mybatis.dynamic.sql.SqlBuilder;
 
 class FilterAndMapTest {
@@ -493,6 +497,46 @@ class FilterAndMapTest {
     }
 
     @Test
+    void testBetweenWhenPresentFilterWithBiPredicate() {
+        IsBetweenWhenPresent<Integer> cond = SqlBuilder.isBetweenWhenPresent("3").and("4")
+                .map(Integer::parseInt)
+                .filter((v1, v2) -> true);
+        assertThat(cond.isEmpty()).isFalse();
+        assertThat(cond.value1()).isEqualTo(3);
+        assertThat(cond.value2()).isEqualTo(4);
+    }
+
+    @Test
+    void testNotBetweenWhenPresentFilterWithBiPredicate() {
+        IsNotBetweenWhenPresent<Integer> cond = SqlBuilder.isNotBetweenWhenPresent("3").and("4")
+                .map(Integer::parseInt)
+                .filter((v1, v2) -> true);
+        assertThat(cond.isEmpty()).isFalse();
+        assertThat(cond.value1()).isEqualTo(3);
+        assertThat(cond.value2()).isEqualTo(4);
+    }
+
+    @ParameterizedTest
+    @MethodSource("testBetweenFilterVariations")
+    void testBetweenFilterVariations(FilterVariation variation) {
+        IsBetween<Integer> cond = SqlBuilder.isBetween("4").and("6")
+                .map(Integer::parseInt)
+                .filter(variation.predicate);
+        assertThat(cond.isEmpty()).isEqualTo(variation.empty);
+    }
+
+    private record FilterVariation(Predicate<Integer> predicate, boolean empty) {}
+
+    private static Stream<FilterVariation> testBetweenFilterVariations() {
+        return Stream.of(
+                new FilterVariation(v -> v == 4, true),
+                new FilterVariation(v -> v == 6, true),
+                new FilterVariation(v -> v == 1, true),
+                new FilterVariation(v -> v % 2 == 0, false)
+        );
+    }
+
+    @Test
     void testNotBetweenUnRenderableFilterShouldReturnSameObject() {
         IsNotBetween<Integer> cond = SqlBuilder.isNotBetween(3).and(4).filter((i1, i2) -> false);
         assertThat(cond.isEmpty()).isTrue();
@@ -522,6 +566,24 @@ class FilterAndMapTest {
         assertThat(cond.isEmpty()).isFalse();
         assertThat(cond.value1()).isEqualTo(3);
         assertThat(cond.value2()).isEqualTo(4);
+    }
+
+    @Test
+    void testBetweenFilterToEmpty() {
+        var cond = SqlBuilder.isBetween("3").and("4").map(Integer::parseInt)
+                .filter((i1, i2) -> false);
+        assertThat(cond.isEmpty()).isTrue();
+        assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(cond::value1);
+        assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(cond::value2);
+    }
+
+    @Test
+    void testNotBetweenFilterToEmpty() {
+        var cond = SqlBuilder.isNotBetween("3").and("4").map(Integer::parseInt)
+                .filter((i1, i2) -> false);
+        assertThat(cond.isEmpty()).isTrue();
+        assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(cond::value1);
+        assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(cond::value2);
     }
 
     @Test

--- a/src/test/java/org/mybatis/dynamic/sql/where/condition/NullContractTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/where/condition/NullContractTest.java
@@ -438,4 +438,94 @@ public class NullContractTest {
         assertThat(mapped.isEmpty()).isTrue();
         assertThat(mapped.values().toList()).isEmpty();
     }
+
+    @SuppressWarnings("DataFlowIssue") // we are deliberately passing nulls into non-null methods for testing
+    @Test
+    void testIsBetweenNull() {
+        IsBetween<Integer> cond = SqlBuilder.isBetween(() -> (Integer) null).and(() -> null);
+        assertThat(cond.value1()).isNull();
+        assertThat(cond.value2()).isNull();
+        assertThat(cond.isEmpty()).isFalse();
+    }
+
+    @SuppressWarnings("DataFlowIssue") // we are deliberately passing nulls into non-null methods for testing
+    @Test
+    void testIsNotBetweenNull() {
+        IsNotBetween<Integer> cond = SqlBuilder.isNotBetween(() -> (Integer) null).and(() -> null);
+        assertThat(cond.value1()).isNull();
+        assertThat(cond.value2()).isNull();
+        assertThat(cond.isEmpty()).isFalse();
+    }
+
+    @SuppressWarnings("DataFlowIssue") // we are deliberately passing nulls into non-null methods for testing
+    @Test
+    void testIsNotEqualToNull() {
+        IsNotEqualTo<Integer> cond = SqlBuilder.isNotEqualTo(() -> (Integer) null);
+        assertThat(cond.value()).isNull();
+        assertThat(cond.isEmpty()).isFalse();
+    }
+
+    @SuppressWarnings("DataFlowIssue") // we are deliberately passing nulls into non-null methods for testing
+    @Test
+    void testIsGreaterThanNull() {
+        IsGreaterThan<Integer> cond = SqlBuilder.isGreaterThan(() -> (Integer) null);
+        assertThat(cond.value()).isNull();
+        assertThat(cond.isEmpty()).isFalse();
+    }
+
+    @SuppressWarnings("DataFlowIssue") // we are deliberately passing nulls into non-null methods for testing
+    @Test
+    void testIsGreaterThanOrEqualToNull() {
+        IsGreaterThanOrEqualTo<Integer> cond = SqlBuilder.isGreaterThanOrEqualTo(() -> (Integer) null);
+        assertThat(cond.value()).isNull();
+        assertThat(cond.isEmpty()).isFalse();
+    }
+
+    @SuppressWarnings("DataFlowIssue") // we are deliberately passing nulls into non-null methods for testing
+    @Test
+    void testIsLessThanNull() {
+        IsLessThan<Integer> cond = SqlBuilder.isLessThan(() -> (Integer) null);
+        assertThat(cond.value()).isNull();
+        assertThat(cond.isEmpty()).isFalse();
+    }
+
+    @SuppressWarnings("DataFlowIssue") // we are deliberately passing nulls into non-null methods for testing
+    @Test
+    void testIsLessThanOrEqualToNull() {
+        IsLessThanOrEqualTo<Integer> cond = SqlBuilder.isLessThanOrEqualTo(() -> (Integer) null);
+        assertThat(cond.value()).isNull();
+        assertThat(cond.isEmpty()).isFalse();
+    }
+
+    @SuppressWarnings("DataFlowIssue") // we are deliberately passing nulls into non-null methods for testing
+    @Test
+    void testIsLikeNull() {
+        IsLike<String> cond = SqlBuilder.isLike(() -> null);
+        assertThat(cond.value()).isNull();
+        assertThat(cond.isEmpty()).isFalse();
+    }
+
+    @SuppressWarnings("DataFlowIssue") // we are deliberately passing nulls into non-null methods for testing
+    @Test
+    void testIsLikeCaseInsensitiveNull() {
+        IsLikeCaseInsensitive<String> cond = SqlBuilder.isLikeCaseInsensitive(() -> null);
+        assertThat(cond.value()).isNull();
+        assertThat(cond.isEmpty()).isFalse();
+    }
+
+    @SuppressWarnings("DataFlowIssue") // we are deliberately passing nulls into non-null methods for testing
+    @Test
+    void testIsNotLikeNull() {
+        IsNotLike<String> cond = SqlBuilder.isNotLike(() -> null);
+        assertThat(cond.value()).isNull();
+        assertThat(cond.isEmpty()).isFalse();
+    }
+
+    @SuppressWarnings("DataFlowIssue") // we are deliberately passing nulls into non-null methods for testing
+    @Test
+    void testIsNotLikeCaseInsensitiveNull() {
+        IsNotLikeCaseInsensitive<String> cond = SqlBuilder.isNotLikeCaseInsensitive(() -> null);
+        assertThat(cond.value()).isNull();
+        assertThat(cond.isEmpty()).isFalse();
+    }
 }

--- a/src/test/java/org/mybatis/dynamic/sql/where/condition/NullContractTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/where/condition/NullContractTest.java
@@ -1,3 +1,18 @@
+/*
+ *    Copyright 2016-2025 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.mybatis.dynamic.sql.where.condition;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/org/mybatis/dynamic/sql/where/condition/NullContractTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/where/condition/NullContractTest.java
@@ -1,0 +1,441 @@
+package org.mybatis.dynamic.sql.where.condition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import java.util.NoSuchElementException;
+
+import org.junit.jupiter.api.Test;
+import org.mybatis.dynamic.sql.SqlBuilder;
+
+/**
+ * This set of tests verifies that the library handles null values in conditions as expected.
+ *
+ * <p>In version 2.0, we adopted JSpecify which brought several issues to light.
+ * In general, the library does not support passing null values into methods unless the method
+ * is a "whenPresent" method. However, from the beginning the library has handled null values in conditions
+ * by placing a null into the generated parameter map. We consider this a misuse of the library, but we are
+ * keeping that behavior for compatibility.
+ *
+ * <p>In a future version, we will stop supporting this misuse.
+ *
+ * <p>This set of tests should be the only tests in the library that verify this behavior. All other tests
+ * should use the library properly.
+ */
+public class NullContractTest {
+    @SuppressWarnings("DataFlowIssue") // we are deliberately passing nulls into non-null methods for testing
+    @Test
+    void testIsBetween() {
+        IsBetween<Integer> nullCond = SqlBuilder.isBetween((Integer) null).and((Integer) null);
+        assertThat(nullCond.isEmpty()).isFalse();
+
+        IsBetween<Integer> cond = SqlBuilder.isBetween(1).and(10);
+        IsBetween<Integer> filtered = cond.filter(i -> i >= 1);
+        IsBetween<Integer> mapped = filtered.map(i -> null);
+        assertThat(mapped.isEmpty()).isFalse();
+
+        mapped = filtered.map(v1 -> null, v2 -> null);
+        assertThat(mapped.isEmpty()).isFalse();
+        assertThat(mapped.value1()).isNull();
+        assertThat(mapped.value2()).isNull();
+    }
+
+    @Test
+    void testIsBetweenWhenPresent() {
+        IsBetweenWhenPresent<Integer> nullCond = SqlBuilder.isBetweenWhenPresent((Integer) null).and((Integer) null);
+        assertThat(nullCond.isEmpty()).isTrue();
+
+        IsBetweenWhenPresent<Integer> cond = SqlBuilder.isBetweenWhenPresent(1).and(10);
+        IsBetweenWhenPresent<Integer> filtered = cond.filter(i -> i == 1);
+        IsBetweenWhenPresent<Integer> mapped = filtered.map(i -> null);
+        assertThat(mapped.isEmpty()).isTrue();
+
+        mapped = filtered.map(v1 -> null, v2 -> null);
+        assertThat(mapped.isEmpty()).isTrue();
+        assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(mapped::value1);
+        assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(mapped::value2);
+    }
+
+    @SuppressWarnings("DataFlowIssue") // we are deliberately passing nulls into non-null methods for testing
+    @Test
+    void testIsEqualTo() {
+        IsEqualTo<Integer> nullCond = SqlBuilder.isEqualTo((Integer) null); // should be an IDE warning
+        assertThat(nullCond.isEmpty()).isFalse();
+
+        IsEqualTo<Integer> cond = SqlBuilder.isEqualTo(1);
+        IsEqualTo<Integer> filtered = cond.filter(i -> i == 1);
+        IsEqualTo<Integer> mapped = filtered.map(i -> null);  // should be an IDE warning
+        assertThat(mapped.isEmpty()).isFalse();
+        assertThat(mapped.value()).isNull();
+    }
+
+    @Test
+    void testIsEqualToWhenPresent() {
+        IsEqualToWhenPresent<Integer> nullCond = SqlBuilder.isEqualToWhenPresent((Integer) null);
+        assertThat(nullCond.isEmpty()).isTrue();
+
+        IsEqualToWhenPresent<Integer> cond = SqlBuilder.isEqualToWhenPresent(1);
+        IsEqualToWhenPresent<Integer> filtered = cond.filter(i -> i == 1);
+        IsEqualToWhenPresent<Integer> mapped = filtered.map(i -> null);
+        assertThat(mapped.isEmpty()).isTrue();
+        assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(mapped::value);
+    }
+
+    @SuppressWarnings("DataFlowIssue") // we are deliberately passing nulls into non-null methods for testing
+    @Test
+    void testIsGreaterThan() {
+        IsGreaterThan<Integer> nullCond = SqlBuilder.isGreaterThan((Integer) null); // should be an IDE warning
+        assertThat(nullCond.isEmpty()).isFalse();
+
+        IsGreaterThan<Integer> cond = SqlBuilder.isGreaterThan(1);
+        IsGreaterThan<Integer> filtered = cond.filter(i -> i == 1);
+        IsGreaterThan<Integer> mapped = filtered.map(i -> null);  // should be an IDE warning
+        assertThat(mapped.isEmpty()).isFalse();
+        assertThat(mapped.value()).isNull();
+    }
+
+    @Test
+    void testIsGreaterThanWhenPresent() {
+        IsGreaterThanWhenPresent<Integer> nullCond = SqlBuilder.isGreaterThanWhenPresent((Integer) null);
+        assertThat(nullCond.isEmpty()).isTrue();
+
+        IsGreaterThanWhenPresent<Integer> cond = SqlBuilder.isGreaterThanWhenPresent(1);
+        IsGreaterThanWhenPresent<Integer> filtered = cond.filter(i -> i == 1);
+        IsGreaterThanWhenPresent<Integer> mapped = filtered.map(i -> null);
+        assertThat(mapped.isEmpty()).isTrue();
+        assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(mapped::value);
+    }
+
+    @SuppressWarnings("DataFlowIssue") // we are deliberately passing nulls into non-null methods for testing
+    @Test
+    void testIsGreaterThanOrEqualTo() {
+        IsGreaterThanOrEqualTo<Integer> nullCond = SqlBuilder.isGreaterThanOrEqualTo((Integer) null); // should be an IDE warning
+        assertThat(nullCond.isEmpty()).isFalse();
+
+        IsGreaterThanOrEqualTo<Integer> cond = SqlBuilder.isGreaterThanOrEqualTo(1);
+        IsGreaterThanOrEqualTo<Integer> filtered = cond.filter(i -> i == 1);
+        IsGreaterThanOrEqualTo<Integer> mapped = filtered.map(i -> null);  // should be an IDE warning
+        assertThat(mapped.isEmpty()).isFalse();
+        assertThat(mapped.value()).isNull();
+    }
+
+    @Test
+    void testIsGreaterThanOrEqualToWhenPresent() {
+        IsGreaterThanOrEqualToWhenPresent<Integer> nullCond = SqlBuilder.isGreaterThanOrEqualToWhenPresent((Integer) null);
+        assertThat(nullCond.isEmpty()).isTrue();
+
+        IsGreaterThanOrEqualToWhenPresent<Integer> cond = SqlBuilder.isGreaterThanOrEqualToWhenPresent(1);
+        IsGreaterThanOrEqualToWhenPresent<Integer> filtered = cond.filter(i -> i == 1);
+        IsGreaterThanOrEqualToWhenPresent<Integer> mapped = filtered.map(i -> null);
+        assertThat(mapped.isEmpty()).isTrue();
+        assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(mapped::value);
+    }
+
+    @SuppressWarnings("DataFlowIssue") // we are deliberately passing nulls into non-null methods for testing
+    @Test
+    void testIsLessThan() {
+        IsLessThan<Integer> nullCond = SqlBuilder.isLessThan((Integer) null); // should be an IDE warning
+        assertThat(nullCond.isEmpty()).isFalse();
+
+        IsLessThan<Integer> cond = SqlBuilder.isLessThan(1);
+        IsLessThan<Integer> filtered = cond.filter(i -> i == 1);
+        IsLessThan<Integer> mapped = filtered.map(i -> null);  // should be an IDE warning
+        assertThat(mapped.isEmpty()).isFalse();
+        assertThat(mapped.value()).isNull();
+    }
+
+    @Test
+    void testIsLessThanWhenPresent() {
+        IsLessThanWhenPresent<Integer> nullCond = SqlBuilder.isLessThanWhenPresent((Integer) null);
+        assertThat(nullCond.isEmpty()).isTrue();
+
+        IsLessThanWhenPresent<Integer> cond = SqlBuilder.isLessThanWhenPresent(1);
+        IsLessThanWhenPresent<Integer> filtered = cond.filter(i -> i == 1);
+        IsLessThanWhenPresent<Integer> mapped = filtered.map(i -> null);
+        assertThat(mapped.isEmpty()).isTrue();
+        assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(mapped::value);
+    }
+
+    @SuppressWarnings("DataFlowIssue") // we are deliberately passing nulls into non-null methods for testing
+    @Test
+    void testIsLessThanOrEqualTo() {
+        IsLessThanOrEqualTo<Integer> nullCond = SqlBuilder.isLessThanOrEqualTo((Integer) null); // should be an IDE warning
+        assertThat(nullCond.isEmpty()).isFalse();
+
+        IsLessThanOrEqualTo<Integer> cond = SqlBuilder.isLessThanOrEqualTo(1);
+        IsLessThanOrEqualTo<Integer> filtered = cond.filter(i -> i == 1);
+        IsLessThanOrEqualTo<Integer> mapped = filtered.map(i -> null);  // should be an IDE warning
+        assertThat(mapped.isEmpty()).isFalse();
+        assertThat(mapped.value()).isNull();
+    }
+
+    @Test
+    void testIsLessThanOrEqualToWhenPresent() {
+        IsLessThanOrEqualToWhenPresent<Integer> nullCond = SqlBuilder.isLessThanOrEqualToWhenPresent((Integer) null);
+        assertThat(nullCond.isEmpty()).isTrue();
+
+        IsLessThanOrEqualToWhenPresent<Integer> cond = SqlBuilder.isLessThanOrEqualToWhenPresent(1);
+        IsLessThanOrEqualToWhenPresent<Integer> filtered = cond.filter(i -> i == 1);
+        IsLessThanOrEqualToWhenPresent<Integer> mapped = filtered.map(i -> null);
+        assertThat(mapped.isEmpty()).isTrue();
+        assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(mapped::value);
+    }
+
+    @SuppressWarnings("DataFlowIssue") // we are deliberately passing nulls into non-null methods for testing
+    @Test
+    void testIsNotBetween() {
+        IsNotBetween<Integer> nullCond = SqlBuilder.isNotBetween((Integer) null).and((Integer) null);
+        assertThat(nullCond.isEmpty()).isFalse();
+
+        IsNotBetween<Integer> cond = SqlBuilder.isNotBetween(1).and(10);
+        IsNotBetween<Integer> filtered = cond.filter(i -> i >= 1);
+        IsNotBetween<Integer> mapped = filtered.map(i -> null);
+        assertThat(mapped.isEmpty()).isFalse();
+
+        mapped = filtered.map(v1 -> null, v2 -> null);
+        assertThat(mapped.isEmpty()).isFalse();
+        assertThat(mapped.value1()).isNull();
+        assertThat(mapped.value2()).isNull();
+    }
+
+    @Test
+    void testIsNotBetweenWhenPresent() {
+        IsNotBetweenWhenPresent<Integer> nullCond = SqlBuilder.isNotBetweenWhenPresent((Integer) null).and((Integer) null);
+        assertThat(nullCond.isEmpty()).isTrue();
+
+        IsNotBetweenWhenPresent<Integer> cond = SqlBuilder.isNotBetweenWhenPresent(1).and(10);
+        IsNotBetweenWhenPresent<Integer> filtered = cond.filter(i -> i == 1);
+        IsNotBetweenWhenPresent<Integer> mapped = filtered.map(i -> null);
+        assertThat(mapped.isEmpty()).isTrue();
+
+        mapped = filtered.map(v1 -> null, v2 -> null);
+        assertThat(mapped.isEmpty()).isTrue();
+        assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(mapped::value1);
+        assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(mapped::value2);
+    }
+
+    @SuppressWarnings("DataFlowIssue") // we are deliberately passing nulls into non-null methods for testing
+    @Test
+    void testIsNotEqualTo() {
+        IsNotEqualTo<Integer> nullCond = SqlBuilder.isNotEqualTo((Integer) null); // should be an IDE warning
+        assertThat(nullCond.isEmpty()).isFalse();
+
+        IsNotEqualTo<Integer> cond = SqlBuilder.isNotEqualTo(1);
+        IsNotEqualTo<Integer> filtered = cond.filter(i -> i == 1);
+        IsNotEqualTo<Integer> mapped = filtered.map(i -> null); // should be an IDE warning
+        assertThat(mapped.isEmpty()).isFalse();
+        assertThat(mapped.value()).isNull();
+    }
+
+    @Test
+    void testIsNotEqualToWhenPresent() {
+        IsNotEqualToWhenPresent<Integer> nullCond = SqlBuilder.isNotEqualToWhenPresent((Integer) null);
+        assertThat(nullCond.isEmpty()).isTrue();
+
+        IsNotEqualToWhenPresent<Integer> cond = SqlBuilder.isNotEqualToWhenPresent(1);
+        IsNotEqualToWhenPresent<Integer> filtered = cond.filter(i -> i == 1);
+        IsNotEqualToWhenPresent<Integer> mapped = filtered.map(i -> null);
+        assertThat(mapped.isEmpty()).isTrue();
+        assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(mapped::value);
+    }
+
+    @SuppressWarnings("DataFlowIssue") // we are deliberately passing nulls into non-null methods for testing
+    @Test
+    void testIsLike() {
+        IsLike<String> nullCond = SqlBuilder.isLike((String) null); // should be an IDE warning
+        assertThat(nullCond.isEmpty()).isFalse();
+
+        IsLike<String> cond = SqlBuilder.isLike("fred");
+        IsLike<String> filtered = cond.filter(i -> i.equals("fred"));
+        IsLike<String> mapped = filtered.map(i -> null); // should be an IDE warning
+        assertThat(mapped.isEmpty()).isFalse();
+        assertThat(mapped.value()).isNull();
+    }
+
+    @Test
+    void testIsLikeWhenPresent() {
+        IsLikeWhenPresent<String> nullCond = SqlBuilder.isLikeWhenPresent((String) null);
+        assertThat(nullCond.isEmpty()).isTrue();
+
+        IsLikeWhenPresent<String> cond = SqlBuilder.isLikeWhenPresent("fred");
+        IsLikeWhenPresent<String> filtered = cond.filter(i -> i.equals("fred"));
+        IsLikeWhenPresent<String> mapped = filtered.map(i -> null);
+        assertThat(mapped.isEmpty()).isTrue();
+        assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(mapped::value);
+    }
+
+    @SuppressWarnings("DataFlowIssue") // we are deliberately passing nulls into non-null methods for testing
+    @Test
+    void testIsLikeCaseInsensitive() {
+        IsLikeCaseInsensitive<String> nullCond = SqlBuilder.isLikeCaseInsensitive((String) null); // should be an IDE warning
+        assertThat(nullCond.isEmpty()).isFalse();
+
+        IsLikeCaseInsensitive<String> cond = SqlBuilder.isLikeCaseInsensitive("fred");
+        IsLikeCaseInsensitive<String> filtered = cond.filter(i -> i.equals("FRED"));
+        IsLikeCaseInsensitive<String> mapped = filtered.map(i -> null); // should be an IDE warning
+        assertThat(mapped.isEmpty()).isFalse();
+        assertThat(mapped.value()).isNull();
+    }
+
+    @Test
+    void testIsLikeCaseInsensitiveWhenPresent() {
+        IsLikeCaseInsensitiveWhenPresent<String> nullCond = SqlBuilder.isLikeCaseInsensitiveWhenPresent((String) null);
+        assertThat(nullCond.isEmpty()).isTrue();
+
+        IsLikeCaseInsensitiveWhenPresent<String> cond = SqlBuilder.isLikeCaseInsensitiveWhenPresent("fred");
+        IsLikeCaseInsensitiveWhenPresent<String> filtered = cond.filter(i -> i.equals("fred"));
+        IsLikeCaseInsensitiveWhenPresent<String> mapped = filtered.map(i -> null);
+        assertThat(mapped.isEmpty()).isTrue();
+        assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(mapped::value);
+    }
+
+    @SuppressWarnings("DataFlowIssue") // we are deliberately passing nulls into non-null methods for testing
+    @Test
+    void testIsNotLike() {
+        IsNotLike<String> nullCond = SqlBuilder.isNotLike((String) null); // should be an IDE warning
+        assertThat(nullCond.isEmpty()).isFalse();
+
+        IsNotLike<String> cond = SqlBuilder.isNotLike("fred");
+        IsNotLike<String> filtered = cond.filter(i -> i.equals("fred"));
+        IsNotLike<String> mapped = filtered.map(i -> null); // should be an IDE warning
+        assertThat(mapped.isEmpty()).isFalse();
+        assertThat(mapped.value()).isNull();
+    }
+
+    @Test
+    void testIsNotLikeWhenPresent() {
+        IsNotLikeWhenPresent<String> nullCond = SqlBuilder.isNotLikeWhenPresent((String) null);
+        assertThat(nullCond.isEmpty()).isTrue();
+
+        IsNotLikeWhenPresent<String> cond = SqlBuilder.isNotLikeWhenPresent("fred");
+        IsNotLikeWhenPresent<String> filtered = cond.filter(i -> i.equals("fred"));
+        IsNotLikeWhenPresent<String> mapped = filtered.map(i -> null);
+        assertThat(mapped.isEmpty()).isTrue();
+        assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(mapped::value);
+    }
+
+    @SuppressWarnings("DataFlowIssue") // we are deliberately passing nulls into non-null methods for testing
+    @Test
+    void testIsNotLikeCaseInsensitive() {
+        IsNotLikeCaseInsensitive<String> nullCond = SqlBuilder.isNotLikeCaseInsensitive((String) null); // should be an IDE warning
+        assertThat(nullCond.isEmpty()).isFalse();
+
+        IsNotLikeCaseInsensitive<String> cond = SqlBuilder.isNotLikeCaseInsensitive("fred");
+        IsNotLikeCaseInsensitive<String> filtered = cond.filter(i -> i.equals("FRED"));
+        IsNotLikeCaseInsensitive<String> mapped = filtered.map(i -> null); // should be an IDE warning
+        assertThat(mapped.isEmpty()).isFalse();
+        assertThat(mapped.value()).isNull();
+    }
+
+    @Test
+    void testIsNotLikeCaseInsensitiveWhenPresent() {
+        IsNotLikeCaseInsensitiveWhenPresent<String> nullCond = SqlBuilder.isNotLikeCaseInsensitiveWhenPresent((String) null);
+        assertThat(nullCond.isEmpty()).isTrue();
+
+        IsNotLikeCaseInsensitiveWhenPresent<String> cond = SqlBuilder.isNotLikeCaseInsensitiveWhenPresent("fred");
+        IsNotLikeCaseInsensitiveWhenPresent<String> filtered = cond.filter(i -> i.equals("FRED"));
+        IsNotLikeCaseInsensitiveWhenPresent<String> mapped = filtered.map(i -> null);
+        assertThat(mapped.isEmpty()).isTrue();
+        assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(mapped::value);
+    }
+
+    @SuppressWarnings("DataFlowIssue") // we are deliberately passing nulls into non-null methods for testing
+    @Test
+    void testIsIn() {
+        IsIn<Integer> nullCond = SqlBuilder.isIn((Integer) null); // should be an IDE warning
+        assertThat(nullCond.isEmpty()).isFalse();
+
+        IsIn<Integer> cond = SqlBuilder.isIn(1);
+        IsIn<Integer> filtered = cond.filter(i -> i == 1);
+        IsIn<Integer> mapped = filtered.map(i -> null); // should be an IDE warning
+        assertThat(mapped.isEmpty()).isFalse();
+        assertThat(mapped.values().toList()).containsExactly((Integer) null);
+    }
+
+    @Test
+    void testIsInWhenPresent() {
+        IsInWhenPresent<Integer> nullCond = SqlBuilder.isInWhenPresent((Integer) null);
+        assertThat(nullCond.isEmpty()).isTrue();
+
+        IsInWhenPresent<Integer> cond = SqlBuilder.isInWhenPresent(1);
+        IsInWhenPresent<Integer> filtered = cond.filter(i -> i == 1);
+        IsInWhenPresent<Integer> mapped = filtered.map(i -> null);
+        assertThat(mapped.isEmpty()).isTrue();
+        assertThat(mapped.values().toList()).isEmpty();;
+    }
+
+    @SuppressWarnings("DataFlowIssue") // we are deliberately passing nulls into non-null methods for testing
+    @Test
+    void testIsInCaseInsensitive() {
+        IsInCaseInsensitive<String> nullCond = SqlBuilder.isInCaseInsensitive((String) null); // should be an IDE warning
+        assertThat(nullCond.isEmpty()).isFalse();
+
+        IsInCaseInsensitive<String> cond = SqlBuilder.isInCaseInsensitive("fred");
+        IsInCaseInsensitive<String> filtered = cond.filter(i -> i.equals("FRED"));
+        IsInCaseInsensitive<String> mapped = filtered.map(i -> null); // should be an IDE warning
+        assertThat(mapped.isEmpty()).isFalse();
+        assertThat(mapped.values().toList()).containsExactly((String) null);
+    }
+
+    @Test
+    void testIsInCaseInsensitiveWhenPresent() {
+        IsInCaseInsensitiveWhenPresent<String> nullCond = SqlBuilder.isInCaseInsensitiveWhenPresent((String) null);
+        assertThat(nullCond.isEmpty()).isTrue();
+
+        IsInCaseInsensitiveWhenPresent<String> cond = SqlBuilder.isInCaseInsensitiveWhenPresent("fred");
+        IsInCaseInsensitiveWhenPresent<String> filtered = cond.filter(i -> i.equals("FRED"));
+        IsInCaseInsensitiveWhenPresent<String> mapped = filtered.map(i -> null);
+        assertThat(mapped.isEmpty()).isTrue();
+        assertThat(mapped.values().toList()).isEmpty();;
+    }
+
+    @SuppressWarnings("DataFlowIssue") // we are deliberately passing nulls into non-null methods for testing
+    @Test
+    void testIsNotIn() {
+        IsNotIn<Integer> nullCond = SqlBuilder.isNotIn((Integer) null); // should be an IDE warning
+        assertThat(nullCond.isEmpty()).isFalse();
+
+        IsNotIn<Integer> cond = SqlBuilder.isNotIn(1);
+        IsNotIn<Integer> filtered = cond.filter(i -> i == 1);
+        IsNotIn<Integer> mapped = filtered.map(i -> null); // should be an IDE warning
+        assertThat(mapped.isEmpty()).isFalse();
+        assertThat(mapped.values().toList()).containsExactly((Integer) null);
+    }
+
+    @Test
+    void testIsNotInWhenPresent() {
+        IsNotInWhenPresent<Integer> nullCond = SqlBuilder.isNotInWhenPresent((Integer) null);
+        assertThat(nullCond.isEmpty()).isTrue();
+
+        IsNotInWhenPresent<Integer> cond = SqlBuilder.isNotInWhenPresent(1);
+        IsNotInWhenPresent<Integer> filtered = cond.filter(i -> i == 1);
+        IsNotInWhenPresent<Integer> mapped = filtered.map(i -> null);
+        assertThat(mapped.isEmpty()).isTrue();
+        assertThat(mapped.values().toList()).isEmpty();;
+    }
+
+    @SuppressWarnings("DataFlowIssue") // we are deliberately passing nulls into non-null methods for testing
+    @Test
+    void testIsNotInCaseInsensitive() {
+        IsNotInCaseInsensitive<String> nullCond = SqlBuilder.isNotInCaseInsensitive((String) null); // should be an IDE warning
+        assertThat(nullCond.isEmpty()).isFalse();
+
+        IsNotInCaseInsensitive<String> cond = SqlBuilder.isNotInCaseInsensitive("fred");
+        IsNotInCaseInsensitive<String> filtered = cond.filter(i -> i.equals("FRED"));
+        IsNotInCaseInsensitive<String> mapped = filtered.map(i -> null); // should be an IDE warning
+        assertThat(mapped.isEmpty()).isFalse();
+        assertThat(mapped.values().toList()).containsExactly((String) null);
+    }
+
+    @Test
+    void testIsNotInCaseInsensitiveWhenPresent() {
+        IsNotInCaseInsensitiveWhenPresent<String> nullCond = SqlBuilder.isNotInCaseInsensitiveWhenPresent((String) null);
+        assertThat(nullCond.isEmpty()).isTrue();
+
+        IsNotInCaseInsensitiveWhenPresent<String> cond = SqlBuilder.isNotInCaseInsensitiveWhenPresent("fred");
+        IsNotInCaseInsensitiveWhenPresent<String> filtered = cond.filter(i -> i.equals("FRED"));
+        IsNotInCaseInsensitiveWhenPresent<String> mapped = filtered.map(i -> null);
+        assertThat(mapped.isEmpty()).isTrue();
+        assertThat(mapped.values().toList()).isEmpty();;
+    }
+}

--- a/src/test/java/org/mybatis/dynamic/sql/where/condition/NullContractTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/where/condition/NullContractTest.java
@@ -37,7 +37,7 @@ import org.mybatis.dynamic.sql.SqlBuilder;
  * <p>This set of tests should be the only tests in the library that verify this behavior. All other tests
  * should use the library properly.
  */
-public class NullContractTest {
+class NullContractTest {
     @SuppressWarnings("DataFlowIssue") // we are deliberately passing nulls into non-null methods for testing
     @Test
     void testIsBetween() {

--- a/src/test/java/org/mybatis/dynamic/sql/where/condition/NullContractTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/where/condition/NullContractTest.java
@@ -361,7 +361,7 @@ public class NullContractTest {
         IsInWhenPresent<Integer> filtered = cond.filter(i -> i == 1);
         IsInWhenPresent<Integer> mapped = filtered.map(i -> null);
         assertThat(mapped.isEmpty()).isTrue();
-        assertThat(mapped.values().toList()).isEmpty();;
+        assertThat(mapped.values().toList()).isEmpty();
     }
 
     @SuppressWarnings("DataFlowIssue") // we are deliberately passing nulls into non-null methods for testing
@@ -386,7 +386,7 @@ public class NullContractTest {
         IsInCaseInsensitiveWhenPresent<String> filtered = cond.filter(i -> i.equals("FRED"));
         IsInCaseInsensitiveWhenPresent<String> mapped = filtered.map(i -> null);
         assertThat(mapped.isEmpty()).isTrue();
-        assertThat(mapped.values().toList()).isEmpty();;
+        assertThat(mapped.values().toList()).isEmpty();
     }
 
     @SuppressWarnings("DataFlowIssue") // we are deliberately passing nulls into non-null methods for testing
@@ -411,7 +411,7 @@ public class NullContractTest {
         IsNotInWhenPresent<Integer> filtered = cond.filter(i -> i == 1);
         IsNotInWhenPresent<Integer> mapped = filtered.map(i -> null);
         assertThat(mapped.isEmpty()).isTrue();
-        assertThat(mapped.values().toList()).isEmpty();;
+        assertThat(mapped.values().toList()).isEmpty();
     }
 
     @SuppressWarnings("DataFlowIssue") // we are deliberately passing nulls into non-null methods for testing
@@ -436,6 +436,6 @@ public class NullContractTest {
         IsNotInCaseInsensitiveWhenPresent<String> filtered = cond.filter(i -> i.equals("FRED"));
         IsNotInCaseInsensitiveWhenPresent<String> mapped = filtered.map(i -> null);
         assertThat(mapped.isEmpty()).isTrue();
-        assertThat(mapped.values().toList()).isEmpty();;
+        assertThat(mapped.values().toList()).isEmpty();
     }
 }

--- a/src/test/java/org/mybatis/dynamic/sql/where/condition/SupplierTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/where/condition/SupplierTest.java
@@ -44,7 +44,7 @@ class SupplierTest {
 
     @Test
     void testIsBetweenWhenPresent() {
-        IsBetween<Integer> cond = SqlBuilder.isBetweenWhenPresent(() -> 3).and(() -> 4);
+        IsBetweenWhenPresent<Integer> cond = SqlBuilder.isBetweenWhenPresent(() -> 3).and(() -> 4);
         assertThat(cond.value1()).isEqualTo(3);
         assertThat(cond.value2()).isEqualTo(4);
         assertThat(cond.isEmpty()).isFalse();
@@ -52,7 +52,7 @@ class SupplierTest {
 
     @Test
     void testIsBetweenWhenPresentNull() {
-        IsBetween<Integer> cond = SqlBuilder.isBetweenWhenPresent(() -> (Integer) null).and(() -> null);
+        IsBetweenWhenPresent<Integer> cond = SqlBuilder.isBetweenWhenPresent(() -> (Integer) null).and(() -> null);
         assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(cond::value1);
         assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(cond::value2);
         assertThat(cond.isEmpty()).isTrue();
@@ -76,7 +76,7 @@ class SupplierTest {
 
     @Test
     void testIsNotBetweenWhenPresent() {
-        IsNotBetween<Integer> cond = SqlBuilder.isNotBetweenWhenPresent(() -> 3).and(() -> 4);
+        IsNotBetweenWhenPresent<Integer> cond = SqlBuilder.isNotBetweenWhenPresent(() -> 3).and(() -> 4);
         assertThat(cond.value1()).isEqualTo(3);
         assertThat(cond.value2()).isEqualTo(4);
         assertThat(cond.isEmpty()).isFalse();
@@ -84,7 +84,7 @@ class SupplierTest {
 
     @Test
     void testIsNotBetweenWhenPresentNull() {
-        IsNotBetween<Integer> cond = SqlBuilder.isNotBetweenWhenPresent(() -> (Integer) null).and(() -> null);
+        IsNotBetweenWhenPresent<Integer> cond = SqlBuilder.isNotBetweenWhenPresent(() -> (Integer) null).and(() -> null);
         assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(cond::value1);
         assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(cond::value2);
         assertThat(cond.isEmpty()).isTrue();
@@ -92,14 +92,14 @@ class SupplierTest {
 
     @Test
     void testIsEqualToWhenPresent() {
-        IsEqualTo<Integer> cond = SqlBuilder.isEqualToWhenPresent(() -> 3);
+        IsEqualToWhenPresent<Integer> cond = SqlBuilder.isEqualToWhenPresent(() -> 3);
         assertThat(cond.value()).isEqualTo(3);
         assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsEqualToWhenPresentNull() {
-        IsEqualTo<Integer> cond = SqlBuilder.isEqualToWhenPresent(() -> null);
+        IsEqualToWhenPresent<Integer> cond = SqlBuilder.isEqualToWhenPresent(() -> null);
         assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(cond::value);
         assertThat(cond.isEmpty()).isTrue();
     }
@@ -120,14 +120,14 @@ class SupplierTest {
 
     @Test
     void testIsNotEqualToWhenPresent() {
-        IsNotEqualTo<Integer> cond = SqlBuilder.isNotEqualToWhenPresent(() -> 3);
+        IsNotEqualToWhenPresent<Integer> cond = SqlBuilder.isNotEqualToWhenPresent(() -> 3);
         assertThat(cond.value()).isEqualTo(3);
         assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsNotEqualToWhenPresentNull() {
-        IsNotEqualTo<Integer> cond = SqlBuilder.isNotEqualToWhenPresent(() -> null);
+        IsNotEqualToWhenPresent<Integer> cond = SqlBuilder.isNotEqualToWhenPresent(() -> null);
         assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(cond::value);
         assertThat(cond.isEmpty()).isTrue();
     }
@@ -148,14 +148,14 @@ class SupplierTest {
 
     @Test
     void testIsGreaterThanWhenPresent() {
-        IsGreaterThan<Integer> cond = SqlBuilder.isGreaterThanWhenPresent(() -> 3);
+        IsGreaterThanWhenPresent<Integer> cond = SqlBuilder.isGreaterThanWhenPresent(() -> 3);
         assertThat(cond.value()).isEqualTo(3);
         assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsGreaterThanWhenPresentNull() {
-        IsGreaterThan<Integer> cond = SqlBuilder.isGreaterThanWhenPresent(() -> null);
+        IsGreaterThanWhenPresent<Integer> cond = SqlBuilder.isGreaterThanWhenPresent(() -> null);
         assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(cond::value);
         assertThat(cond.isEmpty()).isTrue();
     }
@@ -176,14 +176,14 @@ class SupplierTest {
 
     @Test
     void testIsGreaterThanOrEqualToWhenPresent() {
-        IsGreaterThanOrEqualTo<Integer> cond = SqlBuilder.isGreaterThanOrEqualToWhenPresent(() -> 3);
+        IsGreaterThanOrEqualToWhenPresent<Integer> cond = SqlBuilder.isGreaterThanOrEqualToWhenPresent(() -> 3);
         assertThat(cond.value()).isEqualTo(3);
         assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsGreaterThanOrEqualToWhenPresentNull() {
-        IsGreaterThanOrEqualTo<Integer> cond = SqlBuilder.isGreaterThanOrEqualToWhenPresent(() -> null);
+        IsGreaterThanOrEqualToWhenPresent<Integer> cond = SqlBuilder.isGreaterThanOrEqualToWhenPresent(() -> null);
         assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(cond::value);
         assertThat(cond.isEmpty()).isTrue();
     }
@@ -204,14 +204,14 @@ class SupplierTest {
 
     @Test
     void testIsLessThanWhenPresent() {
-        IsLessThan<Integer> cond = SqlBuilder.isLessThanWhenPresent(() -> 3);
+        IsLessThanWhenPresent<Integer> cond = SqlBuilder.isLessThanWhenPresent(() -> 3);
         assertThat(cond.value()).isEqualTo(3);
         assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsLessThanWhenPresentNull() {
-        IsLessThan<Integer> cond = SqlBuilder.isLessThanWhenPresent(() -> null);
+        IsLessThanWhenPresent<Integer> cond = SqlBuilder.isLessThanWhenPresent(() -> null);
         assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(cond::value);
         assertThat(cond.isEmpty()).isTrue();
     }
@@ -232,14 +232,14 @@ class SupplierTest {
 
     @Test
     void testIsLessThanOrEqualToWhenPresent() {
-        IsLessThanOrEqualTo<Integer> cond = SqlBuilder.isLessThanOrEqualToWhenPresent(() -> 3);
+        IsLessThanOrEqualToWhenPresent<Integer> cond = SqlBuilder.isLessThanOrEqualToWhenPresent(() -> 3);
         assertThat(cond.value()).isEqualTo(3);
         assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsLessThanOrEqualToWhenPresentNull() {
-        IsLessThanOrEqualTo<Integer> cond = SqlBuilder.isLessThanOrEqualToWhenPresent(() -> null);
+        IsLessThanOrEqualToWhenPresent<Integer> cond = SqlBuilder.isLessThanOrEqualToWhenPresent(() -> null);
         assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(cond::value);
         assertThat(cond.isEmpty()).isTrue();
     }
@@ -274,28 +274,28 @@ class SupplierTest {
 
     @Test
     void testIsLikeCaseInsensitiveWhenPresent() {
-        IsLikeCaseInsensitive<String> cond = SqlBuilder.isLikeCaseInsensitiveWhenPresent(() -> "%f%");
+        IsLikeCaseInsensitiveWhenPresent<String> cond = SqlBuilder.isLikeCaseInsensitiveWhenPresent(() -> "%f%");
         assertThat(cond.value()).isEqualTo("%F%");
         assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsLikeCaseInsensitiveWhenPresentNull() {
-        IsLikeCaseInsensitive<String> cond = SqlBuilder.isLikeCaseInsensitiveWhenPresent(() -> null);
+        IsLikeCaseInsensitiveWhenPresent<String> cond = SqlBuilder.isLikeCaseInsensitiveWhenPresent(() -> null);
         assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(cond::value);
         assertThat(cond.isEmpty()).isTrue();
     }
 
     @Test
     void testIsLikeWhenPresent() {
-        IsLike<String> cond = SqlBuilder.isLikeWhenPresent(() -> "%F%");
+        IsLikeWhenPresent<String> cond = SqlBuilder.isLikeWhenPresent(() -> "%F%");
         assertThat(cond.value()).isEqualTo("%F%");
         assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsLikeWhenPresentNull() {
-        IsLike<String> cond = SqlBuilder.isLikeWhenPresent(() -> null);
+        IsLikeWhenPresent<String> cond = SqlBuilder.isLikeWhenPresent(() -> null);
         assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(cond::value);
         assertThat(cond.isEmpty()).isTrue();
     }
@@ -316,14 +316,14 @@ class SupplierTest {
 
     @Test
     void testIsNotLikeWhenPresent() {
-        IsNotLike<String> cond = SqlBuilder.isNotLikeWhenPresent(() -> "%F%");
+        IsNotLikeWhenPresent<String> cond = SqlBuilder.isNotLikeWhenPresent(() -> "%F%");
         assertThat(cond.value()).isEqualTo("%F%");
         assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsNotLikeWhenPresentNull() {
-        IsNotLike<String> cond = SqlBuilder.isNotLikeWhenPresent(() -> null);
+        IsNotLikeWhenPresent<String> cond = SqlBuilder.isNotLikeWhenPresent(() -> null);
         assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(cond::value);
         assertThat(cond.isEmpty()).isTrue();
     }
@@ -344,14 +344,14 @@ class SupplierTest {
 
     @Test
     void testIsNotLikeCaseInsensitiveWhenPresent() {
-        IsNotLikeCaseInsensitive<String> cond = SqlBuilder.isNotLikeCaseInsensitiveWhenPresent(() -> "%f%");
+        IsNotLikeCaseInsensitiveWhenPresent<String> cond = SqlBuilder.isNotLikeCaseInsensitiveWhenPresent(() -> "%f%");
         assertThat(cond.value()).isEqualTo("%F%");
         assertThat(cond.isEmpty()).isFalse();
     }
 
     @Test
     void testIsNotLikeCaseInsensitiveWhenPresentNull() {
-        IsNotLikeCaseInsensitive<String> cond = SqlBuilder.isNotLikeCaseInsensitiveWhenPresent(() -> null);
+        IsNotLikeCaseInsensitiveWhenPresent<String> cond = SqlBuilder.isNotLikeCaseInsensitiveWhenPresent(() -> null);
         assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(cond::value);
         assertThat(cond.isEmpty()).isTrue();
     }

--- a/src/test/java/org/mybatis/dynamic/sql/where/condition/SupplierTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/where/condition/SupplierTest.java
@@ -35,14 +35,6 @@ class SupplierTest {
     }
 
     @Test
-    void testIsBetweenNull() {
-        IsBetween<Integer> cond = SqlBuilder.isBetween(() -> (Integer) null).and(() -> null);
-        assertThat(cond.value1()).isNull();
-        assertThat(cond.value2()).isNull();
-        assertThat(cond.isEmpty()).isFalse();
-    }
-
-    @Test
     void testIsBetweenWhenPresent() {
         IsBetweenWhenPresent<Integer> cond = SqlBuilder.isBetweenWhenPresent(() -> 3).and(() -> 4);
         assertThat(cond.value1()).isEqualTo(3);
@@ -63,14 +55,6 @@ class SupplierTest {
         IsNotBetween<Integer> cond = SqlBuilder.isNotBetween(() -> 3).and(() -> 4);
         assertThat(cond.value1()).isEqualTo(3);
         assertThat(cond.value2()).isEqualTo(4);
-        assertThat(cond.isEmpty()).isFalse();
-    }
-
-    @Test
-    void testIsNotBetweenNull() {
-        IsNotBetween<Integer> cond = SqlBuilder.isNotBetween(() -> (Integer) null).and(() -> null);
-        assertThat(cond.value1()).isNull();
-        assertThat(cond.value2()).isNull();
         assertThat(cond.isEmpty()).isFalse();
     }
 
@@ -112,13 +96,6 @@ class SupplierTest {
     }
 
     @Test
-    void testIsNotEqualToNull() {
-        IsNotEqualTo<Integer> cond = SqlBuilder.isNotEqualTo(() -> (Integer) null);
-        assertThat(cond.value()).isNull();
-        assertThat(cond.isEmpty()).isFalse();
-    }
-
-    @Test
     void testIsNotEqualToWhenPresent() {
         IsNotEqualToWhenPresent<Integer> cond = SqlBuilder.isNotEqualToWhenPresent(() -> 3);
         assertThat(cond.value()).isEqualTo(3);
@@ -136,13 +113,6 @@ class SupplierTest {
     void testIsGreaterThan() {
         IsGreaterThan<Integer> cond = SqlBuilder.isGreaterThan(() -> 3);
         assertThat(cond.value()).isEqualTo(3);
-        assertThat(cond.isEmpty()).isFalse();
-    }
-
-    @Test
-    void testIsGreaterThanNull() {
-        IsGreaterThan<Integer> cond = SqlBuilder.isGreaterThan(() -> (Integer) null);
-        assertThat(cond.value()).isNull();
         assertThat(cond.isEmpty()).isFalse();
     }
 
@@ -168,13 +138,6 @@ class SupplierTest {
     }
 
     @Test
-    void testIsGreaterThanOrEqualToNull() {
-        IsGreaterThanOrEqualTo<Integer> cond = SqlBuilder.isGreaterThanOrEqualTo(() -> (Integer) null);
-        assertThat(cond.value()).isNull();
-        assertThat(cond.isEmpty()).isFalse();
-    }
-
-    @Test
     void testIsGreaterThanOrEqualToWhenPresent() {
         IsGreaterThanOrEqualToWhenPresent<Integer> cond = SqlBuilder.isGreaterThanOrEqualToWhenPresent(() -> 3);
         assertThat(cond.value()).isEqualTo(3);
@@ -192,13 +155,6 @@ class SupplierTest {
     void testIsLessThan() {
         IsLessThan<Integer> cond = SqlBuilder.isLessThan(() -> 3);
         assertThat(cond.value()).isEqualTo(3);
-        assertThat(cond.isEmpty()).isFalse();
-    }
-
-    @Test
-    void testIsLessThanNull() {
-        IsLessThan<Integer> cond = SqlBuilder.isLessThan(() -> (Integer) null);
-        assertThat(cond.value()).isNull();
         assertThat(cond.isEmpty()).isFalse();
     }
 
@@ -224,13 +180,6 @@ class SupplierTest {
     }
 
     @Test
-    void testIsLessThanOrEqualToNull() {
-        IsLessThanOrEqualTo<Integer> cond = SqlBuilder.isLessThanOrEqualTo(() -> (Integer) null);
-        assertThat(cond.value()).isNull();
-        assertThat(cond.isEmpty()).isFalse();
-    }
-
-    @Test
     void testIsLessThanOrEqualToWhenPresent() {
         IsLessThanOrEqualToWhenPresent<Integer> cond = SqlBuilder.isLessThanOrEqualToWhenPresent(() -> 3);
         assertThat(cond.value()).isEqualTo(3);
@@ -252,23 +201,9 @@ class SupplierTest {
     }
 
     @Test
-    void testIsLikeNull() {
-        IsLike<String> cond = SqlBuilder.isLike(() -> null);
-        assertThat(cond.value()).isNull();
-        assertThat(cond.isEmpty()).isFalse();
-    }
-
-    @Test
     void testIsLikeCaseInsensitive() {
         IsLikeCaseInsensitive<String> cond = SqlBuilder.isLikeCaseInsensitive(() -> "%f%");
         assertThat(cond.value()).isEqualTo("%F%");
-        assertThat(cond.isEmpty()).isFalse();
-    }
-
-    @Test
-    void testIsLikeCaseInsensitiveNull() {
-        IsLikeCaseInsensitive<String> cond = SqlBuilder.isLikeCaseInsensitive(() -> null);
-        assertThat(cond.value()).isNull();
         assertThat(cond.isEmpty()).isFalse();
     }
 
@@ -308,13 +243,6 @@ class SupplierTest {
     }
 
     @Test
-    void testIsNotLikeNull() {
-        IsNotLike<String> cond = SqlBuilder.isNotLike(() -> null);
-        assertThat(cond.value()).isNull();
-        assertThat(cond.isEmpty()).isFalse();
-    }
-
-    @Test
     void testIsNotLikeWhenPresent() {
         IsNotLikeWhenPresent<String> cond = SqlBuilder.isNotLikeWhenPresent(() -> "%F%");
         assertThat(cond.value()).isEqualTo("%F%");
@@ -332,13 +260,6 @@ class SupplierTest {
     void testIsNotLikeCaseInsensitive() {
         IsNotLikeCaseInsensitive<String> cond = SqlBuilder.isNotLikeCaseInsensitive(() -> "%f%");
         assertThat(cond.value()).isEqualTo("%F%");
-        assertThat(cond.isEmpty()).isFalse();
-    }
-
-    @Test
-    void testIsNotLikeCaseInsensitiveNull() {
-        IsNotLikeCaseInsensitive<String> cond = SqlBuilder.isNotLikeCaseInsensitive(() -> null);
-        assertThat(cond.value()).isNull();
         assertThat(cond.isEmpty()).isFalse();
     }
 

--- a/src/test/java/org/mybatis/dynamic/sql/where/render/OptionalCriterionRenderTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/where/render/OptionalCriterionRenderTest.java
@@ -34,21 +34,7 @@ class OptionalCriterionRenderTest {
 
     @Test
     void testNoRenderableCriteria() {
-        Integer nullId = null;
-
-        Optional<WhereClauseProvider> whereClause = where(id, isEqualToWhenPresent(nullId))
-                .configureStatement(c -> c.setNonRenderingWhereClauseAllowed(true))
-                .build()
-                .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
-
-        assertThat(whereClause).isEmpty();
-    }
-
-    @Test
-    void testNoRenderableCriteriaWithIf() {
-        Integer nullId = null;
-
-        Optional<WhereClauseProvider> whereClause = where(id, isEqualToWhenPresent(nullId))
+        Optional<WhereClauseProvider> whereClause = where(id, isEqualToWhenPresent((Integer) null))
                 .configureStatement(c -> c.setNonRenderingWhereClauseAllowed(true))
                 .build()
                 .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
@@ -102,10 +88,8 @@ class OptionalCriterionRenderTest {
 
     @Test
     void testOneRenderableCriteriaBeforeNull() {
-        String nullFirstName = null;
-
         Optional<WhereClauseProvider> whereClause = where(id, isEqualToWhenPresent(22))
-                .and(firstName, isEqualToWhenPresent(nullFirstName))
+                .and(firstName, isEqualToWhenPresent((String) null))
                 .build()
                 .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
 
@@ -117,9 +101,7 @@ class OptionalCriterionRenderTest {
 
     @Test
     void testOneRenderableCriteriaBeforeNull2() {
-        String nullFirstName = null;
-
-        Optional<WhereClauseProvider> whereClause = where(id, isEqualToWhenPresent(22), and(firstName, isEqualToWhenPresent(nullFirstName)))
+        Optional<WhereClauseProvider> whereClause = where(id, isEqualToWhenPresent(22), and(firstName, isEqualToWhenPresent((String) null)))
                 .build()
                 .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
 
@@ -131,9 +113,7 @@ class OptionalCriterionRenderTest {
 
     @Test
     void testOneRenderableCriteriaAfterNull() {
-        Integer nullId = null;
-
-        Optional<WhereClauseProvider> whereClause = where(id, isEqualToWhenPresent(nullId))
+        Optional<WhereClauseProvider> whereClause = where(id, isEqualToWhenPresent((Integer) null))
                 .and(firstName, isEqualToWhenPresent("fred"))
                 .build()
                 .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
@@ -146,9 +126,7 @@ class OptionalCriterionRenderTest {
 
     @Test
     void testOneRenderableCriteriaAfterNull2() {
-        Integer nullId = null;
-
-        Optional<WhereClauseProvider> whereClause = where(id, isEqualToWhenPresent(nullId), and(firstName, isEqualToWhenPresent("fred")))
+        Optional<WhereClauseProvider> whereClause = where(id, isEqualToWhenPresent((Integer) null), and(firstName, isEqualToWhenPresent("fred")))
                 .build()
                 .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
 
@@ -160,9 +138,7 @@ class OptionalCriterionRenderTest {
 
     @Test
     void testOverrideFirstConnector() {
-        Integer nullId = null;
-
-        Optional<WhereClauseProvider> whereClause = where(id, isEqualToWhenPresent(nullId), and(firstName, isEqualToWhenPresent("fred")), or(lastName, isEqualTo("flintstone")))
+        Optional<WhereClauseProvider> whereClause = where(id, isEqualToWhenPresent((Integer) null), and(firstName, isEqualToWhenPresent("fred")), or(lastName, isEqualTo("flintstone")))
                 .build()
                 .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
 
@@ -305,10 +281,8 @@ class OptionalCriterionRenderTest {
 
     @Test
     void testCollapsingCriteriaGroup1() {
-        String name1 = null;
-
         Optional<WhereClauseProvider> whereClause = where(
-                group(firstName, isEqualToWhenPresent(name1)), or(lastName, isEqualToWhenPresent(name1)))
+                group(firstName, isEqualToWhenPresent((String) null)), or(lastName, isEqualToWhenPresent((String) null)))
                 .configureStatement(c -> c.setNonRenderingWhereClauseAllowed(true))
                 .build()
                 .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
@@ -318,10 +292,8 @@ class OptionalCriterionRenderTest {
 
     @Test
     void testCollapsingCriteriaGroup2() {
-        String name1 = null;
-
         Optional<WhereClauseProvider> whereClause = where(
-                group(firstName, isEqualTo("Fred")), or(lastName, isEqualToWhenPresent(name1)))
+                group(firstName, isEqualTo("Fred")), or(lastName, isEqualToWhenPresent((String) null)))
                 .build()
                 .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
 
@@ -335,10 +307,8 @@ class OptionalCriterionRenderTest {
 
     @Test
     void testCollapsingCriteriaGroup3() {
-        String name1 = null;
-
         Optional<WhereClauseProvider> whereClause = where(
-                group(firstName, isEqualTo("Fred")), or(lastName, isEqualToWhenPresent(name1)), or(firstName, isEqualTo("Betty")))
+                group(firstName, isEqualTo("Fred")), or(lastName, isEqualToWhenPresent((String) null)), or(firstName, isEqualTo("Betty")))
                 .build()
                 .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
 

--- a/src/test/java/org/mybatis/dynamic/sql/where/render/OptionalCriterionRenderTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/where/render/OptionalCriterionRenderTest.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.mybatis.dynamic.sql.SqlBuilder.*;
 
-import java.util.Objects;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
@@ -49,7 +48,7 @@ class OptionalCriterionRenderTest {
     void testNoRenderableCriteriaWithIf() {
         Integer nullId = null;
 
-        Optional<WhereClauseProvider> whereClause = where(id, isEqualTo(nullId).filter(Objects::nonNull))
+        Optional<WhereClauseProvider> whereClause = where(id, isEqualToWhenPresent(nullId))
                 .configureStatement(c -> c.setNonRenderingWhereClauseAllowed(true))
                 .build()
                 .render(RenderingStrategies.SPRING_NAMED_PARAMETER);

--- a/src/test/kotlin/examples/kotlin/mybatis3/mariadb/KIsLikeEscape.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/mariadb/KIsLikeEscape.kt
@@ -1,3 +1,18 @@
+/*
+ *    Copyright 2016-2025 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package examples.kotlin.mybatis3.mariadb
 
 import java.util.function.Predicate


### PR DESCRIPTION
The "filter" and "map" methods on conditions now explicitly specify whether they expect null values or not.

We now implement the "when present" conditions as specific classes so that they will function properly even if a "map" method results in a null. Previously it was possible to "sneak" a null value into a "when present" condition.