### PR TITLE
Fix flaky tests `JoinMapperNewSyntaxTest`

### DIFF
--- a/src/test/kotlin/examples/kotlin/mybatis3/joins/JoinMapperNewSyntaxTest.kt
+++ b/src/test/kotlin/examples/kotlin/mybatis3/joins/JoinMapperNewSyntaxTest.kt
@@ -407,17 +407,17 @@ class JoinMapperNewSyntaxTest {
 
             assertThat(rows).hasSize(6)
 
-            assertThat(rows[0]).containsExactly(
+            assertThat(rows[0]).containsOnly(
                 entry("DESCRIPTION", "Catcher Glove"),
                 entry("ITEM_ID", 55)
             )
 
-            assertThat(rows[3]).containsExactly(
+            assertThat(rows[3]).containsOnly(
                 entry("ORDER_ID", 2),
                 entry("QUANTITY", 6)
             )
 
-            assertThat(rows[5]).containsExactly(
+            assertThat(rows[5]).containsOnly(
                 entry("ORDER_ID", 2),
                 entry("QUANTITY", 1),
                 entry("DESCRIPTION", "Outfield Glove"),
@@ -455,12 +455,12 @@ class JoinMapperNewSyntaxTest {
 
             assertThat(rows).hasSize(5)
 
-            assertThat(rows[2]).containsExactly(
+            assertThat(rows[2]).containsOnly(
                 entry("ORDER_ID", 2),
                 entry("QUANTITY", 6)
             )
 
-            assertThat(rows[4]).containsExactly(
+            assertThat(rows[4]).containsOnly(
                 entry("ORDER_ID", 2),
                 entry("QUANTITY", 1),
                 entry("DESCRIPTION", "Outfield Glove"),
@@ -504,12 +504,12 @@ class JoinMapperNewSyntaxTest {
 
             assertThat(rows).hasSize(5)
 
-            assertThat(rows[2]).containsExactly(
+            assertThat(rows[2]).containsOnly(
                 entry("ORDER_ID", 2),
                 entry("QUANTITY", 6)
             )
 
-            assertThat(rows[4]).containsExactly(
+            assertThat(rows[4]).containsOnly(
                 entry("ORDER_ID", 2),
                 entry("QUANTITY", 1),
                 entry("DESCRIPTION", "Outfield Glove"),
@@ -547,12 +547,12 @@ class JoinMapperNewSyntaxTest {
 
             assertThat(rows).hasSize(5)
 
-            assertThat(rows[2]).containsExactly(
+            assertThat(rows[2]).containsOnly(
                 entry("ORDER_ID", 2),
                 entry("QUANTITY", 6)
             )
 
-            assertThat(rows[4]).containsExactly(
+            assertThat(rows[4]).containsOnly(
                 entry("ORDER_ID", 2),
                 entry("QUANTITY", 1),
                 entry("DESCRIPTION", "Outfield Glove"),
@@ -590,12 +590,12 @@ class JoinMapperNewSyntaxTest {
 
             assertThat(rows).hasSize(5)
 
-            assertThat(rows[0]).containsExactly(
+            assertThat(rows[0]).containsOnly(
                 entry("DESCRIPTION", "Catcher Glove"),
                 entry("ITEM_ID", 55)
             )
 
-            assertThat(rows[4]).containsExactly(
+            assertThat(rows[4]).containsOnly(
                 entry("ORDER_ID", 2),
                 entry("QUANTITY", 1),
                 entry("DESCRIPTION", "Outfield Glove"),
@@ -639,12 +639,12 @@ class JoinMapperNewSyntaxTest {
 
             assertThat(rows).hasSize(5)
 
-            assertThat(rows[0]).containsExactly(
+            assertThat(rows[0]).containsOnly(
                 entry("DESCRIPTION", "Catcher Glove"),
                 entry("ITEM_ID", 55)
             )
 
-            assertThat(rows[4]).containsExactly(
+            assertThat(rows[4]).containsOnly(
                 entry("ORDER_ID", 2),
                 entry("QUANTITY", 1),
                 entry("DESCRIPTION", "Outfield Glove"),
@@ -682,12 +682,12 @@ class JoinMapperNewSyntaxTest {
 
             assertThat(rows).hasSize(5)
 
-            assertThat(rows[0]).containsExactly(
+            assertThat(rows[0]).containsOnly(
                 entry("DESCRIPTION", "Catcher Glove"),
                 entry("ITEM_ID", 55)
             )
 
-            assertThat(rows[4]).containsExactly(
+            assertThat(rows[4]).containsOnly(
                 entry("ORDER_ID", 2),
                 entry("QUANTITY", 1),
                 entry("DESCRIPTION", "Outfield Glove"),
@@ -720,7 +720,7 @@ class JoinMapperNewSyntaxTest {
             val rows = mapper.selectManyMappedRows(selectStatement)
 
             assertThat(rows).hasSize(1)
-            assertThat(rows[0]).containsExactly(
+            assertThat(rows[0]).containsOnly(
                 entry("USER_ID", 2),
                 entry("USER_NAME", "Barney"),
             )
@@ -752,7 +752,7 @@ class JoinMapperNewSyntaxTest {
             val rows = mapper.selectManyMappedRows(selectStatement)
             assertThat(rows).hasSize(1)
 
-            assertThat(rows[0]).containsExactly(
+            assertThat(rows[0]).containsOnly(
                 entry("USER_ID", 2),
                 entry("USER_NAME", "Barney"),
             )
@@ -783,7 +783,7 @@ class JoinMapperNewSyntaxTest {
             val rows = mapper.selectManyMappedRows(selectStatement)
             assertThat(rows).hasSize(1)
 
-            assertThat(rows[0]).containsExactly(
+            assertThat(rows[0]).containsOnly(
                 entry("USER_ID", 2),
                 entry("USER_NAME", "Barney"),
             )
@@ -814,7 +814,7 @@ class JoinMapperNewSyntaxTest {
             val rows = mapper.selectManyMappedRows(selectStatement)
             assertThat(rows).hasSize(1)
 
-            assertThat(rows[0]).containsExactly(
+            assertThat(rows[0]).containsOnly(
                 entry("USER_ID", 2),
                 entry("USER_NAME", "Barney"),
             )


### PR DESCRIPTION
## What changed

Similar to #981.
Replaced `containsExactly(...)` with `containsOnly(...)` to avoid assuming deterministic field order in rows/Maps.

## Why

The test failed intermittently because Map iteration order is not guaranteed. [NonDex](https://github.com/TestingResearchIllinois/NonDex) exposed this by randomizing iteration order.

## How to reproduce

Run the test repeatedly with NonDex:

```
mvn -pl . edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=examples.kotlin.mybatis3.joins.JoinMapperNewSyntaxTest -Drat.skip
```

You will see failures like:

```
[ERROR] Tests run: 21, Failures: 8, Errors: 0, Skipped: 0, Time elapsed: 1.274 s <<< FAILURE! -- in examples.kotlin.mybatis3.joins.JoinMapperNewSyntaxTest
[ERROR] examples.kotlin.mybatis3.joins.JoinMapperNewSyntaxTest.testRightJoinWithAliases -- Time elapsed: 0.222 s <<< FAILURE!
java.lang.AssertionError: 

Actual and expected have the same elements but not in the same order, at index 1 actual element was:
  "ITEM_ID"=44
whereas expected element was:
  "QUANTITY"=1

	at examples.kotlin.mybatis3.joins.JoinMapperNewSyntaxTest.testRightJoinWithAliases(JoinMapperNewSyntaxTest.kt:598)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
```

## How tested

Verified with the same NonDex runs; no further order-related failures occurred.

## Tests fixed
`examples.kotlin.mybatis3.joins.JoinMapperNewSyntaxTest.testFullJoinWithoutAliases`
`examples.kotlin.mybatis3.joins.JoinMapperNewSyntaxTest.testLeftJoinWithAliases`
`examples.kotlin.mybatis3.joins.JoinMapperNewSyntaxTest.testLeftJoinWithoutAliases`
`examples.kotlin.mybatis3.joins.JoinMapperNewSyntaxTest.testLeftJoinWithSubQuery`
`examples.kotlin.mybatis3.joins.JoinMapperNewSyntaxTest.testRightJoinWithAliases`
`examples.kotlin.mybatis3.joins.JoinMapperNewSyntaxTest.testRightJoinWithoutAliases`
`examples.kotlin.mybatis3.joins.JoinMapperNewSyntaxTest.testRightJoinWithSubQuery`
`examples.kotlin.mybatis3.joins.JoinMapperNewSyntaxTest.testSelf`
`examples.kotlin.mybatis3.joins.JoinMapperNewSyntaxTest.testSelfWithNewAlias`
`examples.kotlin.mybatis3.joins.JoinMapperNewSyntaxTest.testSelfWithNewAliasAndOverride`
