### PR TITLE
Add Ability to configure a mapped Java property in an SqlColumn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,8 @@ Runtime behavior changes:
   are not supported by the library out of the box. The statement renderers now call methods `renderCondition` and
   `renderLeftColumn` that you can override to implement any rendering you need. In addition, we've made `filter` and
   `map` support optional if you implement custom conditions
+- Added support for configuring a Java property name to be associated with an `SqlColumn`. This property name can be
+  used with the record based insert methods to reduce the boilerplate code for mapping columns to Java properties.
 
 ## Release 1.5.2 - June 3, 2024
 

--- a/src/main/java/org/mybatis/dynamic/sql/SqlColumn.java
+++ b/src/main/java/org/mybatis/dynamic/sql/SqlColumn.java
@@ -37,6 +37,7 @@ public class SqlColumn<T> implements BindableColumn<T>, SortSpecification {
     protected final ParameterTypeConverter<T, ?> parameterTypeConverter;
     protected final @Nullable String tableQualifier;
     protected final @Nullable Class<T> javaType;
+    protected final @Nullable String javaProperty;
 
     private SqlColumn(Builder<T> builder) {
         name = Objects.requireNonNull(builder.name);
@@ -49,6 +50,7 @@ public class SqlColumn<T> implements BindableColumn<T>, SortSpecification {
         parameterTypeConverter = Objects.requireNonNull(builder.parameterTypeConverter);
         tableQualifier = builder.tableQualifier;
         javaType = builder.javaType;
+        javaProperty = builder.javaProperty;
     }
 
     public String name() {
@@ -77,6 +79,10 @@ public class SqlColumn<T> implements BindableColumn<T>, SortSpecification {
     @Override
     public Optional<Class<T>> javaType() {
         return Optional.ofNullable(javaType);
+    }
+
+    public Optional<String> javaProperty() {
+        return Optional.ofNullable(javaProperty);
     }
 
     @Override
@@ -164,6 +170,11 @@ public class SqlColumn<T> implements BindableColumn<T>, SortSpecification {
         return b.withJavaType(javaType).build();
     }
 
+    public <S> SqlColumn<S> withJavaProperty(String javaProperty) {
+        Builder<S> b = copy();
+        return b.withJavaProperty(javaProperty).build();
+    }
+
     /**
      * This method helps us tell a bit of fiction to the Java compiler. Java, for better or worse,
      * does not carry generic type information through chained methods. We want to enable method
@@ -185,7 +196,8 @@ public class SqlColumn<T> implements BindableColumn<T>, SortSpecification {
                 .withRenderingStrategy(this.renderingStrategy)
                 .withParameterTypeConverter((ParameterTypeConverter<S, ?>) this.parameterTypeConverter)
                 .withTableQualifier(this.tableQualifier)
-                .withJavaType((Class<S>) this.javaType);
+                .withJavaType((Class<S>) this.javaType)
+                .withJavaProperty(this.javaProperty);
     }
 
     public static <T> SqlColumn<T> of(String name, SqlTable table) {
@@ -212,6 +224,7 @@ public class SqlColumn<T> implements BindableColumn<T>, SortSpecification {
         protected ParameterTypeConverter<T, ?> parameterTypeConverter = v -> v;
         protected @Nullable String tableQualifier;
         protected @Nullable Class<T> javaType;
+        protected @Nullable String javaProperty;
 
         public Builder<T> withName(String name) {
             this.name = name;
@@ -260,6 +273,11 @@ public class SqlColumn<T> implements BindableColumn<T>, SortSpecification {
 
         public Builder<T> withJavaType(@Nullable Class<T> javaType) {
             this.javaType = javaType;
+            return this;
+        }
+
+        public Builder<T> withJavaProperty(@Nullable String javaProperty) {
+            this.javaProperty = javaProperty;
             return this;
         }
 

--- a/src/main/java/org/mybatis/dynamic/sql/insert/BatchInsertDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/BatchInsertDSL.java
@@ -27,6 +27,7 @@ import org.mybatis.dynamic.sql.SqlTable;
 import org.mybatis.dynamic.sql.util.AbstractColumnMapping;
 import org.mybatis.dynamic.sql.util.Buildable;
 import org.mybatis.dynamic.sql.util.ConstantMapping;
+import org.mybatis.dynamic.sql.util.MappedColumnMapping;
 import org.mybatis.dynamic.sql.util.NullMapping;
 import org.mybatis.dynamic.sql.util.PropertyMapping;
 import org.mybatis.dynamic.sql.util.RowMapping;
@@ -46,6 +47,11 @@ public class BatchInsertDSL<T> implements Buildable<BatchInsertModel<T>> {
 
     public <F> ColumnMappingFinisher<F> map(SqlColumn<F> column) {
         return new ColumnMappingFinisher<>(column);
+    }
+
+    public <F> BatchInsertDSL<T> withMappedColumn(SqlColumn<F> column) {
+        columnMappings.add(MappedColumnMapping.of(column));
+        return this;
     }
 
     @Override

--- a/src/main/java/org/mybatis/dynamic/sql/insert/InsertDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/InsertDSL.java
@@ -27,6 +27,8 @@ import org.mybatis.dynamic.sql.SqlTable;
 import org.mybatis.dynamic.sql.util.AbstractColumnMapping;
 import org.mybatis.dynamic.sql.util.Buildable;
 import org.mybatis.dynamic.sql.util.ConstantMapping;
+import org.mybatis.dynamic.sql.util.MappedColumnMapping;
+import org.mybatis.dynamic.sql.util.MappedColumnWhenPresentMapping;
 import org.mybatis.dynamic.sql.util.NullMapping;
 import org.mybatis.dynamic.sql.util.PropertyMapping;
 import org.mybatis.dynamic.sql.util.PropertyWhenPresentMapping;
@@ -47,6 +49,16 @@ public class InsertDSL<T> implements Buildable<InsertModel<T>> {
 
     public <F> ColumnMappingFinisher<F> map(SqlColumn<F> column) {
         return new ColumnMappingFinisher<>(column);
+    }
+
+    public <F> InsertDSL<T> withMappedColumn(SqlColumn<F> column) {
+        columnMappings.add(MappedColumnMapping.of(column));
+        return this;
+    }
+
+    public <F> InsertDSL<T> withMappedColumnWhenPresent(SqlColumn<F> column, Supplier<?> valueSupplier) {
+        columnMappings.add(MappedColumnWhenPresentMapping.of(column, valueSupplier));
+        return this;
     }
 
     @Override

--- a/src/main/java/org/mybatis/dynamic/sql/insert/MultiRowInsertDSL.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/MultiRowInsertDSL.java
@@ -25,6 +25,7 @@ import org.mybatis.dynamic.sql.SqlTable;
 import org.mybatis.dynamic.sql.util.AbstractColumnMapping;
 import org.mybatis.dynamic.sql.util.Buildable;
 import org.mybatis.dynamic.sql.util.ConstantMapping;
+import org.mybatis.dynamic.sql.util.MappedColumnMapping;
 import org.mybatis.dynamic.sql.util.NullMapping;
 import org.mybatis.dynamic.sql.util.PropertyMapping;
 import org.mybatis.dynamic.sql.util.RowMapping;
@@ -44,6 +45,11 @@ public class MultiRowInsertDSL<T> implements Buildable<MultiRowInsertModel<T>> {
 
     public <F> ColumnMappingFinisher<F> map(SqlColumn<F> column) {
         return new ColumnMappingFinisher<>(column);
+    }
+
+    public <F> MultiRowInsertDSL<T> withMappedColumn(SqlColumn<F> column) {
+        columnMappings.add(MappedColumnMapping.of(column));
+        return this;
     }
 
     @Override

--- a/src/main/java/org/mybatis/dynamic/sql/insert/render/InsertRenderingUtilities.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/render/InsertRenderingUtilities.java
@@ -17,7 +17,10 @@ package org.mybatis.dynamic.sql.insert.render;
 
 import static org.mybatis.dynamic.sql.util.StringUtilities.spaceBefore;
 
+import org.mybatis.dynamic.sql.SqlColumn;
 import org.mybatis.dynamic.sql.SqlTable;
+import org.mybatis.dynamic.sql.exception.InvalidSqlException;
+import org.mybatis.dynamic.sql.util.Messages;
 
 public class InsertRenderingUtilities {
     private InsertRenderingUtilities() {}
@@ -32,5 +35,11 @@ public class InsertRenderingUtilities {
 
     public static String calculateInsertStatementStart(SqlTable table) {
         return "insert into " + table.tableName(); //$NON-NLS-1$
+    }
+
+    public static String getMappedPropertyName(SqlColumn<?> column) {
+        return column.javaProperty().orElseThrow(() ->
+                new InvalidSqlException(Messages
+                        .getString("ERROR.50", column.name()))); //$NON-NLS-1$
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/insert/render/MultiRowValuePhraseVisitor.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/render/MultiRowValuePhraseVisitor.java
@@ -16,11 +16,9 @@
 package org.mybatis.dynamic.sql.insert.render;
 
 import org.mybatis.dynamic.sql.SqlColumn;
-import org.mybatis.dynamic.sql.exception.InvalidSqlException;
 import org.mybatis.dynamic.sql.render.RenderingStrategy;
 import org.mybatis.dynamic.sql.util.ConstantMapping;
 import org.mybatis.dynamic.sql.util.MappedColumnMapping;
-import org.mybatis.dynamic.sql.util.Messages;
 import org.mybatis.dynamic.sql.util.MultiRowInsertMappingVisitor;
 import org.mybatis.dynamic.sql.util.NullMapping;
 import org.mybatis.dynamic.sql.util.PropertyMapping;
@@ -77,15 +75,9 @@ public class MultiRowValuePhraseVisitor extends MultiRowInsertMappingVisitor<Fie
         return FieldAndValueAndParameters.withFieldName(mapping.columnName())
                 .withValuePhrase(calculateJdbcPlaceholder(
                         mapping.column(),
-                        getMappedPropertyName(mapping.column()))
+                        InsertRenderingUtilities.getMappedPropertyName(mapping.column()))
                 )
                 .build();
-    }
-
-    private String getMappedPropertyName(SqlColumn<?> column) {
-        return column.javaProperty().orElseThrow(() ->
-                new InvalidSqlException(Messages
-                        .getString("ERROR.50", column.name()))); //$NON-NLS-1$
     }
 
     private String calculateJdbcPlaceholder(SqlColumn<?> column) {

--- a/src/main/java/org/mybatis/dynamic/sql/insert/render/MultiRowValuePhraseVisitor.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/render/MultiRowValuePhraseVisitor.java
@@ -16,8 +16,11 @@
 package org.mybatis.dynamic.sql.insert.render;
 
 import org.mybatis.dynamic.sql.SqlColumn;
+import org.mybatis.dynamic.sql.exception.InvalidSqlException;
 import org.mybatis.dynamic.sql.render.RenderingStrategy;
 import org.mybatis.dynamic.sql.util.ConstantMapping;
+import org.mybatis.dynamic.sql.util.MappedColumnMapping;
+import org.mybatis.dynamic.sql.util.Messages;
 import org.mybatis.dynamic.sql.util.MultiRowInsertMappingVisitor;
 import org.mybatis.dynamic.sql.util.NullMapping;
 import org.mybatis.dynamic.sql.util.PropertyMapping;
@@ -67,6 +70,22 @@ public class MultiRowValuePhraseVisitor extends MultiRowInsertMappingVisitor<Fie
         return FieldAndValueAndParameters.withFieldName(mapping.columnName())
                 .withValuePhrase(calculateJdbcPlaceholder(mapping.column()))
                 .build();
+    }
+
+    @Override
+    public FieldAndValueAndParameters visit(MappedColumnMapping mapping) {
+        return FieldAndValueAndParameters.withFieldName(mapping.columnName())
+                .withValuePhrase(calculateJdbcPlaceholder(
+                        mapping.column(),
+                        getMappedPropertyName(mapping.column()))
+                )
+                .build();
+    }
+
+    private String getMappedPropertyName(SqlColumn<?> column) {
+        return column.javaProperty().orElseThrow(() ->
+                new InvalidSqlException(Messages
+                        .getString("ERROR.50", column.name()))); //$NON-NLS-1$
     }
 
     private String calculateJdbcPlaceholder(SqlColumn<?> column) {

--- a/src/main/java/org/mybatis/dynamic/sql/insert/render/ValuePhraseVisitor.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/render/ValuePhraseVisitor.java
@@ -18,9 +18,13 @@ package org.mybatis.dynamic.sql.insert.render;
 import java.util.Optional;
 
 import org.mybatis.dynamic.sql.SqlColumn;
+import org.mybatis.dynamic.sql.exception.InvalidSqlException;
 import org.mybatis.dynamic.sql.render.RenderingStrategy;
 import org.mybatis.dynamic.sql.util.ConstantMapping;
 import org.mybatis.dynamic.sql.util.InsertMappingVisitor;
+import org.mybatis.dynamic.sql.util.MappedColumnMapping;
+import org.mybatis.dynamic.sql.util.MappedColumnWhenPresentMapping;
+import org.mybatis.dynamic.sql.util.Messages;
 import org.mybatis.dynamic.sql.util.NullMapping;
 import org.mybatis.dynamic.sql.util.PropertyMapping;
 import org.mybatis.dynamic.sql.util.PropertyWhenPresentMapping;
@@ -78,6 +82,31 @@ public class ValuePhraseVisitor extends InsertMappingVisitor<Optional<FieldAndVa
         return FieldAndValueAndParameters.withFieldName(mapping.columnName())
                 .withValuePhrase(calculateJdbcPlaceholder(mapping.column()))
                 .buildOptional();
+    }
+
+    @Override
+    public Optional<FieldAndValueAndParameters> visit(MappedColumnMapping mapping) {
+        return FieldAndValueAndParameters.withFieldName(mapping.columnName())
+                .withValuePhrase(calculateJdbcPlaceholder(
+                        mapping.column(),
+                        getMappedPropertyName(mapping.column()))
+                )
+                .buildOptional();
+    }
+
+    @Override
+    public Optional<FieldAndValueAndParameters> visit(MappedColumnWhenPresentMapping mapping) {
+        if (mapping.shouldRender()) {
+            return visit((MappedColumnMapping) mapping);
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    private String getMappedPropertyName(SqlColumn<?> column) {
+        return column.javaProperty().orElseThrow(() ->
+                new InvalidSqlException(Messages
+                        .getString("ERROR.50", column.name()))); //$NON-NLS-1$
     }
 
     private String calculateJdbcPlaceholder(SqlColumn<?> column) {

--- a/src/main/java/org/mybatis/dynamic/sql/insert/render/ValuePhraseVisitor.java
+++ b/src/main/java/org/mybatis/dynamic/sql/insert/render/ValuePhraseVisitor.java
@@ -18,13 +18,11 @@ package org.mybatis.dynamic.sql.insert.render;
 import java.util.Optional;
 
 import org.mybatis.dynamic.sql.SqlColumn;
-import org.mybatis.dynamic.sql.exception.InvalidSqlException;
 import org.mybatis.dynamic.sql.render.RenderingStrategy;
 import org.mybatis.dynamic.sql.util.ConstantMapping;
 import org.mybatis.dynamic.sql.util.InsertMappingVisitor;
 import org.mybatis.dynamic.sql.util.MappedColumnMapping;
 import org.mybatis.dynamic.sql.util.MappedColumnWhenPresentMapping;
-import org.mybatis.dynamic.sql.util.Messages;
 import org.mybatis.dynamic.sql.util.NullMapping;
 import org.mybatis.dynamic.sql.util.PropertyMapping;
 import org.mybatis.dynamic.sql.util.PropertyWhenPresentMapping;
@@ -89,7 +87,7 @@ public class ValuePhraseVisitor extends InsertMappingVisitor<Optional<FieldAndVa
         return FieldAndValueAndParameters.withFieldName(mapping.columnName())
                 .withValuePhrase(calculateJdbcPlaceholder(
                         mapping.column(),
-                        getMappedPropertyName(mapping.column()))
+                        InsertRenderingUtilities.getMappedPropertyName(mapping.column()))
                 )
                 .buildOptional();
     }
@@ -101,12 +99,6 @@ public class ValuePhraseVisitor extends InsertMappingVisitor<Optional<FieldAndVa
         } else {
             return Optional.empty();
         }
-    }
-
-    private String getMappedPropertyName(SqlColumn<?> column) {
-        return column.javaProperty().orElseThrow(() ->
-                new InvalidSqlException(Messages
-                        .getString("ERROR.50", column.name()))); //$NON-NLS-1$
     }
 
     private String calculateJdbcPlaceholder(SqlColumn<?> column) {

--- a/src/main/java/org/mybatis/dynamic/sql/util/ColumnMappingVisitor.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/ColumnMappingVisitor.java
@@ -52,4 +52,8 @@ public interface ColumnMappingVisitor<R> {
     R visit(ColumnToColumnMapping mapping);
 
     R visit(RowMapping mapping);
+
+    R visit(MappedColumnMapping mapping);
+
+    R visit(MappedColumnWhenPresentMapping mapping);
 }

--- a/src/main/java/org/mybatis/dynamic/sql/util/GeneralInsertMappingVisitor.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/GeneralInsertMappingVisitor.java
@@ -40,4 +40,14 @@ public abstract class GeneralInsertMappingVisitor<R> implements ColumnMappingVis
     public final R visit(RowMapping mapping) {
         throw new UnsupportedOperationException(Messages.getInternalErrorString(InternalError.INTERNAL_ERROR_14));
     }
+
+    @Override
+    public R visit(MappedColumnMapping mapping) {
+        throw new UnsupportedOperationException(Messages.getInternalErrorString(InternalError.INTERNAL_ERROR_16));
+    }
+
+    @Override
+    public R visit(MappedColumnWhenPresentMapping mapping) {
+        throw new UnsupportedOperationException(Messages.getInternalErrorString(InternalError.INTERNAL_ERROR_17));
+    }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/util/InternalError.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/InternalError.java
@@ -33,7 +33,12 @@ public enum InternalError {
     INTERNAL_ERROR_12(12),
     INTERNAL_ERROR_13(13),
     INTERNAL_ERROR_14(14),
-    INTERNAL_ERROR_15(15);
+    INTERNAL_ERROR_15(15),
+    INTERNAL_ERROR_16(16),
+    INTERNAL_ERROR_17(17),
+    INTERNAL_ERROR_18(18),
+    INTERNAL_ERROR_19(19),
+    INTERNAL_ERROR_20(20);
 
     private final int number;
 

--- a/src/main/java/org/mybatis/dynamic/sql/util/MappedColumnMapping.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/MappedColumnMapping.java
@@ -15,14 +15,20 @@
  */
 package org.mybatis.dynamic.sql.util;
 
-public abstract class MultiRowInsertMappingVisitor<R> extends InsertMappingVisitor<R> {
-    @Override
-    public final R visit(PropertyWhenPresentMapping mapping) {
-        throw new UnsupportedOperationException(Messages.getInternalErrorString(InternalError.INTERNAL_ERROR_12));
+import org.mybatis.dynamic.sql.SqlColumn;
+
+public class MappedColumnMapping extends AbstractColumnMapping {
+
+    protected MappedColumnMapping(SqlColumn<?> column) {
+        super(column);
     }
 
     @Override
-    public R visit(MappedColumnWhenPresentMapping mapping) {
-        throw new UnsupportedOperationException(Messages.getInternalErrorString(InternalError.INTERNAL_ERROR_18));
+    public <R> R accept(ColumnMappingVisitor<R> visitor) {
+        return visitor.visit(this);
+    }
+
+    public static MappedColumnMapping of(SqlColumn<?> column) {
+        return new MappedColumnMapping(column);
     }
 }

--- a/src/main/java/org/mybatis/dynamic/sql/util/MappedColumnWhenPresentMapping.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/MappedColumnWhenPresentMapping.java
@@ -1,0 +1,43 @@
+/*
+ *    Copyright 2016-2025 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.dynamic.sql.util;
+
+import org.mybatis.dynamic.sql.SqlColumn;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+
+public class MappedColumnWhenPresentMapping extends MappedColumnMapping {
+    private final Supplier<?> valueSupplier;
+
+    private MappedColumnWhenPresentMapping(SqlColumn<?> column, Supplier<?> valueSupplier) {
+        super(column);
+        this.valueSupplier = Objects.requireNonNull(valueSupplier);
+    }
+
+    public boolean shouldRender() {
+        return valueSupplier.get() != null;
+    }
+
+    @Override
+    public <R> R accept(ColumnMappingVisitor<R> visitor) {
+        return visitor.visit(this);
+    }
+
+    public static MappedColumnWhenPresentMapping of(SqlColumn<?> column, Supplier<?> valueSupplier) {
+        return new MappedColumnWhenPresentMapping(column, valueSupplier);
+    }
+}

--- a/src/main/java/org/mybatis/dynamic/sql/util/MappedColumnWhenPresentMapping.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/MappedColumnWhenPresentMapping.java
@@ -15,10 +15,10 @@
  */
 package org.mybatis.dynamic.sql.util;
 
-import org.mybatis.dynamic.sql.SqlColumn;
-
 import java.util.Objects;
 import java.util.function.Supplier;
+
+import org.mybatis.dynamic.sql.SqlColumn;
 
 public class MappedColumnWhenPresentMapping extends MappedColumnMapping {
     private final Supplier<?> valueSupplier;

--- a/src/main/java/org/mybatis/dynamic/sql/util/UpdateMappingVisitor.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/UpdateMappingVisitor.java
@@ -30,4 +30,14 @@ public abstract class UpdateMappingVisitor<R> implements ColumnMappingVisitor<R>
     public final R visit(RowMapping mapping) {
         throw new UnsupportedOperationException(Messages.getInternalErrorString(InternalError.INTERNAL_ERROR_15));
     }
+
+    @Override
+    public R visit(MappedColumnMapping mapping) {
+        throw new UnsupportedOperationException(Messages.getInternalErrorString(InternalError.INTERNAL_ERROR_19));
+    }
+
+    @Override
+    public R visit(MappedColumnWhenPresentMapping mapping) {
+        throw new UnsupportedOperationException(Messages.getInternalErrorString(InternalError.INTERNAL_ERROR_20));
+    }
 }

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinBatchInsertBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinBatchInsertBuilder.kt
@@ -21,6 +21,7 @@ import org.mybatis.dynamic.sql.insert.BatchInsertDSL
 import org.mybatis.dynamic.sql.insert.BatchInsertModel
 import org.mybatis.dynamic.sql.util.AbstractColumnMapping
 import org.mybatis.dynamic.sql.util.Buildable
+import org.mybatis.dynamic.sql.util.MappedColumnMapping
 
 typealias KotlinBatchInsertCompleter<T> = KotlinBatchInsertBuilder<T>.() -> Unit
 
@@ -35,6 +36,10 @@ class KotlinBatchInsertBuilder<T : Any> (private val rows: Collection<T>): Build
 
     fun <C : Any> map(column: SqlColumn<C>) = MultiRowInsertColumnMapCompleter(column) {
         columnMappings.add(it)
+    }
+
+    fun <C : Any> withMappedColumn(column: SqlColumn<C>) {
+        columnMappings.add(MappedColumnMapping.of(column))
     }
 
     override fun build(): BatchInsertModel<T> {

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinInsertBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinInsertBuilder.kt
@@ -21,6 +21,8 @@ import org.mybatis.dynamic.sql.insert.InsertDSL
 import org.mybatis.dynamic.sql.insert.InsertModel
 import org.mybatis.dynamic.sql.util.AbstractColumnMapping
 import org.mybatis.dynamic.sql.util.Buildable
+import org.mybatis.dynamic.sql.util.MappedColumnMapping
+import org.mybatis.dynamic.sql.util.MappedColumnWhenPresentMapping
 
 typealias KotlinInsertCompleter<T> = KotlinInsertBuilder<T>.() -> Unit
 
@@ -35,6 +37,14 @@ class KotlinInsertBuilder<T : Any> (private val row: T): Buildable<InsertModel<T
 
     fun <C : Any> map(column: SqlColumn<C>) = SingleRowInsertColumnMapCompleter(column) {
         columnMappings.add(it)
+    }
+
+    fun <C : Any> withMappedColumn(column: SqlColumn<C>) {
+        columnMappings.add(MappedColumnMapping.of(column))
+    }
+
+    fun <C : Any> withMappedColumnWhenPresent(column: SqlColumn<C>, valueSupplier: () -> Any?) {
+        columnMappings.add(MappedColumnWhenPresentMapping.of(column, valueSupplier))
     }
 
     override fun build(): InsertModel<T> {

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinMultiRowInsertBuilder.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/KotlinMultiRowInsertBuilder.kt
@@ -21,6 +21,7 @@ import org.mybatis.dynamic.sql.insert.MultiRowInsertDSL
 import org.mybatis.dynamic.sql.insert.MultiRowInsertModel
 import org.mybatis.dynamic.sql.util.AbstractColumnMapping
 import org.mybatis.dynamic.sql.util.Buildable
+import org.mybatis.dynamic.sql.util.MappedColumnMapping
 
 typealias KotlinMultiRowInsertCompleter<T> = KotlinMultiRowInsertBuilder<T>.() -> Unit
 
@@ -35,6 +36,10 @@ class KotlinMultiRowInsertBuilder<T : Any> (private val rows: Collection<T>): Bu
 
     fun <C : Any> map(column: SqlColumn<C>) = MultiRowInsertColumnMapCompleter(column) {
         columnMappings.add(it)
+    }
+
+    fun <C : Any> withMappedColumn(column: SqlColumn<C>) {
+        columnMappings.add(MappedColumnMapping.of(column))
     }
 
     override fun build(): MultiRowInsertModel<T> {

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/elements/SqlTableExtensions.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/elements/SqlTableExtensions.kt
@@ -34,7 +34,8 @@ fun <T : Any> SqlTable.column(
     typeHandler: String? = null,
     renderingStrategy: RenderingStrategy? = null,
     parameterTypeConverter: ((T?) -> Any?) = { it },
-    javaType: KClass<T>? = null
+    javaType: KClass<T>? = null,
+    javaProperty: String? = null,
 ): SqlColumn<T> = SqlColumn.Builder<T>().run {
     withTable(this@column)
     withName(name)
@@ -43,5 +44,6 @@ fun <T : Any> SqlTable.column(
     withRenderingStrategy(renderingStrategy)
     withParameterTypeConverter(parameterTypeConverter)
     withJavaType(javaType?.java)
+    withJavaProperty(javaProperty)
     build()
 }

--- a/src/main/resources/org/mybatis/dynamic/sql/util/messages.properties
+++ b/src/main/resources/org/mybatis/dynamic/sql/util/messages.properties
@@ -67,4 +67,5 @@ ERROR.47=A Kotlin case statement must specify a "then" clause for every "when" c
 ERROR.48=You cannot call more than one of "forUpdate", "forNoKeyUpdate", "forShare", or "forKeyShare" in a select \
   statement
 ERROR.49=You cannot call more than one of "skipLocked", or "nowait" in a select statement
+ERROR.50=Mapped column {0} does not have a javaProperty configured
 INTERNAL.ERROR=Internal Error {0}

--- a/src/test/java/examples/generated/always/spring/GeneratedAlwaysDynamicSqlSupport.java
+++ b/src/test/java/examples/generated/always/spring/GeneratedAlwaysDynamicSqlSupport.java
@@ -26,10 +26,10 @@ public final class GeneratedAlwaysDynamicSqlSupport {
     public static final SqlColumn<String> fullName = generatedAlways.fullName;
 
     public static final class GeneratedAlways extends SqlTable {
-        public final SqlColumn<Integer> id = column("id");
-        public final SqlColumn<String> firstName = column("first_name");
-        public final SqlColumn<String> lastName = column("last_name");
-        public final SqlColumn<String> fullName = column("full_name");
+        public final SqlColumn<Integer> id = column("id").withJavaProperty("id");
+        public final SqlColumn<String> firstName = column("first_name").withJavaProperty("firstName");
+        public final SqlColumn<String> lastName = column("last_name").withJavaProperty("lastName");
+        public final SqlColumn<String> fullName = column("full_name").withJavaProperty("fullName");
 
         public GeneratedAlways() {
             super("GeneratedAlways");

--- a/src/test/java/examples/generated/always/spring/SpringTest.java
+++ b/src/test/java/examples/generated/always/spring/SpringTest.java
@@ -241,9 +241,9 @@ class SpringTest {
 
         BatchInsert<GeneratedAlwaysRecord> batchInsert = insertBatch(records)
                 .into(generatedAlways)
-                .map(id).toProperty("id")
-                .map(firstName).toProperty("firstName")
-                .map(lastName).toProperty("lastName")
+                .withMappedColumn(id)
+                .withMappedColumn(firstName)
+                .withMappedColumn(lastName)
                 .build()
                 .render(RenderingStrategies.SPRING_NAMED_PARAMETER);
 

--- a/src/test/java/examples/simple/PersonDynamicSqlSupport.java
+++ b/src/test/java/examples/simple/PersonDynamicSqlSupport.java
@@ -32,13 +32,21 @@ public final class PersonDynamicSqlSupport {
     public static final SqlColumn<Integer> addressId = person.addressId;
 
     public static final class Person extends SqlTable {
-        public final SqlColumn<Integer> id = column("id", JDBCType.INTEGER);
-        public final SqlColumn<String> firstName = column("first_name", JDBCType.VARCHAR);
-        public final SqlColumn<LastName> lastName = column("last_name", JDBCType.VARCHAR, "examples.simple.LastNameTypeHandler");
-        public final SqlColumn<Date> birthDate = column("birth_date", JDBCType.DATE);
-        public final SqlColumn<Boolean> employed = column("employed", JDBCType.VARCHAR, "examples.simple.YesNoTypeHandler");
-        public final SqlColumn<String> occupation = column("occupation", JDBCType.VARCHAR);
-        public final SqlColumn<Integer> addressId = column("address_id", JDBCType.INTEGER);
+        public final SqlColumn<Integer> id = column("id", JDBCType.INTEGER).withJavaProperty("id");
+        public final SqlColumn<String> firstName = column("first_name", JDBCType.VARCHAR)
+                .withJavaProperty("firstName");
+        public final SqlColumn<LastName> lastName =
+                column("last_name", JDBCType.VARCHAR, "examples.simple.LastNameTypeHandler")
+                        .withJavaProperty("lastName");
+        public final SqlColumn<Date> birthDate = column("birth_date", JDBCType.DATE)
+                .withJavaProperty("birthDate");
+        public final SqlColumn<Boolean> employed =
+                column("employed", JDBCType.VARCHAR, "examples.simple.YesNoTypeHandler")
+                        .withJavaProperty("employed");
+        public final SqlColumn<String> occupation = column("occupation", JDBCType.VARCHAR)
+                .withJavaProperty("occupation");
+        public final SqlColumn<Integer> addressId = column("address_id", JDBCType.INTEGER)
+                .withJavaProperty("addressId");
 
         public Person() {
             super("Person");

--- a/src/test/java/examples/simple/PersonMapper.java
+++ b/src/test/java/examples/simple/PersonMapper.java
@@ -106,13 +106,13 @@ public interface PersonMapper extends CommonCountMapper, CommonDeleteMapper, Com
 
     default int insert(PersonRecord row) {
         return MyBatis3Utils.insert(this::insert, row, person, c ->
-            c.map(id).toProperty("id")
-            .map(firstName).toProperty("firstName")
-            .map(lastName).toProperty("lastName")
-            .map(birthDate).toProperty("birthDate")
-            .map(employed).toProperty("employed")
-            .map(occupation).toProperty("occupation")
-            .map(addressId).toProperty("addressId")
+            c.withMappedColumn(id)
+            .withMappedColumn(firstName)
+            .withMappedColumn(lastName)
+            .withMappedColumn(birthDate)
+            .withMappedColumn(employed)
+            .withMappedColumn(occupation)
+            .withMappedColumn(addressId)
         );
     }
 
@@ -122,25 +122,25 @@ public interface PersonMapper extends CommonCountMapper, CommonDeleteMapper, Com
 
     default int insertMultiple(Collection<PersonRecord> records) {
         return MyBatis3Utils.insertMultiple(this::insertMultiple, records, person, c ->
-            c.map(id).toProperty("id")
-            .map(firstName).toProperty("firstName")
-            .map(lastName).toProperty("lastName")
-            .map(birthDate).toProperty("birthDate")
-            .map(employed).toProperty("employed")
-            .map(occupation).toProperty("occupation")
-            .map(addressId).toProperty("addressId")
+            c.withMappedColumn(id)
+            .withMappedColumn(firstName)
+            .withMappedColumn(lastName)
+            .withMappedColumn(birthDate)
+            .withMappedColumn(employed)
+            .withMappedColumn(occupation)
+            .withMappedColumn(addressId)
         );
     }
 
     default int insertSelective(PersonRecord row) {
         return MyBatis3Utils.insert(this::insert, row, person, c ->
-            c.map(id).toPropertyWhenPresent("id", row::id)
-            .map(firstName).toPropertyWhenPresent("firstName", row::firstName)
-            .map(lastName).toPropertyWhenPresent("lastName", row::lastName)
-            .map(birthDate).toPropertyWhenPresent("birthDate", row::birthDate)
-            .map(employed).toPropertyWhenPresent("employed", row::employed)
-            .map(occupation).toPropertyWhenPresent("occupation", row::occupation)
-            .map(addressId).toPropertyWhenPresent("addressId", row::addressId)
+            c.withMappedColumnWhenPresent(id, row::id)
+            .withMappedColumnWhenPresent(firstName, row::firstName)
+            .withMappedColumnWhenPresent(lastName, row::lastName)
+            .withMappedColumnWhenPresent(birthDate, row::birthDate)
+            .withMappedColumnWhenPresent(employed, row::employed)
+            .withMappedColumnWhenPresent(occupation, row::occupation)
+            .withMappedColumnWhenPresent(addressId, row::addressId)
         );
     }
 

--- a/src/test/java/examples/simple/PersonMapperTest.java
+++ b/src/test/java/examples/simple/PersonMapperTest.java
@@ -53,6 +53,7 @@ import org.mybatis.dynamic.sql.delete.DeleteDSLCompleter;
 import org.mybatis.dynamic.sql.delete.render.DeleteStatementProvider;
 import org.mybatis.dynamic.sql.exception.NonRenderingWhereClauseException;
 import org.mybatis.dynamic.sql.insert.render.GeneralInsertStatementProvider;
+import org.mybatis.dynamic.sql.insert.render.InsertStatementProvider;
 import org.mybatis.dynamic.sql.render.RenderingStrategies;
 import org.mybatis.dynamic.sql.select.CountDSLCompleter;
 import org.mybatis.dynamic.sql.select.SelectDSLCompleter;
@@ -334,6 +335,27 @@ class PersonMapperTest {
             PersonRecord row = new PersonRecord(100, "Joe", new LastName("Jones"), new Date(), true, "Developer", 1);
 
             int rows = mapper.insert(row);
+            assertThat(rows).isEqualTo(1);
+        }
+    }
+
+    @Test
+    void testRawInsert() {
+        try (SqlSession session = sqlSessionFactory.openSession()) {
+            PersonMapper mapper = session.getMapper(PersonMapper.class);
+            PersonRecord row = new PersonRecord(100, "Joe", new LastName("Jones"), new Date(), true, "Developer", 1);
+
+            InsertStatementProvider<PersonRecord> insertStatement = insert(row).into(person)
+                    .withMappedColumn(id)
+                    .withMappedColumn(firstName)
+                    .withMappedColumn(lastName)
+                    .withMappedColumn(birthDate)
+                    .withMappedColumn(employed)
+                    .withMappedColumn(occupation)
+                    .withMappedColumn(addressId)
+                    .build().render(RenderingStrategies.MYBATIS3);
+
+            int rows = mapper.insert(insertStatement);
             assertThat(rows).isEqualTo(1);
         }
     }

--- a/src/test/java/examples/spring/PersonTemplateTest.java
+++ b/src/test/java/examples/spring/PersonTemplateTest.java
@@ -201,9 +201,8 @@ class PersonTemplateTest {
 
         List<PersonRecord> rows = template.selectList(selectStatement, personRowMapper);
 
-        assertThat(rows).hasSize(2);
-
-        assertThat(rows).satisfiesExactly(
+        assertThat(rows).hasSize(2)
+                .satisfiesExactly(
                 person1 -> assertThat(person1).isNotNull()
                         .extracting("lastName").isNotNull()
                         .extracting("name").isEqualTo("Flintstone"),

--- a/src/test/java/org/mybatis/dynamic/sql/insert/render/InsertVisitorsTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/insert/render/InsertVisitorsTest.java
@@ -1,0 +1,60 @@
+/*
+ *    Copyright 2016-2025 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.dynamic.sql.insert.render;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import org.junit.jupiter.api.Test;
+import org.mybatis.dynamic.sql.SqlColumn;
+import org.mybatis.dynamic.sql.SqlTable;
+import org.mybatis.dynamic.sql.exception.InvalidSqlException;
+import org.mybatis.dynamic.sql.render.RenderingStrategies;
+import org.mybatis.dynamic.sql.util.MappedColumnMapping;
+import org.mybatis.dynamic.sql.util.Messages;
+
+class InsertVisitorsTest {
+    @Test
+    void testThatMultiRowInsertVisitorErrorsForMappedColumnWhenPropertyIsMissing() {
+        TestTable table = new TestTable();
+        MultiRowValuePhraseVisitor tv = new MultiRowValuePhraseVisitor(RenderingStrategies.MYBATIS3, "prefix");
+        MappedColumnMapping mapping = MappedColumnMapping.of(table.id);
+
+        assertThatExceptionOfType(InvalidSqlException.class).isThrownBy(() -> tv.visit(mapping))
+                .withMessage(Messages.getString("ERROR.50", table.id.name()));
+    }
+
+    @Test
+    void testThatValuePhraseVisitorErrorsForMappedColumnWhenPropertyIsMissing() {
+        TestTable table = new TestTable();
+        ValuePhraseVisitor tv = new ValuePhraseVisitor(RenderingStrategies.MYBATIS3);
+        MappedColumnMapping mapping = MappedColumnMapping.of(table.id);
+
+        assertThatExceptionOfType(InvalidSqlException.class).isThrownBy(() -> tv.visit(mapping))
+                .withMessage(Messages.getString("ERROR.50", table.id.name()));
+    }
+
+    private static class TestTable extends SqlTable {
+        public final SqlColumn<Integer> id;
+        public final SqlColumn<String> description;
+
+        public TestTable() {
+            super("Test");
+
+            id = column("id");
+            description = column("description");
+        }
+    }
+}

--- a/src/test/java/org/mybatis/dynamic/sql/util/ColumnMappingVisitorTest.java
+++ b/src/test/java/org/mybatis/dynamic/sql/util/ColumnMappingVisitorTest.java
@@ -204,6 +204,56 @@ class ColumnMappingVisitorTest {
                 .withMessage("Internal Error 15");
     }
 
+    @Test
+    void testThatUpdateVisitorErrorsForMappedColumnMapping() {
+        TestTable table = new TestTable();
+        UpdateVisitor tv = new UpdateVisitor();
+        MappedColumnMapping mapping = MappedColumnMapping.of(table.id);
+
+        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> tv.visit(mapping))
+                .withMessage("Internal Error 19");
+    }
+
+    @Test
+    void testThatUpdateVisitorErrorsForMappedWhenPresentColumnMapping() {
+        TestTable table = new TestTable();
+        UpdateVisitor tv = new UpdateVisitor();
+        MappedColumnWhenPresentMapping mapping = MappedColumnWhenPresentMapping.of(table.id, () -> 1);
+
+        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> tv.visit(mapping))
+                .withMessage("Internal Error 20");
+    }
+
+    @Test
+    void testThatGeneralInsertVisitorErrorsForMappedColumnMapping() {
+        TestTable table = new TestTable();
+        GeneralInsertVisitor tv = new GeneralInsertVisitor();
+        MappedColumnMapping mapping = MappedColumnMapping.of(table.id);
+
+        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> tv.visit(mapping))
+                .withMessage("Internal Error 16");
+    }
+
+    @Test
+    void testThatGeneralInsertVisitorErrorsForMappedWhenPresentColumnMapping() {
+        TestTable table = new TestTable();
+        GeneralInsertVisitor tv = new GeneralInsertVisitor();
+        MappedColumnWhenPresentMapping mapping = MappedColumnWhenPresentMapping.of(table.id, () -> 1);
+
+        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> tv.visit(mapping))
+                .withMessage("Internal Error 17");
+    }
+
+    @Test
+    void testThatMultiRowInsertVisitorErrorsForMappedColumnWhenPresentMapping() {
+        TestTable table = new TestTable();
+        MultiRowInsertVisitor tv = new MultiRowInsertVisitor();
+        MappedColumnWhenPresentMapping mapping = MappedColumnWhenPresentMapping.of(table.id, () -> 1);
+
+        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> tv.visit(mapping))
+                .withMessage("Internal Error 18");
+    }
+
     private static class TestTable extends SqlTable {
         public final SqlColumn<Integer> id;
         public final SqlColumn<String> description;
@@ -278,6 +328,16 @@ class ColumnMappingVisitorTest {
         public String visit(RowMapping mapping) {
             return "Row Mapping";
         }
+
+        @Override
+        public String visit(MappedColumnMapping mapping) {
+            return "Mapped Column Mapping";
+        }
+
+        @Override
+        public String visit(MappedColumnWhenPresentMapping mapping) {
+            return "Mapped Column When Present Mapping";
+        }
     }
 
     private static class UpdateVisitor extends UpdateMappingVisitor<String> {
@@ -349,5 +409,9 @@ class ColumnMappingVisitorTest {
             return "Row Mapping";
         }
 
+        @Override
+        public String visit(MappedColumnMapping mapping) {
+            return "Mapped Column Mapping";
+        }
     }
 }

--- a/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonDynamicSqlSupport.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonDynamicSqlSupport.kt
@@ -31,20 +31,22 @@ object PersonDynamicSqlSupport {
     val addressId = person.addressId
 
     class Person : SqlTable("Person") {
-        val id = column<Int>(name = "id", jdbcType = JDBCType.INTEGER)
-        val firstName = column<String>(name = "first_name", jdbcType = JDBCType.VARCHAR)
+        val id = column<Int>(name = "id", jdbcType = JDBCType.INTEGER, javaProperty = "id")
+        val firstName = column<String>(name = "first_name", jdbcType = JDBCType.VARCHAR, javaProperty = "firstName")
         val lastName = column<LastName>(
             name = "last_name",
             jdbcType = JDBCType.VARCHAR,
-            typeHandler = "examples.kotlin.mybatis3.canonical.LastNameTypeHandler"
+            typeHandler = "examples.kotlin.mybatis3.canonical.LastNameTypeHandler",
+            javaProperty = "lastName"
         )
-        val birthDate = column<Date>(name = "birth_date", jdbcType = JDBCType.DATE)
+        val birthDate = column<Date>(name = "birth_date", jdbcType = JDBCType.DATE, javaProperty = "birthDate")
         val employed = column<Boolean>(
             name = "employed",
             JDBCType.VARCHAR,
-            typeHandler = "examples.kotlin.mybatis3.canonical.YesNoTypeHandler"
+            typeHandler = "examples.kotlin.mybatis3.canonical.YesNoTypeHandler",
+            javaProperty = "employed"
         )
-        val occupation = column<String>(name = "occupation", jdbcType = JDBCType.VARCHAR)
-        val addressId = column<Int>(name = "address_id", jdbcType = JDBCType.INTEGER)
+        val occupation = column<String>(name = "occupation", jdbcType = JDBCType.VARCHAR, javaProperty = "occupation")
+        val addressId = column<Int>(name = "address_id", jdbcType = JDBCType.INTEGER, javaProperty = "addressId")
     }
 }

--- a/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonMapperExtensions.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/canonical/PersonMapperExtensions.kt
@@ -65,13 +65,13 @@ fun PersonMapper.deleteByPrimaryKey(id_: Int) =
 
 fun PersonMapper.insert(record: PersonRecord) =
     insert(this::insert, record, person) {
-        map(id) toProperty "id"
-        map(firstName) toProperty "firstName"
-        map(lastName) toProperty "lastName"
-        map(birthDate) toProperty "birthDate"
-        map(employed) toProperty "employed"
-        map(occupation) toProperty "occupation"
-        map(addressId) toProperty "addressId"
+        withMappedColumn(id)
+        withMappedColumn(firstName)
+        withMappedColumn(lastName)
+        withMappedColumn(birthDate)
+        withMappedColumn(employed)
+        withMappedColumn(occupation)
+        withMappedColumn(addressId)
     }
 
 fun PersonMapper.generalInsert(completer: GeneralInsertCompleter) =
@@ -85,13 +85,13 @@ fun PersonMapper.insertBatch(vararg records: PersonRecord): List<Int> =
 
 fun PersonMapper.insertBatch(records: Collection<PersonRecord>): List<Int> =
     insertBatch(this::insert, records, person) {
-        map(id) toProperty "id"
-        map(firstName) toProperty "firstName"
-        map(lastName) toProperty "lastName"
-        map(birthDate) toProperty "birthDate"
-        map(employed) toProperty "employed"
-        map(occupation) toProperty "occupation"
-        map(addressId) toProperty "addressId"
+        withMappedColumn(id)
+        withMappedColumn(firstName)
+        withMappedColumn(lastName)
+        withMappedColumn(birthDate)
+        withMappedColumn(employed)
+        withMappedColumn(occupation)
+        withMappedColumn(addressId)
     }
 
 fun PersonMapper.insertMultiple(vararg records: PersonRecord) =
@@ -99,24 +99,24 @@ fun PersonMapper.insertMultiple(vararg records: PersonRecord) =
 
 fun PersonMapper.insertMultiple(records: Collection<PersonRecord>) =
     insertMultiple(this::insertMultiple, records, person) {
-        map(id) toProperty "id"
-        map(firstName) toProperty "firstName"
-        map(lastName) toProperty "lastName"
-        map(birthDate) toProperty "birthDate"
-        map(employed) toProperty "employed"
-        map(occupation) toProperty "occupation"
-        map(addressId) toProperty "addressId"
+        withMappedColumn(id)
+        withMappedColumn(firstName)
+        withMappedColumn(lastName)
+        withMappedColumn(birthDate)
+        withMappedColumn(employed)
+        withMappedColumn(occupation)
+        withMappedColumn(addressId)
     }
 
 fun PersonMapper.insertSelective(record: PersonRecord) =
     insert(this::insert, record, person) {
-        map(id).toPropertyWhenPresent("id", record::id)
-        map(firstName).toPropertyWhenPresent("firstName", record::firstName)
-        map(lastName).toPropertyWhenPresent("lastName", record::lastName)
-        map(birthDate).toPropertyWhenPresent("birthDate", record::birthDate)
-        map(employed).toPropertyWhenPresent("employed", record::employed)
-        map(occupation).toPropertyWhenPresent("occupation", record::occupation)
-        map(addressId).toPropertyWhenPresent("addressId", record::addressId)
+        withMappedColumnWhenPresent(id, record::id)
+        withMappedColumnWhenPresent(firstName, record::firstName)
+        withMappedColumnWhenPresent(lastName, record::lastName)
+        withMappedColumnWhenPresent(birthDate, record::birthDate)
+        withMappedColumnWhenPresent(employed, record::employed)
+        withMappedColumnWhenPresent(occupation, record::occupation)
+        withMappedColumnWhenPresent(addressId, record::addressId)
     }
 
 private val columnList = listOf(id `as` "A_ID", firstName, lastName, birthDate, employed, occupation, addressId)


### PR DESCRIPTION
This also allows us to create new mapping types for the record based inserts that will reduce the required boilerplate code.

Resolves #964
