### PR TITLE
Test for a Kotlin-Specific Usage Error

### DIFF
--- a/src/main/java/org/mybatis/dynamic/sql/util/Messages.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/Messages.java
@@ -33,6 +33,10 @@ public class Messages {
         return MessageFormat.format(getString(key), p1);
     }
 
+    public static String getString(String key, String p1, String p2) {
+        return MessageFormat.format(getString(key), p1, p2);
+    }
+
     public static String getString(String key, String p1, String p2, String p3) {
         return MessageFormat.format(getString(key), p1, p2, p3);
     }

--- a/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/GroupingCriteriaCollector.kt
+++ b/src/main/kotlin/org/mybatis/dynamic/sql/util/kotlin/GroupingCriteriaCollector.kt
@@ -26,8 +26,11 @@ import org.mybatis.dynamic.sql.NullCriterion
 import org.mybatis.dynamic.sql.RenderableCondition
 import org.mybatis.dynamic.sql.SqlBuilder
 import org.mybatis.dynamic.sql.SqlCriterion
+import org.mybatis.dynamic.sql.util.Messages
 
 typealias GroupingCriteriaReceiver = GroupingCriteriaCollector.() -> Unit
+
+private const val ERROR51 = "ERROR.51" //$NON-NLS-1$
 
 fun GroupingCriteriaReceiver.andThen(after: SubCriteriaCollector.() -> Unit): GroupingCriteriaReceiver = {
     invoke(this)
@@ -48,6 +51,12 @@ sealed class SubCriteriaCollector {
      */
     fun and(criteriaReceiver: GroupingCriteriaReceiver): Unit =
         GroupingCriteriaCollector().apply(criteriaReceiver).let {
+            if (it.isEmpty()) {
+                throw KInvalidSQLException(Messages.getString(
+                    ERROR51, "an", "and") //$NON-NLS-1$ //$NON-NLS-2$
+                )
+            }
+
             subCriteria.add(
                 AndOrCriteriaGroup.Builder().withConnector("and") //$NON-NLS-1$
                     .withInitialCriterion(it.initialCriterion)
@@ -86,6 +95,12 @@ sealed class SubCriteriaCollector {
      */
     fun or(criteriaReceiver: GroupingCriteriaReceiver): Unit =
         GroupingCriteriaCollector().apply(criteriaReceiver).let {
+            if (it.isEmpty()) {
+                throw KInvalidSQLException(Messages.getString(
+                    ERROR51, "an", "or") //$NON-NLS-1$ //$NON-NLS-2$
+                )
+            }
+
             subCriteria.add(
                 AndOrCriteriaGroup.Builder().withConnector("or") //$NON-NLS-1$
                     .withInitialCriterion(it.initialCriterion)
@@ -140,6 +155,8 @@ open class GroupingCriteriaCollector : SubCriteriaCollector() {
             field = value
         }
 
+    internal fun isEmpty() = internalInitialCriterion == null && subCriteria.isEmpty()
+
     /**
      * Add an initial criterion preceded with "not" to the current context. If the receiver adds more than one
      * criterion that renders then parentheses will be added.
@@ -151,6 +168,12 @@ open class GroupingCriteriaCollector : SubCriteriaCollector() {
      */
     fun not(criteriaReceiver: GroupingCriteriaReceiver): Unit =
         GroupingCriteriaCollector().apply(criteriaReceiver).let {
+            if (it.isEmpty()) {
+                throw KInvalidSQLException(Messages.getString(
+                    ERROR51, "a", "not") //$NON-NLS-1$ //$NON-NLS-2$
+                )
+            }
+
             internalInitialCriterion = NotCriterion.Builder()
                 .withInitialCriterion(it.initialCriterion)
                 .withSubCriteria(it.subCriteria)
@@ -203,6 +226,12 @@ open class GroupingCriteriaCollector : SubCriteriaCollector() {
      */
     fun group(criteriaReceiver: GroupingCriteriaReceiver): Unit =
         GroupingCriteriaCollector().apply(criteriaReceiver).let {
+            if (it.isEmpty()) {
+                throw KInvalidSQLException(Messages.getString(
+                    ERROR51, "a", "group") //$NON-NLS-1$ //$NON-NLS-2$
+                )
+            }
+
             internalInitialCriterion = CriteriaGroup.Builder()
                 .withInitialCriterion(it.initialCriterion)
                 .withSubCriteria(it.subCriteria)

--- a/src/main/resources/org/mybatis/dynamic/sql/util/messages.properties
+++ b/src/main/resources/org/mybatis/dynamic/sql/util/messages.properties
@@ -68,4 +68,6 @@ ERROR.48=You cannot call more than one of "forUpdate", "forNoKeyUpdate", "forSha
   statement
 ERROR.49=You cannot call more than one of "skipLocked", or "nowait" in a select statement
 ERROR.50=Mapped column {0} does not have a javaProperty configured
+ERROR.51=In the Kotlin DSL, {0} "{1}" method has been called that is effectively empty. Did you put the condition \
+  on a new line?
 INTERNAL.ERROR=Internal Error {0}

--- a/src/test/kotlin/examples/kotlin/spring/canonical/CanonicalSpringKotlinTest.kt
+++ b/src/test/kotlin/examples/kotlin/spring/canonical/CanonicalSpringKotlinTest.kt
@@ -34,6 +34,7 @@ import org.mybatis.dynamic.sql.util.kotlin.KInvalidSQLException
 import org.mybatis.dynamic.sql.util.kotlin.elements.`as`
 import org.mybatis.dynamic.sql.util.kotlin.elements.add
 import org.mybatis.dynamic.sql.util.kotlin.elements.constant
+import org.mybatis.dynamic.sql.util.kotlin.elements.isGreaterThan
 import org.mybatis.dynamic.sql.util.kotlin.elements.isLikeWhenPresent
 import org.mybatis.dynamic.sql.util.kotlin.elements.max
 import org.mybatis.dynamic.sql.util.kotlin.elements.sortColumn
@@ -247,6 +248,64 @@ open class CanonicalSpringKotlinTest {
         val rows = template.delete(deleteStatement)
 
         assertThat(rows).isEqualTo(2)
+    }
+
+    @Test
+    fun testInvalidAnd() {
+        assertThatExceptionOfType(KInvalidSQLException::class.java).isThrownBy {
+            deleteFrom(person) {
+                where {
+                    id isLessThan 10
+                    and {
+                        id
+                        isGreaterThan(5)
+                    }
+                }
+            }
+        }.withMessage(Messages.getString("ERROR.51", "an", "and"))
+    }
+
+    @Test
+    fun testInvalidOr() {
+        assertThatExceptionOfType(KInvalidSQLException::class.java).isThrownBy {
+            deleteFrom(person) {
+                where {
+                    id isLessThan 10
+                    or {
+                        id
+                        isGreaterThan(5)
+                    }
+                }
+            }
+        }.withMessage(Messages.getString("ERROR.51", "an", "or"))
+    }
+
+    @Test
+    fun testInvalidGroup() {
+        assertThatExceptionOfType(KInvalidSQLException::class.java).isThrownBy {
+            deleteFrom(person) {
+                where {
+                    group {
+                        id
+                        isGreaterThan(5)
+                    }
+                }
+            }
+        }.withMessage(Messages.getString("ERROR.51", "a", "group"))
+    }
+
+    @Test
+    fun testInvalidNot() {
+        assertThatExceptionOfType(KInvalidSQLException::class.java).isThrownBy {
+            deleteFrom(person) {
+                where {
+                    not {
+                        id
+                        isGreaterThan(5)
+                    }
+                }
+            }
+        }.withMessage(Messages.getString("ERROR.51", "a", "not"))
     }
 
     @Test


### PR DESCRIPTION
Kotlin does not use a semi-colon to denote line endings. This can cause surprising results if you inadvertently split code lines - especially in lambdas. For example, in this query the condition specified in the `and` clause is ineffective and isn't evaluated:

```kotlin
deleteFrom(person) {
    where {
        id isLessThan 10
        and {
            id
            isGreaterThan(5)
        }
    }
}
```

The change in this PR attempts to detect usage errors like this and will throw a runtime exception if an error is detected.